### PR TITLE
Battle Brothers v2.12 - Fix Destroyers Profile

### DIFF
--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6b93-03ad-4cbe-782d" name="Battle Brothers" revision="8" battleScribeVersion="2.03" library="false" gameSystemId="d755-5d69-2721-c11b" gameSystemRevision="20" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6b93-03ad-4cbe-782d" name="Battle Brothers" revision="9" battleScribeVersion="2.03" library="false" gameSystemId="d755-5d69-2721-c11b" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="dead-6af1-a069-5579" name="Battle Brothers v2.12"/>
     <publication id="a380-f550-5f9a-c792" name="Battle Brothers Detachments v2.12"/>
@@ -9,19 +9,16 @@
     <entryLink id="5e41-31cb-5063-301e" name="Champion" hidden="false" collective="false" import="true" targetId="7708-7d52-a3b5-5a3a" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5ca8-cfce-a793-5ed5" name="New CategoryLink" hidden="false" targetId="4b4e-fbe0-5211-ae65" primary="true"/>
-        <categoryLink id="440b-504f-74fd-d29b" name="Battle Brothers" hidden="false" targetId="34a0-39e2-2641-495f" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="f40c-ef25-e292-b251" name="Engineer" hidden="false" collective="false" import="true" targetId="9a86-009f-5781-1248" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="d465-0609-10b8-5704" name="New CategoryLink" hidden="false" targetId="4b4e-fbe0-5211-ae65" primary="true"/>
-        <categoryLink id="2971-92be-c577-f31d" name="Battle Brothers" hidden="false" targetId="34a0-39e2-2641-495f" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b0c6-2981-399c-67b9" name="Psychic" hidden="false" collective="false" import="true" targetId="9915-789c-4e40-3a7f" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="08f6-7a49-33e1-0b58" name="New CategoryLink" hidden="false" targetId="4b4e-fbe0-5211-ae65" primary="true"/>
-        <categoryLink id="1241-98c7-0cf0-9063" name="Battle Brothers" hidden="false" targetId="34a0-39e2-2641-495f" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1921-5e63-6cca-3660" name="Battle Brothers" hidden="false" collective="false" import="true" targetId="3f4e-5a99-a0c2-85da" type="selectionEntry">
@@ -57,7 +54,6 @@
     <entryLink id="6d24-b586-1bc0-000f" name="Captain" hidden="false" collective="false" import="true" targetId="40e7-3f33-f159-d98d" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="89a7-edc1-3cb5-9a02" name="New CategoryLink" hidden="false" targetId="4b4e-fbe0-5211-ae65" primary="true"/>
-        <categoryLink id="adc8-de36-cfb6-c4cb" name="Battle Brothers" hidden="false" targetId="34a0-39e2-2641-495f" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8bea-6f3d-8e64-96d5" name="Brother Bikers" hidden="false" collective="false" import="true" targetId="bcdb-26e5-0075-6157" type="selectionEntry">
@@ -614,25 +610,21 @@
     <entryLink id="3c60-7f4d-2287-7476" name="Prime Captain" hidden="false" collective="false" import="true" targetId="262c-969e-5797-55f7" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5f9a-6d34-c94d-70ee" name="New CategoryLink" hidden="false" targetId="4b4e-fbe0-5211-ae65" primary="true"/>
-        <categoryLink id="4959-046f-18ac-54f3" name="Prime Brothers" hidden="false" targetId="d368-b779-5c2b-41b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8b9b-dd1e-e37c-eeed" name="Prime Lieutenant" hidden="false" collective="false" import="true" targetId="a8c0-b29d-a0d7-f0be" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="49d0-1e47-c8e2-a086" name="New CategoryLink" hidden="false" targetId="4b4e-fbe0-5211-ae65" primary="true"/>
-        <categoryLink id="f4a4-223f-1d6a-3a0a" name="Prime Brothers" hidden="false" targetId="d368-b779-5c2b-41b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a5e7-0295-4b1e-db8a" name="Prime Ancient" hidden="false" collective="false" import="true" targetId="fcc9-41d7-d66f-d81c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7c55-995a-a979-36f5" name="New CategoryLink" hidden="false" targetId="4b4e-fbe0-5211-ae65" primary="true"/>
-        <categoryLink id="bee6-85e1-86a2-ecd7" name="Prime Brothers" hidden="false" targetId="d368-b779-5c2b-41b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="6b72-ef41-06c6-94a7" name="Prime Psychic" hidden="false" collective="false" import="true" targetId="c8d6-faca-d622-5fa7" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="930f-0692-f5d4-d892" name="New CategoryLink" hidden="false" targetId="4b4e-fbe0-5211-ae65" primary="true"/>
-        <categoryLink id="da0e-97b5-860f-a705" name="Prime Brothers" hidden="false" targetId="d368-b779-5c2b-41b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a079-7d3a-4133-8ebe" name="Prime Brothers" hidden="false" collective="false" import="true" targetId="deed-eef5-264b-a884" type="selectionEntry">
@@ -698,7 +690,6 @@
     <entryLink id="f8ed-a680-cc16-2de7" name="Prime Grave Captain" hidden="false" collective="false" import="true" targetId="7092-baf4-8ce7-475a" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5892-40d3-166e-5e57" name="New CategoryLink" hidden="false" targetId="4b4e-fbe0-5211-ae65" primary="true"/>
-        <categoryLink id="9ad9-ecbf-31e4-4248" name="Prime Brothers" hidden="false" targetId="d368-b779-5c2b-41b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="56e5-e899-3d9a-2bbb" name="Anti-Grav APC" hidden="false" collective="false" import="true" targetId="6861-14d1-eb2c-c1dc" type="selectionEntry">
@@ -733,7 +724,6 @@
     <entryLink id="af51-27ce-8b7c-2b0d" name="Prime Judge" hidden="false" collective="false" import="true" targetId="489a-45c6-a746-ec63" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="85c5-0e45-f2ee-2586" name="New CategoryLink" hidden="false" targetId="4b4e-fbe0-5211-ae65" primary="true"/>
-        <categoryLink id="0236-2277-e8d4-0a9a" name="Prime Brothers" hidden="false" targetId="d368-b779-5c2b-41b1" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="41dd-9421-c651-7f8a" name="Assault Squad" hidden="false" collective="false" import="true" targetId="2cd5-1d2e-7591-8876" type="selectionEntry">
@@ -2185,12 +2175,6 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="374a-0738-ca40-c37f" name="Destroyer" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="1450-8aff-7ff9-f266" name="Destroyers" hidden="false" targetId="db8f-f0fc-6b84-4022" type="profile"/>
-        <infoLink id="39e5-30f4-b56b-1d98" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
-        <infoLink id="bc11-88b1-73f6-810c" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="b10c-79b8-ffd8-f036" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
-      </infoLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="ad39-2db2-ff53-9b33" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="35a0-b147-de11-8dea">
           <constraints>
@@ -2253,12 +2237,6 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="8a86-49bb-ce0e-eea9" name="Destroyer (Special Weapon)" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="d7de-42ec-2eec-b0da" name="Destroyers" hidden="false" targetId="db8f-f0fc-6b84-4022" type="profile"/>
-        <infoLink id="58fc-984e-5f6f-d0d4" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
-        <infoLink id="6779-a6c8-bd1f-f257" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="7bb7-9de7-5cc5-73d0" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
-      </infoLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="da59-9929-64bb-ff60" name="Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="1ac5-abb0-7946-11af">
           <constraints>
@@ -2315,6 +2293,12 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="d2f0-51f0-c8bf-639e" name="Destroyers" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="a725-ab08-4126-d1c0" name="Destroyer" hidden="false" targetId="db8f-f0fc-6b84-4022" type="profile"/>
+        <infoLink id="440a-c972-ba58-841c" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
+        <infoLink id="4831-6fb2-e6af-298d" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
+        <infoLink id="4861-ad63-837b-b137" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
+      </infoLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="45bf-42a2-b446-383e" name="Destroyer Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="a214-2743-285b-71a2">
           <constraints>

--- a/Havoc_Brothers.cat
+++ b/Havoc_Brothers.cat
@@ -1336,6 +1336,9 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="8e23-ff87-a242-818b" name="Havoc Support Trooper" hidden="false" collective="false" import="true" type="upgrade">
       <selectionEntryGroups>
@@ -1525,6 +1528,9 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="df30-aebf-4ff2-9b11" name="Possessed Brother" hidden="false" collective="false" import="true" type="upgrade">
       <entryLinks>
@@ -1649,6 +1655,9 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="eaf8-9a2d-82bb-b8c3" name="Mutated Possessed" hidden="false" collective="false" import="true" type="upgrade">
       <entryLinks>
@@ -1754,6 +1763,9 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="ad1e-d1eb-577a-d56c" name="Talon Raptor (Pistol &amp; CCW (A2))" hidden="false" collective="false" import="true" type="upgrade">
       <entryLinks>
@@ -2119,6 +2131,9 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="808f-355f-ae5f-a331" name="Havoc Destroyer (2x Energy Claws)" hidden="false" collective="false" import="true" type="upgrade">
       <entryLinks>
@@ -3838,6 +3853,9 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="7629-d874-3b78-b264" name="Disciples of Change" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
@@ -4213,6 +4231,9 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="a39f-b8ac-ade7-a849" name="Change Destroyer" hidden="false" collective="false" import="true" type="upgrade">
       <entryLinks>
@@ -4440,6 +4461,9 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="1a12-5515-c96d-1829" name="Missile Rack" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -4826,6 +4850,9 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="7bb7-1ed0-8260-6e07" name="Disciples of Plague" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
@@ -5747,6 +5774,9 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="9dc0-eeb9-ff31-586e" name="Plague Destroyers" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -5840,7 +5870,7 @@
                             <infoLink id="b77b-4876-c6d1-7b6f" name="Plague Flamethrower" hidden="false" targetId="822e-5b86-8e54-cd65" type="profile"/>
                           </infoLinks>
                           <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="7303-5249-9945-f1c2" name="Plague Launcher &amp; Plague Sword" hidden="false" collective="false" import="true" type="upgrade">
@@ -5851,7 +5881,7 @@
                             <infoLink id="47ec-5d29-87af-0332" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
                           </infoLinks>
                           <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="6f58-2ee6-04ee-f4f0" name="Reaper Cannon &amp; Plague Sword" hidden="false" collective="false" import="true" type="upgrade">
@@ -5862,7 +5892,7 @@
                             <infoLink id="d723-02dc-dc83-b574" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
                           </infoLinks>
                           <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -5873,6 +5903,9 @@
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34f0-1389-353d-ea8b" type="max"/>
                       </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                      </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
@@ -5959,7 +5992,7 @@
                             <infoLink id="803f-2738-2bac-0088" name="Plague Flamethrower" hidden="false" targetId="822e-5b86-8e54-cd65" type="profile"/>
                           </infoLinks>
                           <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="eb25-b67f-6c1d-ca63" name="Plague Launcher &amp; Plague Sword" hidden="false" collective="false" import="true" type="upgrade">
@@ -5970,7 +6003,7 @@
                             <infoLink id="2e2f-b7bd-e0b8-e557" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
                           </infoLinks>
                           <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                           </costs>
                         </selectionEntry>
                         <selectionEntry id="95ec-e368-51ee-a85c" name="Reaper Cannon &amp; Plague Sword" hidden="false" collective="false" import="true" type="upgrade">
@@ -5981,7 +6014,7 @@
                             <infoLink id="546e-6ab5-a2bf-0935" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
                           </infoLinks>
                           <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
                           </costs>
                         </selectionEntry>
                       </selectionEntries>
@@ -5992,6 +6025,9 @@
                       <constraints>
                         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b87e-6b67-2c6a-61b9" type="max"/>
                       </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                      </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
@@ -6003,6 +6039,9 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="226f-8fc0-a9bb-ca29" name="Plague Bodyguard Destroyers" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -6059,6 +6098,9 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="ab98-cbb5-b254-0f2b" name="Plague Hauler" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -6501,6 +6543,9 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="96b2-7d8b-a2b9-aa9e" name="2x CCWs (A2)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -6551,6 +6596,9 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="9105-399f-916d-422f" name="Heavy Cleaver" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -7143,6 +7191,9 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="05cd-2d35-70d3-1bf6" name="Endless Brothers" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -7198,6 +7249,9 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="8e0e-19cb-9a28-d061" name="Assault Carbine" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>

--- a/Havoc_Brothers.cat
+++ b/Havoc_Brothers.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="f600-0926-eecd-eca5" name="Havoc Brothers" revision="7" battleScribeVersion="2.03" library="false" gameSystemId="d755-5d69-2721-c11b" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="f600-0926-eecd-eca5" name="Havoc Brothers" revision="8" battleScribeVersion="2.03" library="false" gameSystemId="d755-5d69-2721-c11b" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="0087-62dd-65cd-178c" name="Havoc Brothers v2.11"/>
     <publication id="a23a-0fd7-52cd-e3da" name="Havoc Brother Disciples v2.13"/>


### PR DESCRIPTION
Small bug fix where unit profile didn't appear when selecting the energy claws option.