### PR TITLE
Fix Issue #112

### DIFF
--- a/Dwarf_Guilds.cat
+++ b/Dwarf_Guilds.cat
@@ -2823,7 +2823,7 @@
     <selectionEntry id="260a-e27b-35dc-e573" name="Artillery" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="d1a5-f3b3-80db-29a7" name="Slow" hidden="false" targetId="394b-1b64-d270-f49e" type="rule"/>
-        <infoLink id="81d1-21c0-f573-f6b0" name="Artillery Cannon" hidden="false" targetId="aeda-284b-7d65-8e0d" type="profile"/>
+        <infoLink id="81d1-21c0-f573-f6b0" name="Artillery" hidden="false" targetId="4ce2-0304-6c32-1ac6" type="profile"/>
         <infoLink id="10b3-8def-e24d-d6dd" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
       </infoLinks>
       <selectionEntryGroups>


### PR DESCRIPTION
Artillery had the Artillery Cannon shared ranged weapon profile by mistake, switched to the Artillery unit profile.