### PR TITLE
BB Detachments v2.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 2.1
+        dotnet-version: 5.0
      
     - name: Install Wham
       run: dotnet tool install wham --global

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,10 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0
+        dotnet-version: 2.1
      
     - name: Install Wham
-      run: dotnet tool install wham --global
+      run: dotnet tool install wham --global --version 0.11.0
       
     - name: Build Index
       run:  wham publish -a zip bsi -s . -o ./index --repo-name https://grimdark-future.s3.amazonaws.com/index.bsi -f index

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -2735,91 +2735,30 @@
                   <selectionEntryGroups>
                     <selectionEntryGroup id="602d-ac75-8834-748c" name="Specialist Weapon" hidden="false" collective="false" import="true">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87d8-4807-4deb-82bc" type="max"/>
-                        <constraint field="selections" scope="bcdb-26e5-0075-6157" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="678a-cd99-9712-d6c5" type="max"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87d8-4807-4deb-82bc" type="max"/>
                       </constraints>
-                      <selectionEntries>
-                        <selectionEntry id="1401-2189-4cde-83c4" name="Flamethrower" hidden="false" collective="false" import="true" type="upgrade">
-                          <entryLinks>
-                            <entryLink id="4854-2c4c-445e-a60a" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
-                              <constraints>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d214-65c6-03a7-8e70" type="max"/>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b009-63dc-700f-bf88" type="min"/>
-                              </constraints>
-                              <costs>
-                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                              </costs>
-                            </entryLink>
-                          </entryLinks>
+                      <entryLinks>
+                        <entryLink id="942e-011f-1cea-4f7e" name="Gravity Rifle" hidden="false" collective="false" import="true" targetId="3e4a-da63-fdf2-c5fb" type="selectionEntry">
                           <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                           </costs>
-                        </selectionEntry>
-                        <selectionEntry id="4848-f535-bc86-1bc4" name="Gravity Rifle" hidden="false" collective="false" import="true" type="upgrade">
-                          <entryLinks>
-                            <entryLink id="2085-9f01-02db-5deb" name="Gravity Rifle" hidden="false" collective="false" import="true" targetId="3e4a-da63-fdf2-c5fb" type="selectionEntry">
-                              <constraints>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a27e-ed4e-17fe-a90e" type="max"/>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1aec-0ce0-a0d7-4928" type="min"/>
-                              </constraints>
-                              <costs>
-                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                              </costs>
-                            </entryLink>
-                          </entryLinks>
+                        </entryLink>
+                        <entryLink id="9f44-b13c-be73-34f8" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
                           <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                           </costs>
-                        </selectionEntry>
-                        <selectionEntry id="9747-46ab-45ca-0187" name="Heavy Machinegun" hidden="false" collective="false" import="true" type="upgrade">
-                          <entryLinks>
-                            <entryLink id="a426-bab3-3085-a052" name="Heavy Machinegun" hidden="false" collective="false" import="true" targetId="4481-49a4-e4f7-925b" type="selectionEntry">
-                              <constraints>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2705-e233-5452-4982" type="max"/>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a019-9e87-523d-bdd8" type="min"/>
-                              </constraints>
-                              <costs>
-                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-                              </costs>
-                            </entryLink>
-                          </entryLinks>
+                        </entryLink>
+                        <entryLink id="f582-873d-bf2b-035e" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
                           <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
                           </costs>
-                        </selectionEntry>
-                        <selectionEntry id="112d-8d2e-deae-cd4a" name="Missile Launcher" hidden="false" collective="false" import="true" type="upgrade">
-                          <entryLinks>
-                            <entryLink id="966e-bdb7-55da-e6df" name="Missile Launcher" hidden="false" collective="false" import="true" targetId="ff1b-714c-6353-221d" type="selectionEntry">
-                              <constraints>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2c2-6964-06a0-fb51" type="max"/>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7fde-4f82-09a1-4142" type="min"/>
-                              </constraints>
-                              <costs>
-                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
-                              </costs>
-                            </entryLink>
-                          </entryLinks>
+                        </entryLink>
+                        <entryLink id="1068-fef6-244e-7824" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
                           <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
                           </costs>
-                        </selectionEntry>
-                        <selectionEntry id="8f94-834e-35aa-42cf" name="Plasma Rifle" hidden="false" collective="false" import="true" type="upgrade">
-                          <entryLinks>
-                            <entryLink id="1b87-dc3e-3f59-e529" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
-                              <constraints>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8339-570e-28c0-14ae" type="max"/>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="defe-d4ff-4f56-d406" type="min"/>
-                              </constraints>
-                              <costs>
-                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                              </costs>
-                            </entryLink>
-                          </entryLinks>
-                          <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-                          </costs>
-                        </selectionEntry>
-                      </selectionEntries>
+                        </entryLink>
+                      </entryLinks>
                     </selectionEntryGroup>
                   </selectionEntryGroups>
                 </selectionEntryGroup>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -4569,7 +4569,7 @@
             </entryLink>
             <entryLink id="37ed-3f28-2bcc-95ad" name="Destroyer Armor" hidden="false" collective="false" import="true" targetId="8150-2743-e904-7a5c" type="selectionEntry">
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="70.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
               </costs>
             </entryLink>
             <entryLink id="1968-a8ad-ee2c-94e5" name="Bike" hidden="false" collective="false" import="true" targetId="c47e-3660-de3d-86f7" type="selectionEntry">
@@ -6044,7 +6044,7 @@
             </entryLink>
             <entryLink id="1bac-d454-6f1c-7e52" name="Destroyer Armor" hidden="false" collective="false" import="true" targetId="8150-2743-e904-7a5c" type="selectionEntry">
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="70.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -6706,7 +6706,7 @@
             </entryLink>
             <entryLink id="9bc7-72f4-56d7-9bfd" name="Destroyer Armor" hidden="false" collective="false" import="true" targetId="8150-2743-e904-7a5c" type="selectionEntry">
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="70.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
               </costs>
             </entryLink>
           </entryLinks>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -8631,7 +8631,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ba3-4657-79ae-af03" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="70.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
               </costs>
             </entryLink>
             <entryLink id="0618-8b63-c8fb-950b" name="Cyborg Wolf" hidden="false" collective="false" import="true" targetId="a68e-80d5-aa9a-1138" type="selectionEntry">
@@ -14094,7 +14094,7 @@
       <description>When the hero fights in melee pick one of the following stances:
 - Ox: +1 to hit
 - Plow: AP(+1)
-- Fool: Rending
+- Fool: Poison
 - Hoof: Impact(1)	</description>
     </rule>
     <rule id="7399-4a35-48ef-4119" name="Prime" publicationId="339e-d00a-321f-4a00" hidden="false">

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="6b93-03ad-4cbe-782d" name="Battle Brothers" revision="10" battleScribeVersion="2.03" library="false" gameSystemId="d755-5d69-2721-c11b" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="6b93-03ad-4cbe-782d" name="Battle Brothers" revision="11" battleScribeVersion="2.03" library="false" gameSystemId="d755-5d69-2721-c11b" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="dead-6af1-a069-5579" name="Battle Brothers v2.12"/>
-    <publication id="a380-f550-5f9a-c792" name="Battle Brothers Detachments v2.13"/>
+    <publication id="a380-f550-5f9a-c792" name="Battle Brothers Detachments v2.14"/>
     <publication id="339e-d00a-321f-4a00" name="Prime Brothers v2.12"/>
   </publications>
   <entryLinks>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -187,90 +187,6 @@
         <categoryLink id="5eed-eeb9-003d-5dce" name="New CategoryLink" hidden="false" targetId="b820-6309-e900-c733" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="db63-17dc-72bc-885d" name="Custodian Captain" hidden="false" collective="false" import="true" targetId="0e49-7aa5-7e47-eb57" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5fbd-7c2c-ce31-fa5f" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="9b37-6741-e330-3d78" name="New CategoryLink" hidden="false" targetId="4b4e-fbe0-5211-ae65" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="cb42-3386-5561-c146" name="Great Sister" hidden="false" collective="false" import="true" targetId="b122-05bc-5b2d-4d4f" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5fbd-7c2c-ce31-fa5f" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="2125-4fab-2dd7-f2a8" name="New CategoryLink" hidden="false" targetId="4b4e-fbe0-5211-ae65" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="c514-b786-3fee-eb77" name="Custodian Brothers" hidden="false" collective="false" import="true" targetId="f0e1-6a1a-01ac-0223" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5fbd-7c2c-ce31-fa5f" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="86c7-604b-b988-9081" name="New CategoryLink" hidden="false" targetId="dfbf-5076-f148-2f58" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="bc29-8d84-39b6-bc0b" name="Vigilant Sisters" hidden="false" collective="false" import="true" targetId="f599-60b3-c004-85ad" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5fbd-7c2c-ce31-fa5f" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="eaa7-38c6-d692-678d" name="New CategoryLink" hidden="false" targetId="dfbf-5076-f148-2f58" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="45e1-69a9-cf1d-1688" name="Prosecution Sisters" hidden="false" collective="false" import="true" targetId="15d8-66f1-2de1-e61a" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5fbd-7c2c-ce31-fa5f" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="8695-b41d-8a1c-0634" name="New CategoryLink" hidden="false" targetId="dfbf-5076-f148-2f58" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="4280-12dc-a767-d880" name="Hunter Sisters" hidden="false" collective="false" import="true" targetId="d70e-a28a-8d49-0c67" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5fbd-7c2c-ce31-fa5f" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="ae63-52ed-ebf9-8845" name="New CategoryLink" hidden="false" targetId="dfbf-5076-f148-2f58" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="42f2-7c36-8d12-576b" name="Custodian Walker" hidden="false" collective="false" import="true" targetId="e89b-c06d-103d-ec46" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5fbd-7c2c-ce31-fa5f" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="1022-9bef-532a-2b69" name="New CategoryLink" hidden="false" targetId="b820-6309-e900-c733" primary="true"/>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="8113-0761-dd2c-a8eb" name="Interrogator" hidden="false" collective="false" import="true" targetId="f729-b6f1-70a7-ab93" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
@@ -697,30 +613,6 @@
         <categoryLink id="ed59-f041-5ac2-999f" name="New CategoryLink" hidden="false" targetId="b820-6309-e900-c733" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="cfde-e6ca-fc92-6482" name="Custodian Destroyers" hidden="false" collective="false" import="true" targetId="c77a-9942-2734-509a" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5fbd-7c2c-ce31-fa5f" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="2dda-24d4-c0f1-ead2" name="New CategoryLink" hidden="false" targetId="dfbf-5076-f148-2f58" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="83d5-3eaa-a77b-0d8a" name="Custodian Jetbikers" hidden="false" collective="false" import="true" targetId="b7be-2c98-a415-ca1f" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5fbd-7c2c-ce31-fa5f" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="e245-0314-feda-5071" name="New CategoryLink" hidden="false" targetId="dfbf-5076-f148-2f58" primary="true"/>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="af51-27ce-8b7c-2b0d" name="Prime Judge" hidden="false" collective="false" import="true" targetId="489a-45c6-a746-ec63" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="85c5-0e45-f2ee-2586" name="New CategoryLink" hidden="false" targetId="4b4e-fbe0-5211-ae65" primary="true"/>
@@ -818,11 +710,6 @@
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="3b74-3660-bc8f-9927" name="Leader Weapons" hidden="false" collective="false" import="true" targetId="763b-1230-bcad-b19d" type="selectionEntryGroup"/>
-        <entryLink id="d473-5c49-c0bd-38a8" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="5c92-76a5-1912-1169" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
@@ -969,11 +856,6 @@
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
           </costs>
         </entryLink>
-        <entryLink id="8fe6-82b3-e72d-6394" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="a2b9-59fa-5c3b-9e81" name="Death Brothers - Tactical Master" hidden="false" collective="false" import="true" targetId="f2e2-ff33-227d-9876" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
@@ -1054,11 +936,6 @@
         <entryLink id="74bb-bf2e-1e09-86a3" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="2593-dc83-e910-56f8" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
           </costs>
         </entryLink>
         <entryLink id="821e-3f51-9a65-9d46" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
@@ -1177,11 +1054,6 @@
         <entryLink id="1060-d4ae-6f01-7d77" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="3462-2a30-cc52-632c" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
           </costs>
         </entryLink>
         <entryLink id="9b59-3dd9-a27a-e546" name="Dark Brothers - Dark Assault" hidden="false" collective="false" import="true" targetId="cf31-8c37-3347-79a3" type="selectionEntry">
@@ -1484,11 +1356,6 @@
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
           </costs>
         </entryLink>
-        <entryLink id="765c-0c78-ac8b-611e" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="50e8-9ec8-23eb-d9ed" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
@@ -1719,11 +1586,6 @@
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
           </costs>
         </entryLink>
-        <entryLink id="abff-a677-a4ba-6db8" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="df4b-241b-fdf0-9f01" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
@@ -1901,11 +1763,6 @@
         <entryLink id="1864-3499-e948-1cfb" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="597a-d728-d778-d8ae" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
           </costs>
         </entryLink>
         <entryLink id="c573-3120-b856-146e" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
@@ -2149,11 +2006,6 @@
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
           </costs>
         </entryLink>
-        <entryLink id="a5c3-1634-56e3-5062" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="3206-2113-01d9-c23d" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
@@ -2393,11 +2245,6 @@
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
           </costs>
         </entryLink>
-        <entryLink id="d63e-646b-54e4-905e" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="90.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="ad4d-622b-528a-f962" name="Dark Brothers - Dark Assault &amp; Dark Resolve" hidden="false" collective="false" import="true" targetId="cf31-8c37-3347-79a3" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
@@ -2615,11 +2462,6 @@
         <entryLink id="1e54-ba0e-3c1c-cb50" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="9e2b-11f9-6ae6-7477" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="110.0"/>
           </costs>
         </entryLink>
         <entryLink id="a27d-9935-a365-046f" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
@@ -2995,11 +2837,6 @@
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
           </costs>
         </entryLink>
-        <entryLink id="0700-dc28-fc0d-4c3a" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="dc70-1fa2-68e3-7ca8" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
@@ -3334,11 +3171,6 @@
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
           </costs>
         </entryLink>
-        <entryLink id="78f1-449c-a976-aa28" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="96f0-411a-965d-b30d" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
@@ -3400,11 +3232,6 @@
         <entryLink id="a9f9-25dc-63fc-2bb0" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="2041-98d0-3fba-3ab4" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
           </costs>
         </entryLink>
         <entryLink id="87a2-5e8e-0892-940b" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
@@ -3472,11 +3299,6 @@
         <entryLink id="0e6c-89be-a393-c933" name="Blood Brothers - Very Fast" hidden="false" collective="false" import="true" targetId="ec17-0396-1d9d-0ad9" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="c786-69e9-54f5-64d4" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
           </costs>
         </entryLink>
         <entryLink id="53b0-61f0-f457-46a2" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
@@ -3608,11 +3430,6 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="79e7-0efc-d74d-9e78" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="9671-88cf-79f7-185c" name="Blood Brothers - Very Fast" hidden="false" collective="false" import="true" targetId="ec17-0396-1d9d-0ad9" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
@@ -3774,11 +3591,6 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="e272-aa45-04ba-156a" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="70.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="9a7a-c4c9-daa6-9133" name="Blood Brothers - Very Fast" hidden="false" collective="false" import="true" targetId="ec17-0396-1d9d-0ad9" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
@@ -3939,11 +3751,6 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="07f5-c40d-73b0-1f8a" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="110.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="4e07-b81e-9201-0bcf" name="Blood Brothers - Very Fast" hidden="false" collective="false" import="true" targetId="ec17-0396-1d9d-0ad9" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
@@ -4023,11 +3830,6 @@
           </constraints>
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="a5fe-67e6-f091-1e6a" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
           </costs>
         </entryLink>
         <entryLink id="47dd-dc75-5743-31fa" name="Blood Brothers - Very Fast" hidden="false" collective="false" import="true" targetId="ec17-0396-1d9d-0ad9" type="selectionEntry">
@@ -4235,11 +4037,6 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="9029-2581-2543-176b" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="70.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="40e6-c423-732b-3f17" name="Stomp (Walker)" hidden="false" collective="false" import="true" targetId="fd88-1524-b5ee-010c" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55c0-69f4-17ba-c862" type="min"/>
@@ -4921,14 +4718,6 @@
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="5fbd-7c2c-ce31-fa5f" name="Custodian Brothers" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6de9-3c61-6eea-d887" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="8bb9-ad8e-0b56-8649" name="Dark Brothers" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3cd9-f876-58a4-3825" type="max"/>
@@ -5324,24 +5113,6 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5eba-5a59-c1ab-8cbc" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5fbd-7c2c-ce31-fa5f" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fad-b8de-9cb0-073f" type="max"/>
-      </constraints>
-      <infoLinks>
-        <infoLink id="6a24-0975-cd35-d0ea" name="Regeneration" hidden="false" targetId="dea8-a8f9-1865-4424" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="ec17-0396-1d9d-0ad9" name="Blood Brothers - Very Fast" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
@@ -5421,573 +5192,12 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0e49-7aa5-7e47-eb57" name="Custodian Captain" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="7344-c47f-8a81-a74e" name="Custodian Captain" hidden="false" targetId="b425-cb9c-df03-bc13" type="profile"/>
-        <infoLink id="eb1f-f1f8-d32e-b8a2" name="Regeneration" hidden="false" targetId="dea8-a8f9-1865-4424" type="rule"/>
-        <infoLink id="5665-6683-8e98-19a7" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
-        <infoLink id="f211-4af8-48a3-5884" name="Hero" hidden="false" targetId="5065-c3a4-a9cf-db27" type="rule"/>
-        <infoLink id="5705-4301-7273-d8c2" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-      </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="59f4-2ef0-68cf-13e7" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="4d0c-085e-0831-f692">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d140-1293-5c0f-4d57" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5763-75d9-56b2-8420" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="8f52-c9bd-2b97-e89a" name="Sword-Rifle" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="ff98-a38d-9d5c-10ab" name="Sword-Rifle" hidden="false" collective="false" import="true" targetId="ad62-a734-728b-c7d0" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c40f-dd3b-07fe-3db1" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b8a-8cf2-0a43-012e" type="min"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="e1fb-5f17-8522-409b" name="Sword" hidden="false" collective="false" import="true" targetId="1916-4d07-c6cb-0b72" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd12-1990-51ac-0b12" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6440-d088-b905-7145" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="4d0c-085e-0831-f692" name="Spear-Rifle" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="9eb0-d46a-8966-c08a" name="Spear" hidden="false" collective="false" import="true" targetId="86cc-9e22-6960-9f10" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="875f-6ae6-dc47-faa9" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b354-ab36-6ed5-77e1" type="min"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="ac8c-a567-e1f9-1e71" name="Spear-Rifle" hidden="false" collective="false" import="true" targetId="281a-ee78-0632-079d" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e0e-a5e2-741a-060e" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f67c-3d56-1164-b6e1" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="d7ee-b92f-19ba-9247" name="Axe-Rifle" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="2a3e-0ccc-2551-ef08" name="Axe (Captain)" hidden="false" collective="false" import="true" targetId="3c67-faf9-889f-bec7" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d9b-2705-925f-1bc2" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab4b-f275-0070-079f" type="min"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="ec37-3a1f-253b-c839" name="Axe-Rifle" hidden="false" collective="false" import="true" targetId="e4c4-169c-560d-e5a3" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1de6-9ab3-90c8-e782" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f68-b3d4-deb7-4cee" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="b40d-4b83-63f3-6a71" name="Energy Lance" hidden="false" collective="false" import="true" targetId="ff42-7a39-9d57-f334" type="selectionEntry"/>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="9644-8598-9eb4-9160" name="Upgrade with one:" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2742-72af-106f-44f4" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="b3da-6b5d-c466-99b6" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="14e1-022d-4c5d-9735" name="Jetbike" hidden="false" collective="false" import="true" targetId="d5e6-7c9e-bcf1-d156" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="b107-a6f4-6640-f4cf" name="Destroyer Armor" hidden="false" collective="false" import="true" targetId="8150-2743-e904-7a5c" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="120.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="110.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="b122-05bc-5b2d-4d4f" name="Great Sister" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="dfca-4ef1-82eb-8939" name="High Sister" hidden="false" targetId="780f-7669-8076-5c49" type="profile"/>
-        <infoLink id="eb7d-ac15-c8d7-056b" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="fea6-5b7d-278c-94f1" name="Hero" hidden="false" targetId="5065-c3a4-a9cf-db27" type="rule"/>
-        <infoLink id="9922-1b5f-f9f2-85b2" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
-      </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="4ad7-e25f-954c-a2cc" name="Anti-Psychic" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbc5-907d-913d-196a" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="224d-363a-b0de-dc74" name="Anti-Psychic" hidden="false" targetId="bd7f-ef2d-b55f-bc58" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="96a9-cefc-0604-0876" name="Upgrades with one:" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c78d-04a3-0bd5-4d5f" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="67b3-7369-54fb-d78d" name="Witch Destroyer" hidden="false" collective="false" import="true" type="upgrade">
-              <infoLinks>
-                <infoLink id="a1d7-5def-c441-914a" name="Witch Destroyer" hidden="false" targetId="776c-6932-094e-7bbb" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a47c-36e9-53f1-ba27" name="Eternal Vigilant" hidden="false" collective="false" import="true" type="upgrade">
-              <infoLinks>
-                <infoLink id="a7d7-72d8-d4e6-7eef" name="Eternal Vigilant" hidden="false" targetId="f93e-33e7-6cae-cba4" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0a56-162f-ec7b-ad81" name="High Prosecutor" hidden="false" collective="false" import="true" type="upgrade">
-              <infoLinks>
-                <infoLink id="f16a-ec10-ea2c-5b1c" name="High Prosecutor" hidden="false" targetId="aa25-7acd-e4c2-ae7e" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="448d-6d13-fdd9-cbd9" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="2322-36da-4bc8-11a8">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="37c7-cce8-6cd7-580a" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1010-9bc1-7602-7d62" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="2545-50cf-daaf-8c23" name="Prosecution Rifle &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="3d8e-2bd0-121d-6e4a" name="Prosecution Rifle" hidden="false" collective="false" import="true" targetId="d104-a3e3-df5b-025c" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3eeb-f86b-758d-6be0" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1f2-7305-d417-da1e" type="max"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="dcce-3874-30fc-9aa9" name="CCW (A4)" hidden="false" collective="false" import="true" targetId="b37c-f7c4-5111-1731" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5346-f1fb-bb6d-c80a" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c560-4aca-0061-96c0" type="max"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="131f-6026-6e7b-a5d3" name="Flamethrower &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="4411-2705-21bb-f7fb" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd05-fc30-40e3-ce44" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2df1-d0c9-4e74-a6b3" type="max"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="2d59-57b6-fc57-39af" name="CCW (A4)" hidden="false" collective="false" import="true" targetId="b37c-f7c4-5111-1731" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a9a-67bc-8aa0-1161" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c93-cde2-d94a-2c09" type="max"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="2322-36da-4bc8-11a8" name="Energy Sword (A4,Rending)" hidden="false" collective="false" import="true" targetId="cd64-9c2b-796a-a23d" type="selectionEntry"/>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="4c0d-1efe-a1aa-b27b" name="Upgrade with one:" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a22-3e85-cfe3-63e9" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="9225-9cba-6682-9fdf" name="Furious" hidden="false" collective="false" import="true" type="upgrade">
-              <infoLinks>
-                <infoLink id="0a8a-848c-eb60-8708" name="Furious" hidden="false" targetId="ded5-4f1f-c61d-4659" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="353f-bec6-e639-e6d5" name="Relentless" hidden="false" collective="false" import="true" type="upgrade">
-              <infoLinks>
-                <infoLink id="d925-273c-d724-591a" name="Relentless" hidden="false" targetId="973a-bce3-c43c-b039" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8518-4e5c-49c2-c418" name="Scout" hidden="false" collective="false" import="true" type="upgrade">
-              <infoLinks>
-                <infoLink id="0f5f-23a9-e702-37c0" name="Scout" hidden="false" targetId="7bc7-a892-49bc-ad88" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="60.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="ede2-ebed-3414-4832" name="Custodian Brother" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="c148-24c2-7de8-8479" name="Custodian Brother" hidden="false" targetId="c1e7-ff64-4578-657c" type="profile"/>
-        <infoLink id="9cbe-b14d-df22-ca92" name="Regeneration" hidden="false" targetId="dea8-a8f9-1865-4424" type="rule"/>
-        <infoLink id="234c-9c60-698d-1df7" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-      </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="28ec-a629-59e4-e634" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="27cd-2a67-1642-cfa5">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df78-181d-fda8-3cfe" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cdc-35db-94fe-6898" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="1090-bb31-a5d1-04b7" name="Sword-Rifle" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="7f82-cb40-337a-b733" name="Sword-Rifle" hidden="false" collective="false" import="true" targetId="ad62-a734-728b-c7d0" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a719-2c0f-8307-027f" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9917-dc6d-6568-5a83" type="min"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="8e64-0041-b995-c3c1" name="Sword" hidden="false" collective="false" import="true" targetId="dff5-efb2-71a3-1d74" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7032-ca28-c616-9bee" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea6e-dc73-67ce-a205" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="27cd-2a67-1642-cfa5" name="Spear-Rifle" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="db79-349c-79be-0f34" name="Spear" hidden="false" collective="false" import="true" targetId="20f4-7691-4f75-4b58" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e68a-4b40-ffed-9f78" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c6d-7e8f-1e51-e701" type="min"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="d15b-f40f-0922-4d40" name="Spear-Rifle" hidden="false" collective="false" import="true" targetId="281a-ee78-0632-079d" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a534-4d3b-b788-2dc1" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93d4-b59a-655c-40f3" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a4bf-8221-7f88-fef7" name="Axe-Rifle" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="7b4c-07f6-f756-9b7e" name="Axe" hidden="false" collective="false" import="true" targetId="f1e1-8f92-4ddb-c443" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebda-814e-de1d-efae" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a87-4d3a-7f32-7c1f" type="min"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="1568-aa62-9e31-2e41" name="Axe-Rifle" hidden="false" collective="false" import="true" targetId="e4c4-169c-560d-e5a3" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57a7-8676-b7d3-96cb" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ca5-da67-91df-ff53" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="f0e1-6a1a-01ac-0223" name="Custodian Brothers" hidden="false" collective="false" import="true" type="upgrade">
-      <selectionEntryGroups>
-        <selectionEntryGroup id="2866-d5f8-7be2-52f8" name="Upgrade one model with:" hidden="false" collective="false" import="true">
-          <entryLinks>
-            <entryLink id="57e2-6659-19b0-b74c" name="Battle Standard" hidden="false" collective="false" import="true" targetId="398c-3d34-79c6-a425" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ba1-5070-b5e6-76c8" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="948a-3bbb-2acd-a438" name="Upgrade all:" hidden="false" collective="false" import="true">
-          <entryLinks>
-            <entryLink id="f71e-bde5-c777-b3ed" name="Combat Shield" hidden="false" collective="false" import="true" targetId="f5b9-642f-6bfe-ce58" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="618b-7a42-bfd0-f059" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="0677-f328-19d6-b99f" name="Custodian Brother" hidden="false" collective="false" import="true" targetId="ede2-ebed-3414-4832" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd77-793f-0de0-f965" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9969-8147-fdc1-9d7d" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="215.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="fae8-83fd-86e3-a4f9" name="Vigilant Sister" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="8be5-34fe-03bc-f135" name="Vigilant Sister" hidden="false" targetId="cbf5-9b53-0a7c-d5a0" type="profile"/>
-        <infoLink id="6c2e-942d-9528-42d5" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="2333-a3f7-544e-be7f" name="Furious" hidden="false" targetId="ded5-4f1f-c61d-4659" type="rule"/>
-      </infoLinks>
-      <entryLinks>
-        <entryLink id="c9fe-099d-0bbc-f19a" name="Energy Sword" hidden="false" collective="false" import="true" targetId="8716-34a0-f5b9-30b2" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9476-adf8-6403-6fe5" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5471-a3f1-76b1-e340" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="f599-60b3-c004-85ad" name="Vigilant Sisters" hidden="false" collective="false" import="true" type="upgrade">
-      <selectionEntryGroups>
-        <selectionEntryGroup id="8c63-73e8-595c-e6ba" name="Upgrade all:" hidden="false" collective="false" import="true">
-          <selectionEntries>
-            <selectionEntry id="9f58-4d58-a6ef-8439" name="Anti-Psychic" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b2d-8307-085b-d391" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="4118-e4d0-cfe3-d73c" name="Anti-Psychic" hidden="false" targetId="bd7f-ef2d-b55f-bc58" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="0272-a773-bded-50de" name="Vigilant Sister" hidden="false" collective="false" import="true" targetId="fae8-83fd-86e3-a4f9" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6ef-6ec2-3997-f825" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffe8-67bc-59ee-8981" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="120.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="48f9-6da7-cbd3-ffe4" name="Prosecution Sister" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="dcd7-8135-c9ca-807e" name="Prosecution Sister" hidden="false" targetId="57d6-193e-e1a5-9e9d" type="profile"/>
-        <infoLink id="54d9-de18-a60b-4e02" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="3ea4-8836-b19d-2b34" name="Relentless" hidden="false" targetId="973a-bce3-c43c-b039" type="rule"/>
-      </infoLinks>
-      <entryLinks>
-        <entryLink id="def8-75cc-a99f-80a5" name="Prosecution Rifle" hidden="false" collective="false" import="true" targetId="d104-a3e3-df5b-025c" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd53-eeb3-6d36-f9f9" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0ec-1dff-8920-c78a" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="4ff0-9520-8d2b-9c48" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5004-e1da-f874-2914" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4326-b1f0-2ed9-e753" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="15d8-66f1-2de1-e61a" name="Prosecution Sisters" hidden="false" collective="false" import="true" type="upgrade">
-      <selectionEntryGroups>
-        <selectionEntryGroup id="59ed-a74f-051e-fe04" name="Upgrade all:" hidden="false" collective="false" import="true">
-          <selectionEntries>
-            <selectionEntry id="53d7-d153-880f-9d7d" name="Anti-Psychic" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d42d-2997-6e8a-52e2" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="7cc3-6952-69fe-9ddc" name="Anti-Psychic" hidden="false" targetId="bd7f-ef2d-b55f-bc58" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="ed5f-2d72-246a-c606" name="Prosecution Sister" hidden="false" collective="false" import="true" targetId="48f9-6da7-cbd3-ffe4" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2bc5-8fb8-ceb6-6c94" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16c0-d273-f673-81a0" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="150.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="3927-d814-2872-1a5e" name="Hunter Sister" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="aa10-3342-6920-3d0e" name="Witch Hunter Sister" hidden="false" targetId="b391-240e-1c68-e666" type="profile"/>
-        <infoLink id="29fd-4ae4-aca2-2ef0" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="c533-73db-9330-f5e3" name="Scout" hidden="false" targetId="7bc7-a892-49bc-ad88" type="rule"/>
-      </infoLinks>
-      <entryLinks>
-        <entryLink id="e622-9a8e-0d5d-b4ac" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="168d-fc4b-a9af-d00f" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e23-392e-f8a2-ad96" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="981c-08aa-68b1-7c46" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="8241-1dfa-09a5-0cfe" name="Flamethrower" hidden="false" collective="false" import="true" targetId="6cab-fb1d-6ea8-909c" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="071d-b37e-d2d9-1ed4" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d744-27e1-dfd9-9b8e" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="6cab-fb1d-6ea8-909c" name="Flamethrower" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="bb29-7791-d6c8-79a9" name="Flamethrower" hidden="false" targetId="b1bc-ecdd-2f81-a345" type="profile"/>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="d70e-a28a-8d49-0c67" name="Hunter Sisters" hidden="false" collective="false" import="true" type="upgrade">
-      <selectionEntryGroups>
-        <selectionEntryGroup id="c788-5d79-9dbe-174b" name="Upgrade all:" hidden="false" collective="false" import="true">
-          <selectionEntries>
-            <selectionEntry id="2ec1-d9c9-3103-e748" name="Anti-Psychic" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01ae-a4a6-f6c6-3cac" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="ad89-5111-60d5-2222" name="Anti-Psychic" hidden="false" targetId="bd7f-ef2d-b55f-bc58" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="7d41-cc7e-4cd5-139f" name="Witch Hunter Sister" hidden="false" collective="false" import="true" targetId="3927-d814-2872-1a5e" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15fb-907a-d514-3b5e" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b4d-796e-c951-21e3" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="170.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="e89b-c06d-103d-ec46" name="Custodian Walker" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="39d9-f3a4-c2cf-4035" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="7d83-7ff4-b166-cf89" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
-        <infoLink id="f5e4-ac04-2447-09e9" name="Custodian Walker" hidden="false" targetId="06b4-b2b5-1e33-d835" type="profile"/>
-        <infoLink id="2b6e-48a4-6073-9d9d" name="Fear" hidden="false" targetId="d21e-0b0f-ebec-46da" type="rule"/>
-        <infoLink id="ed1b-7e09-2626-da70" name="Regeneration" hidden="false" targetId="dea8-a8f9-1865-4424" type="rule"/>
-      </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="7062-43e5-1971-8326" name="Main Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="dcbd-4672-5fed-8f5d">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb06-24fe-54b8-5ced" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59d4-4cd3-16a9-6b38" type="min"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="dcbd-4672-5fed-8f5d" name="Heavy Minigun" hidden="false" collective="false" import="true" targetId="9db1-0539-dc9f-f147" type="selectionEntry"/>
-            <entryLink id="3576-67b5-05eb-7375" name="Heavy Fusion Rifle" hidden="false" collective="false" import="true" targetId="a5f5-d44a-03b0-9a99" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="3739-de35-233a-9e98" name="Walker Fist" hidden="false" collective="false" import="true" targetId="e008-b179-c068-469a" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fb0-494a-acaf-a2c5" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="496a-5d3f-a60b-ffa3" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="e02f-b374-bcde-e3e2" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8cd7-215e-0f64-e42e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3b7-9bac-2a95-5013" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="691c-1679-fcdb-6e3d" name="Stomp (Walker)" hidden="false" collective="false" import="true" targetId="fd88-1524-b5ee-010c" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b2b-f27d-9344-d040" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf88-1dd6-d28d-5ba0" type="max"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="455.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9db1-0539-dc9f-f147" name="Heavy Minigun" hidden="false" collective="false" import="true" type="upgrade">
@@ -9749,11 +8959,6 @@
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
           </costs>
         </entryLink>
-        <entryLink id="ec02-aa31-dcff-5b06" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="fdb2-adac-4335-ede3" name="Death Brothers - Tactical Master" hidden="false" collective="false" import="true" targetId="f2e2-ff33-227d-9876" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
@@ -9842,11 +9047,6 @@
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
           </costs>
         </entryLink>
-        <entryLink id="e7b7-d6aa-01f5-3572" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="5665-c1f5-304b-9b26" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
@@ -9899,11 +9099,6 @@
         <entryLink id="54cc-56be-4e39-f781" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="6a3e-b6cd-a6c6-f09d" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
           </costs>
         </entryLink>
         <entryLink id="2bc1-05ce-3d97-af6d" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
@@ -9987,11 +9182,6 @@
         <entryLink id="550b-3e2d-7351-6af6" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="3348-3609-c466-f399" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
           </costs>
         </entryLink>
         <entryLink id="3f0c-6b59-53ee-1f31" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
@@ -10096,11 +9286,6 @@
         <entryLink id="249c-d416-9a98-f5c9" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="dcf8-b0d5-f574-2a7f" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
           </costs>
         </entryLink>
         <entryLink id="7804-ac4a-1800-3ed6" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
@@ -10277,11 +9462,6 @@
         <entryLink id="0740-eb20-80b7-93b8" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="a171-f7bf-4bb1-ced8" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
           </costs>
         </entryLink>
         <entryLink id="9015-976e-5c04-013e" name="Wolf Brothers - Counter-Attack" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
@@ -10497,11 +9677,6 @@
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
           </costs>
         </entryLink>
-        <entryLink id="c03e-2de7-2a77-a492" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="d352-23d6-8a63-b07f" name="Wolf Brothers - Counter-Attack" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
@@ -10573,11 +9748,6 @@
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
           </costs>
         </entryLink>
-        <entryLink id="e8d7-194d-fde2-b902" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="a4ba-0eaf-e8db-81aa" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
@@ -10638,11 +9808,6 @@
         <entryLink id="5cd8-0189-ffdc-9b0e" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="0084-bb32-3b89-6ef7" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
           </costs>
         </entryLink>
         <entryLink id="0073-96c9-9d55-339f" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
@@ -10793,11 +9958,6 @@
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
           </costs>
         </entryLink>
-        <entryLink id="e5f7-bbcf-98de-da54" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="55.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="8b23-93ad-6700-f700" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
@@ -10931,11 +10091,6 @@
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
           </costs>
         </entryLink>
-        <entryLink id="d4a8-136a-06a9-5bc9" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="61a5-50ab-14bb-4a20" name="Wolf Brothers - Counter-Attack" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="510.0"/>
@@ -11006,11 +10161,6 @@
         <entryLink id="fd2d-03c2-117f-3168" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="1a96-7411-49f5-e3b8" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
           </costs>
         </entryLink>
         <entryLink id="21e2-a3a7-0908-8ead" name="Wolf Brothers - Counter-Attack" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
@@ -11113,11 +10263,6 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="678b-8d03-846c-f425" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02e8-7e12-c086-4dfd" type="min"/>
           </constraints>
-        </entryLink>
-        <entryLink id="d81c-5fc2-378c-a663" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="70.0"/>
-          </costs>
         </entryLink>
         <entryLink id="2595-a036-6dd3-e780" name="Stomp (Walker)" hidden="false" collective="false" import="true" targetId="fd88-1524-b5ee-010c" type="selectionEntry">
           <constraints>
@@ -11268,11 +10413,6 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b806-0ae2-4e69-9410" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9452-c4e6-8ab2-6c7a" type="min"/>
           </constraints>
-        </entryLink>
-        <entryLink id="6d5a-e386-efc9-15d0" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="90.0"/>
-          </costs>
         </entryLink>
         <entryLink id="5cdc-913a-45ff-1641" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
           <costs>
@@ -11526,11 +10666,6 @@
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
           </costs>
         </entryLink>
-        <entryLink id="de32-0e3a-b7f0-58af" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="110.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="fc5d-e7a0-a7e2-7e7a" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="55.0"/>
@@ -11617,11 +10752,6 @@
         <entryLink id="2963-8a58-24f3-9779" name="Blood Brothers - Very Fast" hidden="false" collective="false" import="true" targetId="ec17-0396-1d9d-0ad9" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="a2b1-94ba-e1ed-dfb5" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="110.0"/>
           </costs>
         </entryLink>
         <entryLink id="6473-3b8a-25a5-9214" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
@@ -12195,11 +11325,6 @@
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
           </costs>
         </entryLink>
-        <entryLink id="dd66-c0ef-811a-8db8" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="70.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="aa10-747b-0040-a5ca" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
@@ -12303,113 +11428,6 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c71c-cdc0-9f3f-07ac" name="Custodian Destroyer" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="2283-83de-d88a-4156" name="Custodian Destroyer" hidden="false" targetId="f4e3-6fe2-059d-633c" type="profile"/>
-        <infoLink id="387b-261d-01a2-7ecf" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="c2a5-fede-a2ad-3f16" name="Regeneration" hidden="false" targetId="dea8-a8f9-1865-4424" type="rule"/>
-        <infoLink id="edf6-dff4-ed58-ca06" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
-        <infoLink id="0534-8764-6c8f-351e" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
-      </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="9b6b-ceed-52c6-c7c0" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="d41d-600f-04c0-acdd">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cce-00ce-b70d-2e64" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fd3-bc6e-1ee5-1fd2" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="d41d-600f-04c0-acdd" name="Spear-Rifle" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="fc6b-a3c8-aec6-3372" name="Spear" hidden="false" collective="false" import="true" targetId="20f4-7691-4f75-4b58" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64aa-aa46-60f9-8d15" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0247-d796-3505-d09b" type="min"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="5768-7f4b-cc03-195f" name="Spear-Rifle" hidden="false" collective="false" import="true" targetId="281a-ee78-0632-079d" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c65-8383-449a-af4c" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7969-2c2c-0b68-7fee" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b93a-d8b5-657c-aa55" name="Axe-Rifle" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="dc13-a6fa-9e8c-5b51" name="Axe" hidden="false" collective="false" import="true" targetId="f1e1-8f92-4ddb-c443" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f62c-9c91-3d27-8c08" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f949-ee82-8820-d741" type="min"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="d7a8-466e-e865-12fb" name="Axe-Rifle" hidden="false" collective="false" import="true" targetId="e4c4-169c-560d-e5a3" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c921-2635-539d-89a7" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="958d-0bb3-5c55-0193" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="c77a-9942-2734-509a" name="Custodian Destroyers" hidden="false" collective="false" import="true" type="upgrade">
-      <selectionEntryGroups>
-        <selectionEntryGroup id="a24e-a78e-c33d-22bf" name="Upgrade all:" hidden="false" collective="false" import="true">
-          <selectionEntries>
-            <selectionEntry id="6b6b-e047-7c8f-717f" name="Wrist-GLs" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c90-d584-4a00-05d3" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="9aa3-9bca-2892-d363" name="Wrist-GLs" hidden="false" collective="false" import="true" targetId="0365-f4b2-3ec0-0693" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32e3-9d77-10a6-963e" type="max"/>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dad4-fdda-2ab4-7c13" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="0ef0-eebd-f3f4-bad5" name="Upgrade one model with:" hidden="false" collective="false" import="true">
-          <entryLinks>
-            <entryLink id="a158-09e4-3503-d882" name="Battle Standard" hidden="false" collective="false" import="true" targetId="398c-3d34-79c6-a425" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1cd-be3f-b3c6-be6e" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="d9d7-a88e-d6b2-7f35" name="Custodian Destroyer" hidden="false" collective="false" import="true" targetId="c71c-cdc0-9f3f-07ac" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43ad-4d28-2aa4-3121" type="max"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ab8-a53a-88b7-e7fa" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="335.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="0365-f4b2-3ec0-0693" name="Wrist-GLs" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="0ee3-977c-8656-5cfe" name="Wrist-GLs" hidden="false" targetId="5ee3-f681-2708-c0fe" type="profile"/>
@@ -12417,60 +11435,6 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="b7be-2c98-a415-ca1f" name="Custodian Jetbikers" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="a991-0a66-fd3a-8c72" name="Custodian Jetbiker" hidden="false" targetId="0efe-cd3b-0181-d9a7" type="profile"/>
-        <infoLink id="ac41-cf44-00ce-3109" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
-        <infoLink id="80d2-bb3e-8035-1645" name="Strider" hidden="false" targetId="9dea-b566-200a-0605" type="rule"/>
-        <infoLink id="ee02-04b2-057b-4d0b" name="Regeneration" hidden="false" targetId="dea8-a8f9-1865-4424" type="rule"/>
-        <infoLink id="6761-d31c-f8ec-9091" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
-        <infoLink id="00de-871a-2409-da74" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-      </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="87ad-5824-da63-43a9" name="Jetbike Weapons" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56ba-0318-78bd-47a8" type="max"/>
-          </constraints>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="662a-5b25-7a51-339b" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="6f8f-b395-790d-9497">
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b834-b63e-b054-5fd7" type="min"/>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c01b-882d-8450-5f21" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="6f8f-b395-790d-9497" name="Assault Rifle Array" hidden="false" collective="false" import="true" targetId="faa1-761d-0d50-2135" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb4c-b4ba-4eb1-157f" type="max"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="1c8c-b427-e671-1b41" name="Fusion Missiles" hidden="false" collective="false" import="true" targetId="0fec-c1d9-5bbe-acdd" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4db0-d844-eee1-dc57" type="max"/>
-                  </constraints>
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-                  </costs>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="70.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <entryLinks>
-        <entryLink id="43e4-a24a-4f16-4b36" name="Energy Lance" hidden="false" collective="false" import="true" targetId="ff42-7a39-9d57-f334" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6817-ca29-f16b-b11b" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0e5-3da1-567e-83a4" type="max"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="170.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="0fec-c1d9-5bbe-acdd" name="Fusion Missiles" hidden="false" collective="false" import="true" type="upgrade">
@@ -12706,11 +11670,6 @@
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
           </costs>
         </entryLink>
-        <entryLink id="eee2-3dae-d528-7159" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="e1f6-9b25-7e37-4ea0" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
@@ -12798,11 +11757,6 @@
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
-                    <entryLink id="cf24-13ac-666a-3425" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
-                      </costs>
-                    </entryLink>
                     <entryLink id="7ebf-1379-8429-d89b" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
@@ -12875,11 +11829,6 @@
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
                       </costs>
                     </entryLink>
-                    <entryLink id="6b39-3f1c-8cad-b1ac" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="60.0"/>
-                      </costs>
-                    </entryLink>
                     <entryLink id="df32-86f3-2e42-8027" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
@@ -12917,7 +11866,7 @@
     <selectionEntry id="d1fa-0853-3307-96ba" name="Guard Squad" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="b45c-2404-05e6-baa5" name="Prime Guard Brother" hidden="false" targetId="8fc7-b5cb-a682-74ea" type="profile"/>
-        <infoLink id="c692-76ac-9cf2-9353" name="Firstborn" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
+        <infoLink id="c692-76ac-9cf2-9353" name="Prime" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
         <infoLink id="3802-c4b7-5a0d-5474" name="Shield Wall" hidden="false" targetId="ff04-8ef9-82f1-a88b" type="rule"/>
       </infoLinks>
       <selectionEntryGroups>
@@ -12964,11 +11913,6 @@
                     <entryLink id="62e9-749c-7a9c-fda3" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="b45c-4a5e-a2b7-dc47" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="ac5c-4b0c-d265-e206" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
@@ -13022,11 +11966,6 @@
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
                       </costs>
                     </entryLink>
-                    <entryLink id="02b1-32f0-4a6e-f0d9" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
-                      </costs>
-                    </entryLink>
                     <entryLink id="e1ed-1114-db3b-a54b" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
@@ -13049,7 +11988,7 @@
     <selectionEntry id="c20f-9972-05d3-59c4" name="Eradication Squad" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="624b-5f2a-7e9d-8263" name="Prime Eradication Brother" hidden="false" targetId="73d9-4ce3-8c08-2200" type="profile"/>
-        <infoLink id="ff3c-14b5-5dea-970b" name="Firstborn" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
+        <infoLink id="ff3c-14b5-5dea-970b" name="Prime" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
         <infoLink id="89a0-6d47-c3ac-ef46" name="Relentless" hidden="false" targetId="973a-bce3-c43c-b039" type="rule"/>
       </infoLinks>
       <selectionEntryGroups>
@@ -13096,11 +12035,6 @@
                     <entryLink id="4397-ece8-76a5-4eb0" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="7f96-49e0-cbb7-11b7" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="4f11-afe2-35e3-051a" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
@@ -13152,11 +12086,6 @@
                     <entryLink id="e001-7b72-2716-f489" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="7177-1774-848a-b8c6" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="cffa-954f-9362-9a63" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
@@ -13240,11 +12169,6 @@
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
-                    <entryLink id="4eb4-1c4b-fc8c-c72f" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-                      </costs>
-                    </entryLink>
                     <entryLink id="7926-8150-5de4-ac9e" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
@@ -13306,11 +12230,6 @@
                     <entryLink id="d378-fadb-73a4-fded" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="c15e-093a-6518-4af6" name="Custodian Brothers - Regeneration" hidden="false" collective="false" import="true" targetId="5eba-5a59-c1ab-8cbc" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="7f4d-7c0a-cff7-3593" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">

--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,7 @@ table!
 |---|---|---|
 |Game System|v2.10|Done|
 |Alien Hives|v2.9|Done|
-|Battle Brothers|Main v2.12 - Prime v2.12 - Detachments v2.12|Done|
+|Battle Brothers|Main v2.12 - Prime v2.12 - Detachments v2.14|Done|
 |Battle Sisters|v2.9|Done|
 |Dark Elf Raiders|v2.7|Done|
 |Dwarf Guilds|v2.6|Done|


### PR DESCRIPTION
Update the Battle Brothers Detachments to v2.14, notably:
- Update Destroyer Armor costs
- Update Combat Master rule
- Remove Custodian Brothers detachment (this will need to be a new catalog)
- Fixed weapon options issue with Brother Bikers (issue #99)