### PR TITLE
Soul-Snatcher Cults v2.6

### DIFF
--- a/Soul_Snatchers.cat
+++ b/Soul_Snatchers.cat
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="736c-fc7e-387d-c489" name="Soul Snatchers" revision="1" battleScribeVersion="2.03" library="false" gameSystemId="d755-5d69-2721-c11b" gameSystemRevision="9" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="736c-fc7e-387d-c489" name="Soul-Snatcher Cults" revision="2" battleScribeVersion="2.03" library="false" gameSystemId="d755-5d69-2721-c11b" gameSystemRevision="1" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
-    <publication id="5915-3eae-51a9-53be" name="Soul Snatchers v2.6"/>
+    <publication id="5915-3eae-51a9-53be" name="Soul-Snatcher Cults v2.6"/>
   </publications>
   <entryLinks>
     <entryLink id="0c25-2fe6-1f00-9719" name="Soul-Snatcher Patriarch" hidden="false" collective="false" import="true" targetId="ffcd-a559-7a12-9c84" type="selectionEntry"/>
@@ -2384,6 +2384,9 @@
         <infoLink id="cd81-c693-5711-3ce3" name="Stomp" hidden="false" targetId="bae4-60ce-13d2-9250" type="profile"/>
         <infoLink id="c402-a79d-7856-7e28" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="ef00-1be8-a923-c411" name="Light Walker" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -2446,25 +2449,25 @@
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedRules>
-    <rule id="5d13-1e1f-67f7-4dcc" name="Agitator" hidden="false">
+    <rule id="5d13-1e1f-67f7-4dcc" name="Agitator" publicationId="5915-3eae-51a9-53be" hidden="false">
       <description>The hero and his unit get Furious.	</description>
     </rule>
-    <rule id="437c-ba05-6e5f-2dd8" name="Banner" hidden="false">
+    <rule id="437c-ba05-6e5f-2dd8" name="Banner" publicationId="5915-3eae-51a9-53be" hidden="false">
       <description>The hero and his unit get the Furious and Regeneration special rules.</description>
     </rule>
-    <rule id="1853-7ddd-1474-0d2a" name="Commander" hidden="false">
+    <rule id="1853-7ddd-1474-0d2a" name="Commander" publicationId="5915-3eae-51a9-53be" hidden="false">
       <description>When the hero is activated pick one friendly non-commander unit within 6&quot; that has no models with Tough(6) or more, and roll one die to give it orders. On a 4+ the unit may immediately be activated, even if it had been activated already this round.</description>
     </rule>
-    <rule id="4576-e504-d9b4-3aa9" name="Experiments" hidden="false">
+    <rule id="4576-e504-d9b4-3aa9" name="Experiments" publicationId="5915-3eae-51a9-53be" hidden="false">
       <description>When the hero and his unit fight in melee roll one die and apply one bonus:
 1-2: Unit gets AP(+1)
 3-4: Unit gets +1 attack
 5-6: Enemies get -1 to hit</description>
     </rule>
-    <rule id="c5e4-6e2a-5b77-1bfe" name="Psychic Idol" hidden="false">
+    <rule id="c5e4-6e2a-5b77-1bfe" name="Psychic Idol" publicationId="5915-3eae-51a9-53be" hidden="false">
       <description>The hero gets +1 when rolling to block enemy spells.</description>
     </rule>
-    <rule id="89c5-e50f-e11d-4123" name="Megaphone" hidden="false">
+    <rule id="89c5-e50f-e11d-4123" name="Megaphone" publicationId="5915-3eae-51a9-53be" hidden="false">
       <description>The hero and his unit get Fast.</description>
     </rule>
   </sharedRules>

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,7 @@ table!
 |Ratmen Clans|v2.3|Done|
 |Rebel Guerrillas|-|Not started|
 |Robot Legions|v2.7|Done|
-|Soul-Snatchers|v2.6|Done|
+|Soul-Snatcher Cults|v2.6|Done|
 |TAO Coalition|v2.7|Done|
 |Titan Lords|v2.2|Done|
 |Wormhole Daemons|v2.5|Done|


### PR DESCRIPTION
OPA renamed the army from Soul-Snatchers to Soul-Snatcher Cults to make them more recognizable to new players. This update just supports that name chante.