### PR TITLE
Orc Marauders v2.9

### DIFF
--- a/Orc_Marauders.cat
+++ b/Orc_Marauders.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="9ca7-5a28-841c-f216" name="Orc Marauders" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="d755-5d69-2721-c11b" gameSystemRevision="6" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="9ca7-5a28-841c-f216" name="Orc Marauders" revision="3" battleScribeVersion="2.03" library="false" gameSystemId="d755-5d69-2721-c11b" gameSystemRevision="6" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="7363-7493-3b62-53bc" name="Orc Marauders v2.9"/>
   </publications>
@@ -663,6 +663,11 @@
                                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c33-902a-717a-b1c9" type="max"/>
                               </constraints>
                             </entryLink>
+                            <entryLink id="4a69-f19b-fc03-eb4c" name="Orc (Special Weapon)" hidden="false" collective="false" import="true" targetId="3ffb-46ae-ab04-ff5c" type="selectionEntry">
+                              <constraints>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f42-1db3-40b3-eed5" type="max"/>
+                              </constraints>
+                            </entryLink>
                           </entryLinks>
                         </selectionEntryGroup>
                       </selectionEntryGroups>
@@ -747,6 +752,11 @@
                             <entryLink id="aff0-2479-643c-21ba" name="Orc (Carbine Leader)" hidden="false" collective="false" import="true" targetId="ab72-8204-f657-1e8e" type="selectionEntry">
                               <constraints>
                                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c70-652b-3868-42c9" type="max"/>
+                              </constraints>
+                            </entryLink>
+                            <entryLink id="463c-d153-ee91-249c" name="Orc (Special Weapon)" hidden="false" collective="false" import="true" targetId="3ffb-46ae-ab04-ff5c" type="selectionEntry">
+                              <constraints>
+                                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6614-1f1c-71d1-d262" type="max"/>
                               </constraints>
                             </entryLink>
                           </entryLinks>
@@ -927,6 +937,9 @@
                   </constraints>
                 </entryLink>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="2722-5441-9307-6e87" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <selectionEntryGroups>
@@ -1077,6 +1090,9 @@
                           </entryLinks>
                         </selectionEntryGroup>
                       </selectionEntryGroups>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+                      </costs>
                     </selectionEntry>
                     <selectionEntry id="ce1a-f1b5-a245-e857" name="Carbines &amp; CCWs" hidden="false" collective="false" import="true" type="upgrade">
                       <selectionEntryGroups>
@@ -1123,6 +1139,9 @@
                   </selectionEntries>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="f2ce-dc3a-6b96-938e" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <selectionEntryGroups>
@@ -1159,6 +1178,9 @@
                           </entryLinks>
                         </selectionEntryGroup>
                       </selectionEntryGroups>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+                      </costs>
                     </selectionEntry>
                     <selectionEntry id="4ace-a43f-039d-d547" name="Carbines &amp; CCWs" hidden="false" collective="false" import="true" type="upgrade">
                       <selectionEntryGroups>
@@ -1205,6 +1227,9 @@
                   </selectionEntries>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -1313,6 +1338,9 @@
                           </entryLinks>
                         </selectionEntryGroup>
                       </selectionEntryGroups>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+                      </costs>
                     </selectionEntry>
                     <selectionEntry id="28f7-c498-74bf-81b0" name="Rocket Launchers/Bomb Hammers" hidden="false" collective="false" import="true" type="upgrade">
                       <selectionEntryGroups>
@@ -1354,6 +1382,9 @@
                   </selectionEntries>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="e0e3-e685-53db-34a4" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <selectionEntryGroups>
@@ -1390,6 +1421,9 @@
                           </entryLinks>
                         </selectionEntryGroup>
                       </selectionEntryGroups>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+                      </costs>
                     </selectionEntry>
                     <selectionEntry id="c30b-0392-339e-94d8" name="Rocket Launchers/Bomb Hammers" hidden="false" collective="false" import="true" type="upgrade">
                       <selectionEntryGroups>
@@ -1510,6 +1544,9 @@
                   </constraints>
                 </entryLink>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="a751-7a72-77b8-019e" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <selectionEntryGroups>
@@ -1637,6 +1674,9 @@
                   </constraints>
                 </entryLink>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="09c1-d432-c76e-a828" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -1778,6 +1818,9 @@
                   </selectionEntries>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="2217-7547-a10c-9711" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
               <selectionEntryGroups>
@@ -1944,6 +1987,9 @@
                   </selectionEntries>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="94d4-86d8-bf5e-7ebb" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
               <selectionEntryGroups>
@@ -3327,6 +3373,9 @@
           </constraints>
         </entryLink>
       </entryLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="d9dc-9cf5-0274-aa67" name="Commando (Pistol Leader)" hidden="false" collective="false" import="true" type="upgrade">
       <entryLinks>
@@ -3343,6 +3392,9 @@
           </constraints>
         </entryLink>
       </entryLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="7071-d65c-db16-d96f" name="Commando (Sniper)" hidden="false" collective="false" import="true" type="upgrade">
       <entryLinks>
@@ -3362,12 +3414,18 @@
           </constraints>
         </entryLink>
       </entryLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="93eb-4b77-66d2-2608" name="Sniper Carbine" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="2417-5ed9-2984-1532" name="Sniper Carbine" hidden="false" targetId="86d8-e19d-eb0e-0b9a" type="profile"/>
         <infoLink id="0541-d081-35d5-64a1" name="Sniper" hidden="false" targetId="2943-e3f6-fb44-ae13" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="5666-40c2-bf60-b209" name="Commando (Special Weapon)" hidden="false" collective="false" import="true" type="upgrade">
       <selectionEntryGroups>
@@ -3413,6 +3471,9 @@
           </constraints>
         </entryLink>
       </entryLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="8d87-6528-52aa-2eb7" name="Commando (Carbine)" hidden="false" collective="false" import="true" type="upgrade">
       <entryLinks>
@@ -3429,6 +3490,9 @@
           </constraints>
         </entryLink>
       </entryLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="3cd0-7911-5499-1a89" name="Commando (Carbine Leader)" hidden="false" collective="false" import="true" type="upgrade">
       <entryLinks>
@@ -3464,6 +3528,9 @@
           </constraints>
         </entryLink>
       </entryLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="5e8d-a857-7e8c-825e" name="Commando (Shotgun)" hidden="false" collective="false" import="true" type="upgrade">
       <entryLinks>
@@ -3480,6 +3547,9 @@
           </constraints>
         </entryLink>
       </entryLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="e5a5-da5d-d610-1204" name="Commando (Shotgun Leader)" hidden="false" collective="false" import="true" type="upgrade">
       <entryLinks>
@@ -3496,22 +3566,34 @@
           </constraints>
         </entryLink>
       </entryLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="eea3-04c2-5912-823f" name="Shotgun" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="6d94-9ef4-7429-22f8" name="Shotgun" hidden="false" targetId="60a3-2b87-f77c-195c" type="profile"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="f22b-1c5b-8bd1-c9bb" name="Flamethrower" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="4d43-0852-9d6a-1d2b" name="Flamethrower" hidden="false" targetId="b1bc-ecdd-2f81-a345" type="profile"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="d18e-7df1-b8c9-a4bf" name="Blowtorches" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="a160-9bcc-8c28-4b2a" name="Blowtorches" hidden="false" targetId="5215-284d-c3df-c898" type="profile"/>
         <infoLink id="789b-9040-172c-d97b" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="be92-2404-8f19-440b" name="Specialist Orc (Railgun)" hidden="false" collective="false" import="true" type="upgrade">
       <selectionEntryGroups>
@@ -3600,12 +3682,18 @@
         <infoLink id="6cf8-abd7-81c7-9266" name="Boarding Pistol" hidden="false" targetId="643b-16c2-4ed8-a242" type="profile"/>
         <infoLink id="4898-3ee6-347c-b5fb" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="bb1f-fc48-f9cb-4868" name="Cutlass" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="c05e-314e-29be-f2b8" name="Cutlass" hidden="false" targetId="518d-4add-e57b-57cd" type="profile"/>
         <infoLink id="0584-de61-a9e8-ad70" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="61c5-6ad4-41f6-53c9" name="Ultra Boss (Carbine+Claw)" hidden="false" collective="false" import="true" type="upgrade">
       <selectionEntryGroups>
@@ -3652,6 +3740,9 @@
           </constraints>
         </entryLink>
       </entryLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="28a3-3009-7e71-cdb3" name="Ultra Bosses" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -3685,6 +3776,9 @@
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="9391-d0e5-dbdb-a608" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
               <selectionEntryGroups>
@@ -3723,6 +3817,9 @@
           </constraints>
         </entryLink>
       </entryLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="966d-6c61-7348-06a7" name="Ultra Sawblade (Elite)" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
@@ -3738,29 +3835,44 @@
         <infoLink id="a8c7-03d3-0df2-8ccc" name="Energy Claw" hidden="false" targetId="63b6-800f-94d2-9c70" type="profile"/>
         <infoLink id="cf1d-6c2b-7f10-0b7c" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="b092-0dff-0924-c1d5" name="Twin Double Shotgun" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="c6a2-158d-3ba2-42f7" name="Twin Double Shotgun" hidden="false" targetId="f48a-3a18-2860-4591" type="profile"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="3178-dcc0-bb53-be4d" name="Stomp (Goblin)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="6199-a71b-9688-522a" name="Stomp (Goblin)" hidden="false" targetId="e157-ffec-e676-0981" type="profile"/>
         <infoLink id="23d9-c7f0-ec27-4dee" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="1368-82a1-8556-1aa0" name="Stomp (Titan)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="c556-07b8-33dc-f9b4" name="Stomp (Titan)" hidden="false" targetId="f1f9-68ef-ae06-5abc" type="profile"/>
         <infoLink id="99f1-cca8-5bc4-9edb" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="49fd-9185-9ec0-74d1" name="Stomp (Walker)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="9081-c0ff-59de-a45d" name="Stomp (Walker)" hidden="false" targetId="584c-41d4-a981-2ec3" type="profile"/>
         <infoLink id="806b-7552-7435-7f02" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="7cf7-634e-447a-0489" name="Walker Sawblade" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -3768,6 +3880,9 @@
         <infoLink id="2fe0-021a-8cd0-476c" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
         <infoLink id="bdb2-103f-b7a2-02c8" name="Deadly(X)" hidden="false" targetId="377b-3864-960e-57ac" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="8ed3-3d95-9ccc-868b" name="Beast Cannon" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -3784,12 +3899,18 @@
         <infoLink id="302c-7375-54f1-d6ad" name="Stick Grenades" hidden="false" targetId="b21a-fd8e-879e-70c4" type="profile"/>
         <infoLink id="e8f6-c2a8-b43e-f4df" name="Blast(X)" hidden="false" targetId="187f-6414-7037-a542" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="b620-59fe-681b-c484" name="2x Twin Heavy Machineguns" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="4222-0678-2955-1e93" name="2x Twin Heavy Machineguns" hidden="false" targetId="acb5-95da-f76e-6965" type="profile"/>
         <infoLink id="9baa-2680-ebfd-28ae" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="02fc-544a-163f-c7f5" name="2x Rocket Launchers" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -3797,6 +3918,9 @@
         <infoLink id="b6ad-e94b-52e3-c3f2" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
         <infoLink id="4c8d-e92b-c9be-9b8d" name="Deadly(X)" hidden="false" targetId="377b-3864-960e-57ac" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="f957-bc7d-ec31-9fd3" name="Deathstorm Plasma Cannon" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -3804,12 +3928,18 @@
         <infoLink id="23fb-bb7e-8316-30cf" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
         <infoLink id="17ea-c9ce-bcbc-7d75" name="Blast(X)" hidden="false" targetId="187f-6414-7037-a542" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="f39b-d482-e22f-06eb" name="Shoot Shoot Shoot!" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="e393-7be3-e310-620d" name="Shoot Shoot Shoot!" hidden="false" targetId="9c07-64c8-4825-8e66" type="profile"/>
         <infoLink id="1a7f-a73c-84fd-1244" name="Relentless" hidden="false" targetId="973a-bce3-c43c-b039" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -4917,7 +5047,7 @@
       <characteristics>
         <characteristic name="Range" typeId="79f4-5578-c041-f866">12&quot;</characteristic>
         <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A8</characteristic>
-        <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d"></characteristic>
+        <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d"/>
       </characteristics>
     </profile>
     <profile id="e157-ffec-e676-0981" name="Stomp (Goblin)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">


### PR DESCRIPTION
Fixed a missing option for specialist weapons after upgrading the unit to use Carbines instead of Pistols.