### PR TITLE
Battle Brothers Overhaul

### DIFF
--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -3785,213 +3785,39 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="225.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0ba8-73d6-6b10-785d" name="Knight Destroyer" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="a613-af5c-99ce-1492" name="Knight Destroyers" hidden="false" targetId="21fb-00b3-1904-e4e6" type="profile"/>
-        <infoLink id="3966-b62c-1eca-0755" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="2b7f-0024-66fb-7a60" name="Aegis" hidden="false" targetId="ed8b-a6ad-6d94-9c14" type="rule"/>
-        <infoLink id="c9ef-991f-eeb1-003d" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
-        <infoLink id="ae24-e273-e99d-cd8a" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
-      </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="36b1-e86f-3fc9-c8d5" name="Psychic(1)" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d405-cb9f-74d0-9c8c" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="cfba-028e-661c-28c5" name="Psychic(1)" hidden="false" targetId="2432-e2b3-c2c4-9482" type="profile"/>
-            <infoLink id="8562-9562-f13d-f89d" name="Psychic(X)" hidden="false" targetId="ba47-b43b-18f8-97c1" type="rule"/>
-          </infoLinks>
-          <entryLinks>
-            <entryLink id="11ac-0e55-b6ad-8851" name="Knight Brothers Psychic Spells" hidden="false" collective="false" import="true" targetId="ef87-9afc-97d0-abdf" type="selectionEntryGroup"/>
-          </entryLinks>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="a3f1-c0f2-50bd-0c7e" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="cc8c-0134-ebc2-6374">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fbc-77df-73ee-5376" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bddb-d9b7-0922-6122" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="5dc1-5d18-cb51-79f6" name="2x Energy Falchions" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="4f31-e7bc-32e0-8798" name="Energy Falchions" hidden="false" collective="false" import="true" targetId="50ff-a6f0-26a7-44be" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6372-0798-370c-a123" type="min"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="460d-b186-6953-17d9" type="max"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="cc8c-0134-ebc2-6374" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry"/>
-            <entryLink id="e0aa-f8c1-5b87-57a0" name="Energy Staff" hidden="false" collective="false" import="true" targetId="5812-eb85-ab7d-c183" type="selectionEntry"/>
-            <entryLink id="f1b9-86ee-e08d-9325" name="Energy Halberd" hidden="false" collective="false" import="true" targetId="7b55-7b95-caec-2fe5" type="selectionEntry"/>
-            <entryLink id="c09a-5eec-c240-d87b" name="Daemon Hammer" hidden="false" collective="false" import="true" targetId="10b6-089c-2053-fa2d" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="ddbb-5efb-913a-c7e2" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff9a-95e5-98de-e97b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c12f-0c1a-cf6a-e1fa" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="f32a-27e3-2e76-19e2" name="Knight Destroyer (Special Weapon)" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="27ec-6dde-7b8b-663e" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="cc65-6bdb-a54b-df54" name="Aegis" hidden="false" targetId="ed8b-a6ad-6d94-9c14" type="rule"/>
-        <infoLink id="4968-1efc-e4ad-ccb5" name="Knight Destroyers" hidden="false" targetId="21fb-00b3-1904-e4e6" type="profile"/>
-        <infoLink id="3358-e660-6412-1c0f" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
-        <infoLink id="abef-06b3-4489-1043" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
-      </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="67c9-4895-0125-1c69" name="Psychic(1)" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5ab-6a55-2150-bdd8" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="fb15-4d69-723a-b067" name="Psychic(1)" hidden="false" targetId="2432-e2b3-c2c4-9482" type="profile"/>
-            <infoLink id="7146-dc2f-5be4-b278" name="Psychic(X)" hidden="false" targetId="ba47-b43b-18f8-97c1" type="rule"/>
-          </infoLinks>
-          <entryLinks>
-            <entryLink id="237c-8d76-589d-6093" name="Knight Brothers Psychic Spells" hidden="false" collective="false" import="true" targetId="ef87-9afc-97d0-abdf" type="selectionEntryGroup"/>
-          </entryLinks>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="e849-c767-165d-7b9d" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="9ee3-eb2e-f528-2d76">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b0b-350b-da05-d206" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d3d-aa57-5c67-642a" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="396e-b8e3-be93-d391" name="2x Energy Falchions" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="b983-099d-2a9a-1261" name="Energy Falchions" hidden="false" collective="false" import="true" targetId="50ff-a6f0-26a7-44be" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cf9-5087-963c-c0d3" type="min"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8098-f6e3-904e-a6f2" type="max"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="9ee3-eb2e-f528-2d76" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry"/>
-            <entryLink id="95f9-62dc-02ac-13cf" name="Energy Staff" hidden="false" collective="false" import="true" targetId="5812-eb85-ab7d-c183" type="selectionEntry"/>
-            <entryLink id="764d-cc9b-4177-138a" name="Energy Halberd" hidden="false" collective="false" import="true" targetId="7b55-7b95-caec-2fe5" type="selectionEntry"/>
-            <entryLink id="5901-3d98-0b8e-96e6" name="Daemon Hammer" hidden="false" collective="false" import="true" targetId="10b6-089c-2053-fa2d" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="6439-ae9b-2ab3-913c" name="Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="ac64-c7a3-f8e1-66fa">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="922f-f178-76c2-18d2" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8504-5250-781f-d253" type="min"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="9ff0-ecb7-a0fc-0b41" name="Psychic Silencer" hidden="false" collective="false" import="true" targetId="ad33-44fc-7c8b-a775" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="ee3e-5160-8abe-8a57" name="Psychic Cannon" hidden="false" collective="false" import="true" targetId="c6a1-a06c-031f-3a28" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="ac64-c7a3-f8e1-66fa" name="Incinerator" hidden="false" collective="false" import="true" targetId="10a4-0331-6a0c-0de6" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="9a90-8232-9496-b9aa" name="Knight Destroyers" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="9255-b3cc-c22b-f5d6" name="Knight Destroyer" hidden="false" targetId="21fb-00b3-1904-e4e6" type="profile"/>
+        <infoLink id="dd80-6c01-b796-2c5d" name="Aegis" hidden="false" targetId="ed8b-a6ad-6d94-9c14" type="rule"/>
+        <infoLink id="cf92-7196-8e7e-27e6" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
+        <infoLink id="5672-aad2-cad6-0a73" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
+        <infoLink id="b240-1af4-2f46-adae" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
+      </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="152a-46cd-9f68-039a" name="Brothers" hidden="false" collective="false" import="true" defaultSelectionEntryId="035e-23a4-5bb0-802e">
+        <selectionEntryGroup id="7f36-2f46-8303-0b13" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="03a7-cb48-43ae-06d2">
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f2d-2ba8-111d-1b13" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62e1-5101-42aa-a6c7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a4f-4d7a-913e-0eca" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76ee-d00f-ab05-6316" type="max"/>
           </constraints>
-          <entryLinks>
-            <entryLink id="035e-23a4-5bb0-802e" name="Knight Destroyer" hidden="false" collective="false" import="true" targetId="0ba8-73d6-6b10-785d" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e76-fd3b-ee4d-e69c" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="7e2e-45c2-e8a2-5711" name="Knight Destroyer (Special Weapon)" hidden="false" collective="false" import="true" targetId="f32a-27e3-2e76-19e2" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b515-c474-5e58-686d" type="max"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="1d33-aa2e-b443-283a" name="Upgrade all:" hidden="false" collective="false" import="true">
           <selectionEntries>
-            <selectionEntry id="9308-b9c3-7c04-08db" name="Paladins" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c77-19c3-dd34-b488" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="8c21-04c4-9f69-81c3" name="Paladins" hidden="false" targetId="622f-f793-edf3-3f22" type="profile"/>
-                <infoLink id="3318-87f8-02f7-8b59" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
-              </infoLinks>
+            <selectionEntry id="03a7-cb48-43ae-06d2" name="Single Unit [5 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="6cea-8921-624c-d1ba" name="Knight Brothers - Upgrade List A (single unit)" hidden="false" collective="false" import="true" targetId="e758-8c7c-e792-b68d" type="selectionEntryGroup"/>
+                <entryLink id="6bbf-ad87-08c4-b104" name="Knight Brothers - Upgrade List E (single unit)" hidden="false" collective="false" import="true" targetId="c413-23dc-124c-d1e5" type="selectionEntryGroup"/>
+                <entryLink id="2756-c327-8ed1-24a8" name="Knight Brothers - Upgrade List D (single unit)" hidden="false" collective="false" import="true" targetId="8f26-05e3-fe29-7e49" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="fb00-036c-80b9-2715" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="6b42-0119-6821-0c89" name="Knight Brothers - Upgrade List A (combined unit)" hidden="false" collective="false" import="true" targetId="06b8-d987-9dec-c128" type="selectionEntryGroup"/>
+                <entryLink id="312a-ba14-990b-dd4c" name="Knight Brothers - Upgrade List E (combined unit)" hidden="false" collective="false" import="true" targetId="bad9-bddd-3169-c1c5" type="selectionEntryGroup"/>
+                <entryLink id="07df-2a8d-1708-56ed" name="Knight Brothers - Upgrade List D (combined unit)" hidden="false" collective="false" import="true" targetId="16af-15c6-e091-cbd6" type="selectionEntryGroup"/>
+              </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="45.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="495.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="3e95-d7c3-5a07-deba" name="Upgrade one model with:" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1490-7a83-1e70-a16f" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="b5f4-df58-2994-8fe6" name="Medical Training" hidden="false" collective="false" import="true" targetId="8352-cbe6-9410-a422" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="90.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="4e19-f4ca-14ee-c812" name="Battle Standard" hidden="false" collective="false" import="true" targetId="398c-3d34-79c6-a425" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
@@ -7268,6 +7094,12 @@
       <infoLinks>
         <infoLink id="e6a3-c91f-4a9c-41c2" name="Interceptors" hidden="false" targetId="e91c-d006-e62c-ad96" type="profile"/>
         <infoLink id="11a3-ee55-d835-a02b" name="Teleport" hidden="false" targetId="8569-65c6-aca3-fcf1" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="7567-fa46-e49e-c0aa" name="Paladins" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="0457-fe2c-cc7c-4de7" name="Paladins" hidden="false" targetId="622f-f793-edf3-3f22" type="profile"/>
+        <infoLink id="9e9f-7fa6-1de5-3e9d" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
       </infoLinks>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -15559,6 +15391,72 @@
           </constraints>
         </entryLink>
       </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="8f26-05e3-fe29-7e49" name="Knight Brothers - Upgrade List D (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c8d9-6a68-1c37-50b4" name="Upgrade one model with:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89e8-3c8b-afc7-c3ac" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="16b9-6884-f35c-14ad" name="Battle Standard" hidden="false" collective="false" import="true" targetId="398c-3d34-79c6-a425" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="3399-8d69-4050-97c3" name="Medical Training" hidden="false" collective="false" import="true" targetId="8352-cbe6-9410-a422" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="90.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f667-15f9-24b0-dd9f" name="Upgrade all models with:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="f023-b0c2-3042-1b3b" name="Paladins" hidden="false" collective="false" import="true" targetId="7567-fa46-e49e-c0aa" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0970-f700-3318-c200" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="45.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="16af-15c6-e091-cbd6" name="Knight Brothers - Upgrade List D (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="06df-0e17-7d16-4298" name="Upgrade two models with:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="591f-5f0e-39eb-1719" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5a79-3080-ca68-ce07" name="Battle Standard" hidden="false" collective="false" import="true" targetId="398c-3d34-79c6-a425" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="30d6-652b-00f4-87cf" name="Medical Training" hidden="false" collective="false" import="true" targetId="8352-cbe6-9410-a422" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="90.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e064-6e6f-28c9-91a1" name="Upgrade all models with:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="b290-5ce2-a4ec-3fd3" name="Paladins" hidden="false" collective="false" import="true" targetId="7567-fa46-e49e-c0aa" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b43a-3af7-0d42-c39e" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="90.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -1578,114 +1578,11 @@
         <infoLink id="0d54-ba40-0f61-b63b" name="Battle Tank" hidden="false" targetId="e2d3-6cb7-49a5-5a9c" type="profile"/>
         <infoLink id="2fe3-9cd5-703f-0158" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="6caa-1d56-d1ca-c96b" name="Upgrades" hidden="false" collective="false" import="true">
-          <entryLinks>
-            <entryLink id="4fe8-05a5-ab8f-9c9f" name="Dozer Blade" hidden="false" collective="false" import="true" targetId="5dc2-4ac8-2769-e4ba" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcc3-119d-935f-4464" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="05ee-1e49-33ae-3355" name="Hunter Missile" hidden="false" collective="false" import="true" targetId="c756-9c2d-beca-986c" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf9a-bf03-17f8-71c5" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="e435-bfa2-774e-4ef8" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2f5-7404-d90c-7581" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="aab3-03fa-7dbd-7d24" name="Weapons - Turret" hidden="false" collective="false" import="true" defaultSelectionEntryId="b6eb-c6b1-8ca2-15e5">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcc8-7c9e-a81a-17b0" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3f9-4590-0323-8a4a" type="min"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="b6eb-c6b1-8ca2-15e5" name="Autocannon" hidden="false" collective="false" import="true" targetId="9557-8f54-7c72-fe96" type="selectionEntry"/>
-            <entryLink id="fde5-7860-04ef-53f8" name="Demolition Cannon" hidden="false" collective="false" import="true" targetId="94a0-27e3-289c-8d4a" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="4ef3-b159-73cd-1b57" name="Twin Storm Cannon" hidden="false" collective="false" import="true" targetId="70b5-9898-054e-7b6a" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="65.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="6801-7e0b-3e02-0c36" name="Twin Laser Cannon" hidden="false" collective="false" import="true" targetId="d271-2d81-e640-0040" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="65.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="30ae-4e1d-fc7c-8743" name="Wind Missile Launcher" hidden="false" collective="false" import="true" targetId="acb1-1539-32b6-1874" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="60.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="ff4c-8d03-ff07-c176" name="Spear Missile Launcher" hidden="false" collective="false" import="true" targetId="8d35-9260-5933-f3dc" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="d701-e081-1e04-14fd" name="Weapons - Sponsons" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b6f-c9a7-1c3a-84a7" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="1eee-2401-5bb6-e3d8" name="2x Heavy Machineguns" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="d821-ab42-9176-ae54" name="Heavy Machinegun" hidden="false" collective="false" import="true" targetId="4481-49a4-e4f7-925b" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f82-0f35-d04c-c63c" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a631-0b33-e08d-89c0" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="55.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="116d-e2a4-0e96-59cd" name="2x Laser Cannons" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="b8ce-b50b-2410-fd4e" name="Laser Cannon" hidden="false" collective="false" import="true" targetId="1f20-2b60-f100-bed0" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1350-3b49-b8d6-9a03" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="19a5-8b3c-481a-9fea" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="95.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="9a7a-c4c9-daa6-9133" name="Blood Brothers - Very Fast" hidden="false" collective="false" import="true" targetId="ec17-0396-1d9d-0ad9" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="3e00-405d-2d59-6d2d" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
-          </costs>
-        </entryLink>
+        <entryLink id="5f2c-20d3-cb18-0bdd" name="** Detachment Upgrade (Units of [1] with Tough(12) &amp; Fast) **" hidden="false" collective="false" import="true" targetId="a235-3a7c-ad55-1c1b" type="selectionEntryGroup"/>
+        <entryLink id="7606-624a-4903-6cb2" name="Battle Brothers 3 - Upgrade List A" hidden="false" collective="false" import="true" targetId="9a2d-b4b4-997a-7075" type="selectionEntryGroup"/>
+        <entryLink id="1817-f706-a3a5-0234" name="Battle Brothers 3 - Upgrade List B" hidden="false" collective="false" import="true" targetId="6d58-cfaf-3917-e973" type="selectionEntryGroup"/>
+        <entryLink id="8ab3-d354-a392-6dd2" name="Battle Brothers 3 - Upgrade List C" hidden="false" collective="false" import="true" targetId="3f80-0132-5847-a410" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="345.0"/>
@@ -14074,6 +13971,146 @@
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="9a2d-b4b4-997a-7075" name="Battle Brothers 3 - Upgrade List A" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7b85-05f6-62ed-1fff" name="Upgrade with any:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="6a8e-369a-f519-538a" name="Dozer Blade" hidden="false" collective="false" import="true" targetId="5dc2-4ac8-2769-e4ba" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a5e-c04b-e3ac-646a" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="86d4-ab3a-eb29-f7fa" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="326f-4c3e-2a13-46e8" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="6d58-cfaf-3917-e973" name="Battle Brothers 3 - Upgrade List B" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="65ec-8c8c-baca-7358" name="Upgrade with:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="1a78-7c2a-fb0c-cebf" name="Hunter Missiles" hidden="false" collective="false" import="true" targetId="c756-9c2d-beca-986c" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc84-2f05-1a61-da2b" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="3f80-0132-5847-a410" name="Battle Brothers 3 - Upgrade List C" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="903e-53ea-3ff0-6ce9" name="Replace Autocannon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="f0d9-9c6b-34cd-c8da">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6fc-29a2-165a-5cb8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7ff-d6c1-1d3c-59e2" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="f0d9-9c6b-34cd-c8da" name="Autocannon" hidden="false" collective="false" import="true" targetId="9557-8f54-7c72-fe96" type="selectionEntry"/>
+            <entryLink id="8497-d4be-bf25-b3fe" name="Spear Missile Launcher" hidden="false" collective="false" import="true" targetId="8d35-9260-5933-f3dc" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="3572-f6b4-3523-bc6a" name="Demolition Cannon" hidden="false" collective="false" import="true" targetId="94a0-27e3-289c-8d4a" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="2b73-79ab-28ef-451b" name="Wind Missile Launcher" hidden="false" collective="false" import="true" targetId="acb1-1539-32b6-1874" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="60.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="67a2-daf9-f8e8-b07f" name="Twin Laser Cannon" hidden="false" collective="false" import="true" targetId="d271-2d81-e640-0040" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="65.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="03b3-bdd0-c733-5af6" name="Twin Storm Cannon" hidden="false" collective="false" import="true" targetId="70b5-9898-054e-7b6a" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="65.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a03d-c7cf-1920-0c7a" name="Upgrade with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9d5-788e-4db2-6db2" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="2c44-36fd-7593-9f9a" name="2x Heavy Machineguns" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="69b4-478b-beea-eebd" name="Heavy Machinegun" hidden="false" collective="false" import="true" targetId="4481-49a4-e4f7-925b" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ce1-170b-537e-c7fb" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8369-1174-c730-067f" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="55.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="05a7-95a2-2b18-63b8" name="2x Laser Cannons" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="e53b-6812-2da1-8061" name="Laser Cannon" hidden="false" collective="false" import="true" targetId="1f20-2b60-f100-bed0" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e7a-6122-1d37-f04d" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efb7-171b-bcfa-9560" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="95.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="a235-3a7c-ad55-1c1b" name="** Detachment Upgrade (Units of [1] with Tough(12) &amp; Fast) **" hidden="false" collective="false" import="true">
+      <entryLinks>
+        <entryLink id="ae70-39d9-eecc-ce86" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="3bf7-7035-8629-6562" name="Blood Brothers - Very Fast" hidden="false" collective="false" import="true" targetId="ec17-0396-1d9d-0ad9" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="6123-09d2-1e2a-e96d" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="e290-dff6-76d8-21b8" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="61ae-8047-c552-e675" name="Wolf Brothers - Counter" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+          </costs>
+        </entryLink>
+      </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -2655,137 +2655,37 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="150.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4a67-2627-40ab-e2c0" name="Watch Vanguard" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="1bd7-2bea-c5e1-9391" name="Watch Vanguard" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="95ed-9e58-6d25-7386" name="Watch Vanguard" hidden="false" targetId="9135-94a4-9ad0-cfa3" type="profile"/>
-        <infoLink id="b5c4-ad9d-1782-cf86" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
-        <infoLink id="a178-5b11-e177-240f" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="f2e1-bc40-1fbc-d79d" name="Flying" hidden="false" targetId="adc6-ddd5-223d-29b1" type="rule"/>
-        <infoLink id="75f2-637c-c31b-921d" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
+        <infoLink id="8234-1c04-bbe3-0d7c" name="Watch Vanguard" hidden="false" targetId="9135-94a4-9ad0-cfa3" type="profile"/>
+        <infoLink id="8b74-0922-54cc-70e3" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
+        <infoLink id="26ea-9ca9-b1b4-dccd" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
+        <infoLink id="495a-f0a8-b58b-ba07" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
+        <infoLink id="5b18-f87e-fc87-5037" name="Flying" hidden="false" targetId="adc6-ddd5-223d-29b1" type="rule"/>
       </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="5b21-3c77-7dd2-0f3e" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="1586-9d7e-0aed-86e6">
+        <selectionEntryGroup id="d035-c627-0f7a-068e" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="018d-d3c0-7d2f-34a0">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc9f-2e65-bba8-38bc" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5a8-6d7e-6777-629e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e200-9dcb-fe23-4c87" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9ff-abe8-158c-0228" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="e091-6e30-70c2-8b58" name="Heavy Energy Hammer" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="018d-d3c0-7d2f-34a0" name="Single Unit [5 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="0be2-eb1a-9467-abe1" name="Heavy Energy Hammer" hidden="false" collective="false" import="true" targetId="5cdf-6e92-c1ce-3a65" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51d7-9226-7bb7-b4b3" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d31-456d-25f5-265c" type="min"/>
-                  </constraints>
-                </entryLink>
+                <entryLink id="d82b-d9ff-29fe-ac6e" name="Watch Brothers - Upgrade List C (single unit)" hidden="false" collective="false" import="true" targetId="4319-a3c9-e906-58cb" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="87ce-21a4-1eac-ebfb" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="dfcb-4563-b348-7fb4" name="Watch Brothers - Upgrade List C (combined unit)" hidden="false" collective="false" import="true" targetId="1f44-e640-bc84-005f" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="1586-9d7e-0aed-86e6" name="Ranged &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="ea2b-8c63-349c-ba4c" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="6e08-d89d-7a7e-a0d9">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73ac-72a8-9db2-1967" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a28e-170d-7750-5751" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="6e08-d89d-7a7e-a0d9" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
-                    <entryLink id="6ddf-ef36-b6ab-d1fa" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="9dd7-6faf-2b83-891b" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="d589-dc3c-8157-9e46" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="2360-fbec-7f3c-c319" name="Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="dd2e-cbf2-7298-31e9">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="573c-0386-f61b-9e26" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c05a-7b9b-f402-5720" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="e1d4-e444-3e2c-f13c" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="dd2e-cbf2-7298-31e9" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
-                    <entryLink id="0301-99e1-31e8-fb14" name="Flame Pistol" hidden="false" collective="false" import="true" targetId="db8f-b317-2b7d-2ed3" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="9e79-2567-e9ce-3125" name="Gravity Pistol" hidden="false" collective="false" import="true" targetId="f790-2f7c-63a0-1603" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="6766-f269-3271-4a46" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="2071-4cb6-f32c-5d11" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="6afa-0dd4-55e6-9b78" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="497e-b782-713b-ae3f" name="Energy Claw" hidden="false" collective="false" import="true" targetId="71e9-a72c-6160-0673" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a98-28a8-33c2-07da" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ff2-171b-ec64-9450" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="270.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="1bd7-2bea-c5e1-9391" name="Watch Vanguard" hidden="false" collective="false" import="true" type="upgrade">
-      <selectionEntryGroups>
-        <selectionEntryGroup id="9f02-de60-4a5b-c463" name="Upgrade all:" hidden="false" collective="false" import="true">
-          <entryLinks>
-            <entryLink id="bf8a-1830-1f4d-608e" name="Combat Shield" hidden="false" collective="false" import="true" targetId="f5b9-642f-6bfe-ce58" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5168-3950-853b-9b35" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="16b5-750d-036d-b926" name="Death Vanguard" hidden="false" collective="false" import="true" targetId="4a67-2627-40ab-e2c0" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f2b-5a94-b791-d00a" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fce-422f-4be6-4b31" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="270.0"/>
       </costs>
@@ -6498,6 +6398,11 @@
       <infoLinks>
         <infoLink id="0457-fe2c-cc7c-4de7" name="Paladins" hidden="false" targetId="622f-f793-edf3-3f22" type="profile"/>
         <infoLink id="9e9f-7fa6-1de5-3e9d" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="3d6f-8204-0d5f-6153" name="Flamethrower Pistol" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="8aec-ce26-c580-e100" name="Flamethrower Pistol" hidden="false" targetId="b574-ad82-82b6-8486" type="profile"/>
       </infoLinks>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -14995,23 +14900,20 @@
           <selectionEntries>
             <selectionEntry id="8e4e-3877-0fa5-143c" name="Pistol &amp; CCW (A2)" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="221d-289e-465a-ed31" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb3a-1d7b-fb9c-91d9" type="max"/>
               </constraints>
               <selectionEntryGroups>
-                <selectionEntryGroup id="a95b-3eb5-b093-440c" name="Replace any Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="5560-3df6-ec48-d3e8">
+                <selectionEntryGroup id="a95b-3eb5-b093-440c" name="Replace any Pistol:" hidden="false" collective="true" import="true" defaultSelectionEntryId="5560-3df6-ec48-d3e8">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed52-ee89-fdbd-844d" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b82-f5ec-a9cd-586e" type="max"/>
                   </constraints>
                   <selectionEntryGroups>
                     <selectionEntryGroup id="1c7a-d728-632f-ff98" name="Replace up to two Pistols:" hidden="false" collective="false" import="true">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aee1-a8ff-5800-22ef" type="max"/>
-                      </constraints>
                       <entryLinks>
                         <entryLink id="5489-81ee-2b5b-ad93" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c36-2813-ebde-e991" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9565-28bb-e68c-aa42" type="max"/>
                           </constraints>
                           <costs>
                             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
@@ -15019,7 +14921,7 @@
                         </entryLink>
                         <entryLink id="bd9e-1abb-3e13-5f73" name="Heavy Machinegun" hidden="false" collective="false" import="true" targetId="4481-49a4-e4f7-925b" type="selectionEntry">
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03f0-b641-27b0-575f" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6081-63cc-d3de-09fa" type="max"/>
                           </constraints>
                           <selectionEntryGroups>
                             <selectionEntryGroup id="d6c4-1726-20a5-9dcf" name="Any model may take one Heavy Machinegun attachment:" hidden="false" collective="false" import="true">
@@ -15041,7 +14943,7 @@
                         </entryLink>
                         <entryLink id="a0ba-de51-c62f-d345" name="Missile Launcher" hidden="false" collective="false" import="true" targetId="ff1b-714c-6353-221d" type="selectionEntry">
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5146-d359-3eaf-8246" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1aed-b6eb-9774-67f5" type="max"/>
                           </constraints>
                           <costs>
                             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
@@ -15049,7 +14951,7 @@
                         </entryLink>
                         <entryLink id="7917-5bef-223f-2920" name="Frag Blaster" hidden="false" collective="false" import="true" targetId="dcff-7eac-1a79-0535" type="selectionEntry">
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd79-ee3b-e912-eb52" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c53b-81c8-38aa-aa26" type="max"/>
                           </constraints>
                           <costs>
                             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
@@ -15061,12 +14963,12 @@
                   <entryLinks>
                     <entryLink id="5560-3df6-ec48-d3e8" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0324-5b28-f242-138e" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95c9-4bcc-2230-6acc" type="max"/>
                       </constraints>
                     </entryLink>
                     <entryLink id="5369-259a-6eaa-467e" name="Gravity Pistol" hidden="false" collective="false" import="true" targetId="f790-2f7c-63a0-1603" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a790-8ebc-3549-ca6d" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99cd-c229-ba4f-f5fd" type="max"/>
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
@@ -15074,7 +14976,7 @@
                     </entryLink>
                     <entryLink id="0da6-a2f5-3ab8-d063" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e542-f412-9b78-0bfc" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4e2-4b31-d622-944f" type="max"/>
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
@@ -15082,7 +14984,7 @@
                     </entryLink>
                     <entryLink id="37d2-b90c-20c5-8192" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="994d-fac1-9ba4-81aa" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d55e-433e-7db8-4a0c" type="max"/>
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
@@ -15090,7 +14992,7 @@
                     </entryLink>
                     <entryLink id="c919-ecd0-f344-06da" name="Death Shotgun" hidden="false" collective="false" import="true" targetId="62f5-cae0-bd32-ff9e" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac75-94a9-2b8e-7b3a" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9fa-aaab-5b5b-d1e3" type="max"/>
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
@@ -15098,7 +15000,7 @@
                     </entryLink>
                     <entryLink id="34c7-ca6f-b610-4d1f" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43b6-ef6d-2bce-b48b" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b06-c58a-3486-fdbe" type="max"/>
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
@@ -15106,7 +15008,7 @@
                     </entryLink>
                     <entryLink id="d4c6-53c4-5b1d-ebab" name="Gravity Rifle" hidden="false" collective="false" import="true" targetId="3e4a-da63-fdf2-c5fb" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d34-1f04-2c75-a443" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf70-ebdf-1f29-6534" type="max"/>
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
@@ -15114,7 +15016,7 @@
                     </entryLink>
                     <entryLink id="ba38-e840-808b-0025" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42fd-c39c-3fe6-ddc5" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c13f-9130-956f-4b74" type="max"/>
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
@@ -15122,7 +15024,7 @@
                     </entryLink>
                     <entryLink id="a27b-fe8f-8557-9536" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="2071-4cb6-f32c-5d11" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b26-8bd5-689a-6c6f" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fbb-2d47-1665-a139" type="max"/>
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
@@ -15130,7 +15032,7 @@
                     </entryLink>
                     <entryLink id="616b-d5ea-1e47-c753" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="378b-8d78-1f82-ca73" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d616-ce6e-0da9-b1ee" type="max"/>
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
@@ -15138,7 +15040,7 @@
                     </entryLink>
                     <entryLink id="133f-2206-ccc7-ecaf" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed37-9f98-d10d-f055" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3893-9c6a-65dc-30fb" type="max"/>
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
@@ -15146,13 +15048,16 @@
                     </entryLink>
                     <entryLink id="62d2-fd97-6928-cd7b" name="Stalker Rifle" hidden="false" collective="false" import="true" targetId="45c7-c680-df64-25c9" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1862-9c7f-020d-4492" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d227-e6d6-44aa-9ea1" type="max"/>
                       </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="1362-1646-9174-eb46" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e61-c667-3662-cfcd" type="max"/>
+                      </constraints>
                       <selectionEntryGroups>
                         <selectionEntryGroup id="582e-ce63-ba1c-5921" name="Any model may take on Assault Rifle attachment:" hidden="false" collective="false" import="true">
                           <constraints>
@@ -15188,24 +15093,37 @@
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="c3e2-06a1-b396-4afc" name="Replace any CCW" hidden="false" collective="false" import="true" defaultSelectionEntryId="c3c6-002c-6425-2d52">
+                <selectionEntryGroup id="c3e2-06a1-b396-4afc" name="Replace any CCW" hidden="false" collective="true" import="true" defaultSelectionEntryId="c3c6-002c-6425-2d52">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98b2-0ff9-1fe0-c76d" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d27-ba72-0f47-06bd" type="max"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="c3c6-002c-6425-2d52" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+                    <entryLink id="c3c6-002c-6425-2d52" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23f8-e5f0-9b5f-d85c" type="max"/>
+                      </constraints>
+                    </entryLink>
                     <entryLink id="a8e8-9745-0d9c-600a" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1dc5-4820-dede-83b9" type="max"/>
+                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="f1a3-0d4b-66f9-dbb7" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2874-5146-a2a2-0e67" type="max"/>
+                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="c708-9c17-35e5-675b" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1b3-c5b5-5a04-c4eb" type="max"/>
+                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
                       </costs>
@@ -15214,12 +15132,12 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
             </selectionEntry>
-            <selectionEntry id="08dd-3deb-7ea6-418e" name="2x Energy Claws" hidden="false" collective="true" import="true" type="upgrade">
+            <selectionEntry id="08dd-3deb-7ea6-418e" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ea3-81e9-91b2-72cb" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44a4-85c2-b02b-868f" type="max"/>
               </constraints>
               <entryLinks>
-                <entryLink id="1ebc-cdb8-88e9-338a" name="Energy Claw" hidden="false" collective="true" import="true" targetId="0ed5-13cf-f02f-9759" type="selectionEntry">
+                <entryLink id="1ebc-cdb8-88e9-338a" name="Energy Claw" hidden="false" collective="false" import="true" targetId="0ed5-13cf-f02f-9759" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e143-bec6-e9cc-af64" type="min"/>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5927-bae3-337d-23c3" type="max"/>
@@ -15236,7 +15154,7 @@
               <selectionEntries>
                 <selectionEntry id="7a97-454b-7265-883d" name="Spear-Rifle &amp; Spear" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf1a-f008-8680-39cc" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b64d-5bac-4005-c19e" type="max"/>
                   </constraints>
                   <entryLinks>
                     <entryLink id="bc3b-1179-dcfe-5375" name="Spear-Rifle" hidden="false" collective="false" import="true" targetId="281a-ee78-0632-079d" type="selectionEntry">
@@ -15262,7 +15180,7 @@
           <entryLinks>
             <entryLink id="f627-617d-aeac-2f7a" name="Heavy Energy Hammer" hidden="false" collective="false" import="true" targetId="5cdf-6e92-c1ce-3a65" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6edf-77b9-cf8e-be3d" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9669-b082-9819-70b1" type="max"/>
               </constraints>
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
@@ -15294,131 +15212,90 @@
           <selectionEntries>
             <selectionEntry id="45e4-4be6-602c-1346" name="Pistol &amp; CCW (A2)" hidden="false" collective="false" import="true" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="a9a2-de4c-5571-5bf5" name="Replace any Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="7c69-a1cd-8113-12a0">
+                <selectionEntryGroup id="a9a2-de4c-5571-5bf5" name="Replace any Pistol:" hidden="false" collective="true" import="true" defaultSelectionEntryId="7c69-a1cd-8113-12a0">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85eb-fc9d-49a7-76f0" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c8b-09be-18d5-5f9e" type="max"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="7c69-a1cd-8113-12a0" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2d8-ebab-ad66-41f7" type="max"/>
-                      </constraints>
-                    </entryLink>
+                    <entryLink id="7c69-a1cd-8113-12a0" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
                     <entryLink id="c72a-e2b9-3b51-24a1" name="Gravity Pistol" hidden="false" collective="false" import="true" targetId="f790-2f7c-63a0-1603" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ab7-13af-2897-b6a1" type="max"/>
-                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="9e91-8e2e-fd1d-4ede" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be9a-75f2-e34c-e4aa" type="max"/>
-                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="cbc9-4b3d-06a7-876d" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e1c-6b23-314e-dff3" type="max"/>
-                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="727c-f79f-e02c-e9ee" name="Death Shotgun" hidden="false" collective="false" import="true" targetId="62f5-cae0-bd32-ff9e" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ed1-a13a-77a1-3d72" type="max"/>
-                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="b5d9-94e2-fbbb-0592" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8177-2800-c092-e91e" type="max"/>
-                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="9438-3613-8be0-a789" name="Gravity Rifle" hidden="false" collective="false" import="true" targetId="3e4a-da63-fdf2-c5fb" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42df-e02a-178e-10ea" type="max"/>
-                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="9cf4-35a7-97e5-152a" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12d1-730d-878c-bcba" type="max"/>
-                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="5e94-eb02-3c7c-9e47" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="2071-4cb6-f32c-5d11" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96bd-ed3b-d33b-c56c" type="max"/>
-                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="1127-fc8d-4779-b5f9" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7b0-72ab-ff7b-735d" type="max"/>
-                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="1fc5-d8f3-4f48-696d" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="834f-7f16-0990-5781" type="max"/>
-                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="7ef8-3c12-a6d3-20aa" name="Stalker Rifle" hidden="false" collective="false" import="true" targetId="45c7-c680-df64-25c9" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4915-e698-70fe-0078" type="max"/>
-                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
                       </costs>
                     </entryLink>
-                    <entryLink id="ca6b-64a7-3d60-4fcb" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdc6-e618-8943-6375" type="max"/>
-                      </constraints>
+                    <entryLink id="d771-88b2-0789-65fe" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
                       <selectionEntryGroups>
-                        <selectionEntryGroup id="ad16-9338-7b49-cf20" name="Any model may take on Assault Rifle attachment:" hidden="false" collective="false" import="true">
+                        <selectionEntryGroup id="f912-bbee-2a99-f2f9" name="Any model may take on Assault Rifle attachment:" hidden="false" collective="true" import="true">
                           <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a32-f305-68f6-596c" type="max"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d423-056f-c168-9a94" type="max"/>
                           </constraints>
                           <entryLinks>
-                            <entryLink id="5d34-5fc6-1138-8813" name="Gravity Rifle" hidden="false" collective="false" import="true" targetId="3e4a-da63-fdf2-c5fb" type="selectionEntry">
+                            <entryLink id="aadd-864e-615d-f62b" name="Gravity Rifle" hidden="false" collective="false" import="true" targetId="3e4a-da63-fdf2-c5fb" type="selectionEntry">
                               <costs>
                                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
                               </costs>
                             </entryLink>
-                            <entryLink id="09a2-e016-cb67-18e8" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
+                            <entryLink id="cdf9-d672-249e-38af" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
                               <costs>
                                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
                               </costs>
                             </entryLink>
-                            <entryLink id="2393-c1d0-60a4-5793" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
+                            <entryLink id="f84d-ce48-483c-938a" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
                               <costs>
                                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
                               </costs>
                             </entryLink>
-                            <entryLink id="64c3-3cbd-4ab1-e09f" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
+                            <entryLink id="6fa7-17bc-a6d6-f30d" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
                               <costs>
                                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
                               </costs>
@@ -15432,10 +15309,9 @@
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="9b2d-5daa-5612-4524" name="Replace any CCW" hidden="false" collective="false" import="true" defaultSelectionEntryId="ae74-69a4-e9e4-a1c3">
+                <selectionEntryGroup id="9b2d-5daa-5612-4524" name="Replace any CCW" hidden="false" collective="true" import="true" defaultSelectionEntryId="ae74-69a4-e9e4-a1c3">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ab8-d9f2-fd0e-372a" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36a3-b6d5-e197-279a" type="max"/>
                   </constraints>
                   <entryLinks>
                     <entryLink id="ae74-69a4-e9e4-a1c3" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
@@ -15473,7 +15349,7 @@
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
-            <selectionEntryGroup id="ee9b-f059-d074-5e24" name="Replace up to two Pistols:" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="ee9b-f059-d074-5e24" name="Replace up to two Pistols:" hidden="false" collective="true" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="61bb-6116-df2f-5f7b" type="max"/>
               </constraints>
@@ -15690,111 +15566,70 @@
           <selectionEntries>
             <selectionEntry id="d21f-721d-b93f-b8c0" name="Pistol &amp; CCW (A2)" hidden="false" collective="false" import="true" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="5eb5-5a8f-d385-be56" name="Replace any Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="f1aa-001f-a2d3-b464">
+                <selectionEntryGroup id="5eb5-5a8f-d385-be56" name="Replace any Pistol:" hidden="false" collective="true" import="true" defaultSelectionEntryId="f1aa-001f-a2d3-b464">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3910-0eed-9f6c-988c" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbf9-fea9-56b8-3dfa" type="max"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="f1aa-001f-a2d3-b464" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc94-ac1c-181e-725c" type="max"/>
-                      </constraints>
-                    </entryLink>
+                    <entryLink id="f1aa-001f-a2d3-b464" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
                     <entryLink id="5b1e-81a2-0456-6959" name="Gravity Pistol" hidden="false" collective="false" import="true" targetId="f790-2f7c-63a0-1603" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46a2-bd91-85c7-14e5" type="max"/>
-                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="5ce0-3522-292e-3408" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7477-668e-1cd5-6de2" type="max"/>
-                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="6e4b-9a4e-a974-5501" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a1d-6e52-a060-3d86" type="max"/>
-                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="8191-a471-db4f-93e4" name="Death Shotgun" hidden="false" collective="false" import="true" targetId="62f5-cae0-bd32-ff9e" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d34-0bb4-9836-b43f" type="max"/>
-                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="6898-e9f9-445d-4045" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ff7-4e1f-483d-2231" type="max"/>
-                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="a0dc-23b5-3b24-8ad4" name="Gravity Rifle" hidden="false" collective="false" import="true" targetId="3e4a-da63-fdf2-c5fb" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="faab-0d43-f558-74cc" type="max"/>
-                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="5194-d2fc-aa9b-7469" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20b8-4e23-390a-b0e5" type="max"/>
-                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="ad97-ef09-5a24-dbd9" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="2071-4cb6-f32c-5d11" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d928-6983-594a-56c0" type="max"/>
-                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="d8c2-6b21-5484-a6d0" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a45b-04e3-1634-04e7" type="max"/>
-                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="e6ea-406c-08a9-9d05" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4324-1c9a-238c-bdcd" type="max"/>
-                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="8898-6793-8758-5082" name="Stalker Rifle" hidden="false" collective="false" import="true" targetId="45c7-c680-df64-25c9" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65a1-f2aa-9045-eb90" type="max"/>
-                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="8005-d779-d10d-58df" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1275-b366-b282-9c60" type="max"/>
-                      </constraints>
                       <selectionEntryGroups>
-                        <selectionEntryGroup id="072f-2fad-7fa2-3aa7" name="Any model may take on Assault Rifle attachment:" hidden="false" collective="false" import="true">
+                        <selectionEntryGroup id="072f-2fad-7fa2-3aa7" name="Any model may take on Assault Rifle attachment:" hidden="false" collective="true" import="true">
                           <constraints>
                             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7950-0611-cab8-794e" type="max"/>
                           </constraints>
@@ -15828,10 +15663,9 @@
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="74bc-59d4-f7fb-5a86" name="Replace any CCW" hidden="false" collective="false" import="true" defaultSelectionEntryId="8bae-0364-fc25-16a7">
+                <selectionEntryGroup id="74bc-59d4-f7fb-5a86" name="Replace any CCW" hidden="false" collective="true" import="true" defaultSelectionEntryId="8bae-0364-fc25-16a7">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83d5-976f-9182-0921" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ea6-e3a1-8f52-ab39" type="max"/>
                   </constraints>
                   <entryLinks>
                     <entryLink id="8bae-0364-fc25-16a7" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
@@ -15869,14 +15703,14 @@
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
-            <selectionEntryGroup id="b1bf-e098-a012-893c" name="Replace up to four Pistols:" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="b1bf-e098-a012-893c" name="Replace up to four Pistols:" hidden="false" collective="true" import="true">
               <constraints>
                 <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="51cc-71e3-ffb9-d0f2" type="max"/>
               </constraints>
               <selectionEntries>
                 <selectionEntry id="fd9d-a7c2-f67d-b250" name="Frag Blaster &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
                   <selectionEntryGroups>
-                    <selectionEntryGroup id="4f30-1b5e-5d71-8610" name="Replace any CCW" hidden="false" collective="false" import="true">
+                    <selectionEntryGroup id="4f30-1b5e-5d71-8610" name="Replace any CCW" hidden="false" collective="false" import="true" defaultSelectionEntryId="1d76-177b-06e7-5d67">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8dda-7058-a44f-f70c" type="min"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6817-95d4-7913-42b3" type="max"/>
@@ -15918,7 +15752,7 @@
                 </selectionEntry>
                 <selectionEntry id="ef48-dba1-0446-eb99" name="Heavy Flamethrower &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
                   <selectionEntryGroups>
-                    <selectionEntryGroup id="ca93-7a9f-cb30-b69e" name="Replace any CCW" hidden="false" collective="false" import="true">
+                    <selectionEntryGroup id="ca93-7a9f-cb30-b69e" name="Replace any CCW" hidden="false" collective="false" import="true" defaultSelectionEntryId="765b-721a-43cb-d426">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="adea-1eb1-f758-931f" type="min"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad39-8179-70c1-7fa9" type="max"/>
@@ -15978,7 +15812,7 @@
                             </entryLink>
                           </entryLinks>
                         </selectionEntryGroup>
-                        <selectionEntryGroup id="088a-c7b3-2675-441f" name="Replace any CCW" hidden="false" collective="false" import="true">
+                        <selectionEntryGroup id="088a-c7b3-2675-441f" name="Replace any CCW" hidden="false" collective="false" import="true" defaultSelectionEntryId="4487-9f47-ed78-9841">
                           <constraints>
                             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9341-53da-8f70-f403" type="min"/>
                             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf9a-8b39-652b-1b7a" type="max"/>
@@ -16011,7 +15845,7 @@
                 </selectionEntry>
                 <selectionEntry id="ca1a-f750-5503-f3dc" name="Missile Launcher &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
                   <selectionEntryGroups>
-                    <selectionEntryGroup id="31e3-26cd-cac1-490a" name="Replace any CCW" hidden="false" collective="false" import="true">
+                    <selectionEntryGroup id="31e3-26cd-cac1-490a" name="Replace any CCW" hidden="false" collective="false" import="true" defaultSelectionEntryId="129b-3bd2-2e24-1c38">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0875-ae1a-6bb9-4df3" type="min"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2356-48bf-346c-2b91" type="max"/>
@@ -16067,6 +15901,210 @@
             <entryLink id="e722-d466-51a7-82f9" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffe2-1d21-c5f8-5195" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="4319-a3c9-e906-58cb" name="Watch Brothers - Upgrade List C (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="75a8-29fb-28c8-c81a" name="Replace any Pistol &amp; CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="d125-104e-7c62-b7ea">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8e2-7ca6-8905-f9c3" type="max"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcf8-f8d0-403d-428f" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="d125-104e-7c62-b7ea" name="Pistol &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="92a8-a132-6682-7838" name="Replace any CCW:" hidden="false" collective="true" import="true" defaultSelectionEntryId="c909-973b-6c22-391f">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="786a-9970-b55a-1507" type="min"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="c909-973b-6c22-391f" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+                    <entryLink id="af79-4d72-1781-6c2e" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="2912-2bf4-785a-200f" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="3e03-421f-3e78-eb57" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="a6ed-e611-6ba2-edcd" name="Replace any Pistol:" hidden="false" collective="true" import="true" defaultSelectionEntryId="0dae-3d06-e78b-8dd2">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e629-a47c-8f9c-29a0" type="min"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="0dae-3d06-e78b-8dd2" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
+                    <entryLink id="0f96-d470-86d5-d896" name="Flame Pistol" hidden="false" collective="false" import="true" targetId="db8f-b317-2b7d-2ed3" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="a16e-381a-f066-6ce2" name="Gravity Pistol" hidden="false" collective="false" import="true" targetId="f790-2f7c-63a0-1603" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="3ff5-6e9a-bca6-5ad3" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="330b-62f1-9db7-d6d6" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="2071-4cb6-f32c-5d11" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c7b3-132d-e5d8-1f77" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="7c4d-b92d-3ed6-221a" name="Energy Claw" hidden="false" collective="false" import="true" targetId="0ed5-13cf-f02f-9759" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c31e-d118-b399-5bc9" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="317a-7d21-74d4-751c" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="ba91-8a84-0d29-84c1" name="Heavy Energy Hammer" hidden="false" collective="false" import="true" targetId="5cdf-6e92-c1ce-3a65" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a77d-588d-0b17-a055" name="Upgrade all models with:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="dd32-349f-9ba9-42e3" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44d1-02f5-eea8-c05c" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="1f44-e640-bc84-005f" name="Watch Brothers - Upgrade List C (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="217f-4f97-1971-1051" name="Replace any Pistol &amp; CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="86f2-1cef-2a16-6f33">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10d8-66d8-0c61-62bd" type="max"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9041-734e-8070-18f1" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="86f2-1cef-2a16-6f33" name="Pistol &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="ac4a-8014-77cb-64eb" name="Replace any CCW:" hidden="false" collective="true" import="true" defaultSelectionEntryId="8a21-5df1-7dba-c71d">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f873-88b4-c988-d44a" type="min"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="8a21-5df1-7dba-c71d" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+                    <entryLink id="1a2f-fe69-f938-5af4" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="0767-a216-eeb3-f200" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="4ddc-f828-08b9-32a3" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="efc1-abfa-3485-dd85" name="Replace any Pistol:" hidden="false" collective="true" import="true" defaultSelectionEntryId="4de4-0e13-f09d-74da">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e852-9cd0-235b-63d8" type="min"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="4de4-0e13-f09d-74da" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
+                    <entryLink id="cd67-8a5a-fbf1-35c9" name="Flame Pistol" hidden="false" collective="false" import="true" targetId="db8f-b317-2b7d-2ed3" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="c93d-d7eb-fd9c-3956" name="Gravity Pistol" hidden="false" collective="false" import="true" targetId="f790-2f7c-63a0-1603" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="a5e6-dad0-b731-7f1a" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="dac8-9488-b8b3-2719" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="2071-4cb6-f32c-5d11" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="425f-2c92-da1c-2cbc" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="95fc-7568-df77-6f30" name="Energy Claw" hidden="false" collective="false" import="true" targetId="0ed5-13cf-f02f-9759" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93d6-2fc0-625b-c56b" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcf0-2f7a-7321-8a3d" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="019c-dbe0-568c-537b" name="Heavy Energy Hammer" hidden="false" collective="false" import="true" targetId="5cdf-6e92-c1ce-3a65" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d91c-84e5-7e67-bdf3" name="Upgrade all models with:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="c9b9-fa19-0ce3-e9c4" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c50-5386-4f66-6eed" type="max"/>
               </constraints>
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -7010,25 +7010,6 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="185.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e05c-e005-0f85-40eb" name="Suppresion Brother" hidden="false" collective="false" import="true" type="upgrade">
-      <entryLinks>
-        <entryLink id="8946-5e56-4a35-ce96" name="Autocannon" hidden="false" collective="false" import="true" targetId="2ca3-1684-8665-05b0" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c00c-9891-edb8-577d" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2d9-c747-a9d6-fade" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="acdb-2afc-c16f-1de8" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="168d-fc4b-a9af-d00f" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a33-c75c-b4bf-6082" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d18-3595-4e9d-fbda" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="2ca3-1684-8665-05b0" name="Autocannon" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="1ad4-04dd-702c-d1a0" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
@@ -7040,44 +7021,58 @@
     </selectionEntry>
     <selectionEntry id="4d7d-3f02-6345-2f6c" name="Suppression Squad" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="7ee9-6916-995c-a4c6" name="Suppression Brother" hidden="false" targetId="587d-90fa-bcdb-932c" type="profile"/>
+        <infoLink id="7ee9-6916-995c-a4c6" name="Prime Suppression Brother" hidden="false" targetId="587d-90fa-bcdb-932c" type="profile"/>
         <infoLink id="73b6-c159-3012-8b67" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
         <infoLink id="e788-173d-9ff0-633f" name="Firstborn" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
         <infoLink id="2400-b4cc-75b2-074c" name="Flying" hidden="false" targetId="adc6-ddd5-223d-29b1" type="rule"/>
       </infoLinks>
-      <entryLinks>
-        <entryLink id="6808-3048-e4e9-3d49" name="Suppresion Brother" hidden="false" collective="false" import="true" targetId="e05c-e005-0f85-40eb" type="selectionEntry">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2ef9-ecaa-2bd2-2aab" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="a93a-f50c-4da2-c4d8">
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9926-2934-1139-53f5" type="max"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="049e-00f1-f160-c6ac" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02ad-63b6-880f-ed57" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bce-8e8b-595b-58b8" type="max"/>
           </constraints>
-        </entryLink>
-        <entryLink id="fd2d-03c2-117f-3168" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="21e2-a3a7-0908-8ead" name="Wolf Brothers - Counter-Attack" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="5233-5956-d3ea-ac21" name="Dark Brothers - Dark Assault &amp; Dark Resolve" hidden="false" collective="false" import="true" targetId="cf31-8c37-3347-79a3" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="5aef-2e13-3c18-ea1f" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="f8ab-b716-6d9c-38a5" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-      </entryLinks>
+          <selectionEntries>
+            <selectionEntry id="a93a-f50c-4da2-c4d8" name="Single Unit [3 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="8fd9-1998-447c-f25a" name="Autocannon" hidden="false" collective="false" import="true" targetId="9557-8f54-7c72-fe96" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b40a-049a-c192-1f28" type="min"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70fd-5bc6-747f-4fbb" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="0085-5789-352f-1132" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d82-fe3e-3923-4788" type="min"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f0b-e5ba-627a-ea56" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="150a-c444-7fd6-92b4" name="** Detachment Upgrade (Units of [3], single unit) **" hidden="false" collective="false" import="true" targetId="a060-d513-9f57-6e27" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="e6a0-4fd5-289b-9002" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="7a26-e38a-0438-8eab" name="Autocannon" hidden="false" collective="false" import="true" targetId="9557-8f54-7c72-fe96" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="882a-640c-3fd1-30b2" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e04-78e2-eddd-31d8" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="fe77-f03b-1d6c-c893" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ee2-c0f4-dd2b-388c" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a88-c9fd-b6c2-dac2" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="6367-0a97-bcad-f110" name="** Detachment Upgrade (Units of [3], combined unit) **" hidden="false" collective="false" import="true" targetId="453e-ef26-c3dc-e2b5" type="selectionEntryGroup"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="245.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="245.0"/>
       </costs>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -3648,174 +3648,15 @@
         <infoLink id="f6e6-36a0-e8ae-c9d7" name="Wolf Walker" hidden="false" targetId="9d9a-bc3f-b4f9-2387" type="profile"/>
         <infoLink id="ee1c-b13a-b611-88b6" name="Fear" hidden="false" targetId="d21e-0b0f-ebec-46da" type="rule"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="f258-00ea-693b-7afe" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="8ea6-1924-6799-a185">
+      <entryLinks>
+        <entryLink id="565d-435e-8832-92ea" name="Wolf Brothers - Upgrade List I" hidden="false" collective="false" import="true" targetId="8fc1-7914-d8f5-e4bf" type="selectionEntryGroup"/>
+        <entryLink id="9be4-aa9a-78ea-a9a8" name="Stomp (Walker)" hidden="false" collective="false" import="true" targetId="fd88-1524-b5ee-010c" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b8c-3ccc-4d7c-b4eb" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba75-67da-1116-49e8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00d1-157b-5cf9-b8e0" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56ea-0198-94a1-d29a" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="24de-f68f-fad1-c063" name="Walker Axe &amp; Combat Shield" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="92d9-64d9-89eb-8ac3" name="Walker Axe" hidden="false" collective="false" import="true" targetId="47ef-e072-52c4-e2da" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbb8-d172-7dc3-0e8c" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e784-132d-527f-ce62" type="min"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="8194-9eec-917b-8900" name="Combat Shield" hidden="false" collective="false" import="true" targetId="f5b9-642f-6bfe-ce58" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4175-e497-2863-53f5" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b482-800a-1012-36a6" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8ea6-1924-6799-a185" name="Ranged &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="7aa8-c536-6f51-8138" name="Right Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="d003-60ba-1363-b127">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08b1-8cbe-5ff3-f690" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3176-410e-614e-1cf5" type="min"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="04e3-d8ef-ea1b-947f" name="Walker Fist/Claw &amp; Under-slung Weapon" hidden="false" collective="false" import="true" type="upgrade">
-                      <selectionEntryGroups>
-                        <selectionEntryGroup id="29b8-92af-c098-bcc8" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="693f-7f7f-0d44-d524">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de8d-6533-0f9e-0872" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="687d-a5e1-39fe-bc34" type="max"/>
-                          </constraints>
-                          <entryLinks>
-                            <entryLink id="693f-7f7f-0d44-d524" name="Walker Fist (Attack Walker)" hidden="false" collective="false" import="true" targetId="e008-b179-c068-469a" type="selectionEntry"/>
-                            <entryLink id="86fb-a1e1-4b64-d66e" name="Walker Claw" hidden="false" collective="false" import="true" targetId="bd83-e5a2-c98a-6bde" type="selectionEntry">
-                              <costs>
-                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                              </costs>
-                            </entryLink>
-                          </entryLinks>
-                        </selectionEntryGroup>
-                        <selectionEntryGroup id="cdd1-9023-abe0-6a9f" name="Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="b79c-d97d-a617-595c">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7350-19d5-9a27-7715" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2b7-e0ce-2fba-3d0f" type="max"/>
-                          </constraints>
-                          <entryLinks>
-                            <entryLink id="b79c-d97d-a617-595c" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry"/>
-                            <entryLink id="8178-6318-d5bc-4831" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
-                              <costs>
-                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                              </costs>
-                            </entryLink>
-                          </entryLinks>
-                        </selectionEntryGroup>
-                      </selectionEntryGroups>
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <entryLinks>
-                    <entryLink id="d003-60ba-1363-b127" name="Frost Cannon" hidden="false" collective="false" import="true" targetId="bf53-e5c1-4818-8c94" type="selectionEntry"/>
-                    <entryLink id="de55-5801-9844-103e" name="Twin Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="76d2-5dc6-d28b-c278" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="0b25-818c-cab9-cd18" name="Heavy Minigun" hidden="false" collective="false" import="true" targetId="9db1-0539-dc9f-f147" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="65f8-6500-adc9-8fb7" name="Plasma Cannon" hidden="false" collective="false" import="true" targetId="05e9-6fae-2a04-8820" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="4ee0-e6dd-e387-ea46" name="Heavy Fusion Rifle" hidden="false" collective="false" import="true" targetId="a5f5-d44a-03b0-9a99" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="30fb-c4cd-e811-152e" name="Twin Heavy Machinegun" hidden="false" collective="false" import="true" targetId="dae8-3106-6a96-228c" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="7319-2b43-abf6-ec5f" name="Twin Autocannon" hidden="false" collective="false" import="true" targetId="3640-bb26-8a54-047c" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="600f-78d4-af3d-af73" name="Twin Laser Cannon" hidden="false" collective="false" import="true" targetId="d271-2d81-e640-0040" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="70.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="425a-c250-5582-3f03" name="Left Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="6419-1197-0bf6-d764">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1b6-b3ff-6e4c-c452" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8057-3bf8-a473-291d" type="min"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="6419-1197-0bf6-d764" name="Walker Fist/Claw &amp; Under-slung Weapon" hidden="false" collective="false" import="true" type="upgrade">
-                      <selectionEntryGroups>
-                        <selectionEntryGroup id="7526-8d83-8667-5716" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="27b5-51dd-0415-a6a8">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e89e-f03e-3238-eb37" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f460-24db-2e74-166d" type="max"/>
-                          </constraints>
-                          <entryLinks>
-                            <entryLink id="27b5-51dd-0415-a6a8" name="Walker Fist (Attack Walker)" hidden="false" collective="false" import="true" targetId="e008-b179-c068-469a" type="selectionEntry"/>
-                            <entryLink id="f811-a87f-e369-fcc0" name="Walker Claw" hidden="false" collective="false" import="true" targetId="bd83-e5a2-c98a-6bde" type="selectionEntry">
-                              <costs>
-                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                              </costs>
-                            </entryLink>
-                          </entryLinks>
-                        </selectionEntryGroup>
-                        <selectionEntryGroup id="2d46-fb0f-665a-bf64" name="Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="0823-63c6-7dc2-976f">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8511-cfd6-d24d-ffd5" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc3b-4300-2300-ad9c" type="max"/>
-                          </constraints>
-                          <entryLinks>
-                            <entryLink id="0823-63c6-7dc2-976f" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry"/>
-                            <entryLink id="9a2c-cb04-d75a-6f35" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
-                              <costs>
-                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                              </costs>
-                            </entryLink>
-                          </entryLinks>
-                        </selectionEntryGroup>
-                      </selectionEntryGroups>
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <entryLinks>
-                    <entryLink id="c511-b066-f22f-7767" name="Missile Launcher" hidden="false" collective="false" import="true" targetId="ff1b-714c-6353-221d" type="selectionEntry"/>
-                    <entryLink id="0c75-6845-aca0-da84" name="Twin Autocannon" hidden="false" collective="false" import="true" targetId="3640-bb26-8a54-047c" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="370.0"/>
       </costs>
@@ -16636,6 +16477,143 @@
               </costs>
             </selectionEntry>
           </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="8fc1-7914-d8f5-e4bf" name="Wolf Brothers - Upgrade List I" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c682-e215-6a84-10d2" name="Replace Frost Cannon, Walker Fist &amp; Storm Rifle:" hidden="false" collective="false" import="true" defaultSelectionEntryId="0f9f-4e8b-5333-2d1c">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e75-6c0f-4e96-120e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf42-ad9e-c71d-1112" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="0f9f-4e8b-5333-2d1c" name="Frost Cannon, Walker Fist &amp; Storm Rifle" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="61fd-784b-b1e1-32f7" name="Replace Frost Cannon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="069c-fcf2-a18f-eb12">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="693f-c3ee-f844-8643" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2619-ea3d-9e6c-0d7a" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="477a-a9d5-cbc6-225a" name="Walker Fist &amp; Storm Rifle" hidden="false" collective="false" import="true" type="upgrade">
+                      <entryLinks>
+                        <entryLink id="4d42-fdb4-b9ba-1675" name="Wolf Brothers - Upgrade List I - Walker Fist &amp; Storm Rifle" hidden="false" collective="false" import="true" targetId="aa68-1322-ef31-f1d6" type="selectionEntryGroup"/>
+                      </entryLinks>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="069c-fcf2-a18f-eb12" name="Frost Cannon" hidden="false" collective="false" import="true" targetId="bf53-e5c1-4818-8c94" type="selectionEntry"/>
+                    <entryLink id="efb4-b892-4950-0521" name="Twin Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="76d2-5dc6-d28b-c278" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="12e0-cc41-cd08-f96f" name="Heavy Minigun" hidden="false" collective="false" import="true" targetId="9db1-0539-dc9f-f147" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="e562-b6b5-a848-7935" name="Plasma Cannon" hidden="false" collective="false" import="true" targetId="05e9-6fae-2a04-8820" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="c9f9-9789-7fb0-920f" name="Heavy Fusion Rifle" hidden="false" collective="false" import="true" targetId="a5f5-d44a-03b0-9a99" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="d972-9628-e785-54d3" name="Twin Heavy Machinegun" hidden="false" collective="false" import="true" targetId="dae8-3106-6a96-228c" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="21fc-b78e-137d-f67a" name="Twin Autocannon" hidden="false" collective="false" import="true" targetId="3640-bb26-8a54-047c" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="674c-6a67-7e3f-20d0" name="Twin Laser Cannon" hidden="false" collective="false" import="true" targetId="d271-2d81-e640-0040" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="70.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="268d-2938-707f-e228" name="Replace one Walker Fist &amp; Storm Rifle:" hidden="false" collective="false" import="true" defaultSelectionEntryId="44b6-f23c-f54b-a426">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2e6-5705-028a-9bf6" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60ff-92b7-092b-288a" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="44b6-f23c-f54b-a426" name="Walker Fist &amp; Storm Rifle" hidden="false" collective="false" import="true" type="upgrade">
+                      <entryLinks>
+                        <entryLink id="4d38-902c-a36e-6ae1" name="Wolf Brothers - Upgrade List I - Walker Fist &amp; Storm Rifle" hidden="false" collective="false" import="true" targetId="aa68-1322-ef31-f1d6" type="selectionEntryGroup"/>
+                      </entryLinks>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="7b9b-16c8-35aa-4d9b" name="Missile Launcher" hidden="false" collective="false" import="true" targetId="ff1b-714c-6353-221d" type="selectionEntry"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntry>
+            <selectionEntry id="115d-fc6d-50a3-520c" name="Walker Axe &amp; Combat Shield" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="0797-d46b-bdb0-4942" name="Walker Axe" hidden="false" collective="false" import="true" targetId="47ef-e072-52c4-e2da" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0372-8e31-07e8-6671" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93d1-ec10-d1f5-248f" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="42e2-f3b7-1f49-9db7" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="823b-4c95-06da-1ba8" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26a1-f1da-a8b7-e839" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="aa68-1322-ef31-f1d6" name="Wolf Brothers - Upgrade List I - Walker Fist &amp; Storm Rifle" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="621c-375c-612c-28ff" name="Replace any Walker Fist:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a5dc-6ae0-a05d-929b">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98e2-6d49-34b5-36a1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2348-2379-e04d-7b06" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="a5dc-6ae0-a05d-929b" name="Walker Fist (Attack Walker)" hidden="false" collective="false" import="true" targetId="e008-b179-c068-469a" type="selectionEntry"/>
+            <entryLink id="ed48-ed49-618a-9ae3" name="Walker Claw" hidden="false" collective="false" import="true" targetId="bd83-e5a2-c98a-6bde" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="186c-2ae0-009a-9e56" name="Replace Storm Rifle:" hidden="false" collective="false" import="true" defaultSelectionEntryId="469c-eac0-6a0c-7f9c">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b16-a954-423d-4bb1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="175f-7337-9089-a901" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="469c-eac0-6a0c-7f9c" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry"/>
+            <entryLink id="ec52-aa65-942f-5848" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -2508,22 +2508,6 @@
         <infoLink id="fe9c-7178-891e-fb22" name="Aircraft" hidden="false" targetId="187f-6a03-5b99-a4db" type="rule"/>
         <infoLink id="00d3-556e-8de9-cc2b" name="Dark Resolve" hidden="false" targetId="5dec-9937-47f8-7cf4" type="rule"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="9f78-595a-df2f-170e" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="ce47-6908-1431-4372">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96bf-e8c6-54e0-a198" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8194-33f5-d829-f336" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="e263-3973-46a1-20d2" name="Twin Laser Cannon" hidden="false" collective="false" import="true" targetId="d271-2d81-e640-0040" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="ce47-6908-1431-4372" name="Avenger Minigun" hidden="false" collective="false" import="true" targetId="e0e3-5fcc-e09c-d3a2" type="selectionEntry"/>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="65ef-f75c-4d4a-65b0" name="Sword Missiles" hidden="false" collective="false" import="true" targetId="7f7f-d5ae-aa1e-45ef" type="selectionEntry">
           <constraints>
@@ -2537,6 +2521,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ae6-abe7-0667-d30a" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="c90f-2396-8669-95d5" name="Dark Brothers - Upgrade List G" hidden="false" collective="false" import="true" targetId="6148-ddcb-4f64-1370" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="295.0"/>
@@ -15496,6 +15481,24 @@
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
               </costs>
             </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="6148-ddcb-4f64-1370" name="Dark Brothers - Upgrade List G" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="df47-9a64-7ac0-8cc1" name="Replace Avenger Minigun:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4945-fc96-3c5f-2fff">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="924d-79f3-cc51-c591" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25b8-9470-17a9-79c3" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="4e54-45a3-629c-b3a6" name="Twin Laser Cannon" hidden="false" collective="false" import="true" targetId="d271-2d81-e640-0040" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="4945-fc96-3c5f-2fff" name="Avenger Minigun" hidden="false" collective="false" import="true" targetId="e0e3-5fcc-e09c-d3a2" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -1277,7 +1277,7 @@
     </selectionEntry>
     <selectionEntry id="0531-6174-1536-a6fc" name="Energy Hammer" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="5a96-50fb-e789-22fc" name="Energy Hammer" hidden="false" targetId="15da-b1f3-bc67-992b" type="profile"/>
+        <infoLink id="5a96-50fb-e789-22fc" name="Energy Hammer" hidden="false" targetId="a84b-1f66-915f-b56f" type="profile"/>
         <infoLink id="7061-c22b-dd68-3a47" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
       </infoLinks>
       <costs>
@@ -1348,14 +1348,6 @@
       <infoLinks>
         <infoLink id="2b4e-32b2-0f4a-666c" name="Energy Fist" page="" hidden="false" targetId="2001-b03e-9d66-d6a0" type="profile"/>
         <infoLink id="c253-afc5-8561-2168" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="f12b-5533-2329-5b92" name="Storm Rifle" hidden="false" collective="true" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="8ac4-139b-f3c6-be32" name="Storm Rifle" hidden="false" targetId="ebf6-9e34-7e8f-e18e" type="profile"/>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
@@ -2160,50 +2152,6 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ad62-a734-728b-c7d0" name="Sword-Rifle" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="68ee-fa11-aeff-8886" name="Sword-Rifle" hidden="false" targetId="07e7-bc55-a5ff-7e45" type="profile"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="1916-4d07-c6cb-0b72" name="Sword (Captain)" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="74f3-471b-7d3e-f2d7" name="Sword" hidden="false" targetId="37a2-1941-90a5-7b6a" type="profile"/>
-        <infoLink id="6162-694c-c21a-f3ca" name="Rending" hidden="false" targetId="9726-accd-9015-f6f6" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="dff5-efb2-71a3-1d74" name="Sword" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="2ad5-35ea-4992-9743" name="Sword" hidden="false" targetId="232e-a3ff-fda4-7f0d" type="profile"/>
-        <infoLink id="3294-d6fb-f15c-631c" name="Rending" hidden="false" targetId="9726-accd-9015-f6f6" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="86cc-9e22-6960-9f10" name="Spear (Captain)" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="6d68-d3a3-bd1f-7ff5" name="Spear" hidden="false" targetId="2c23-f093-b7c2-29b6" type="profile"/>
-        <infoLink id="66e0-c1c3-9214-8e23" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="20f4-7691-4f75-4b58" name="Spear (Custodians)" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="cdf0-83b8-ea94-43f9" name="Spear" hidden="false" targetId="6c19-c764-d797-32d4" type="profile"/>
-        <infoLink id="e30f-041b-a1d4-97c0" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="375a-5ae7-23b5-4350" name="Energy Sword (Champion)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="003f-d591-dc4e-c42a" name="Energy Sword (A4)" hidden="false" targetId="31bb-640e-201e-24a2" type="profile"/>
@@ -2585,9 +2533,9 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2913-b7f2-2c10-a596" name="Spear (Watcher)" hidden="false" collective="true" import="true" type="upgrade">
+    <selectionEntry id="2913-b7f2-2c10-a596" name="Spear" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="b40a-d8f6-0234-9ee2" name="Spear (Watcher)" hidden="false" targetId="3c92-28e7-f9b6-70d8" type="profile"/>
+        <infoLink id="b40a-d8f6-0234-9ee2" name="Spear" hidden="false" targetId="3c92-28e7-f9b6-70d8" type="profile"/>
         <infoLink id="1f45-0993-efff-a420" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
       </infoLinks>
       <costs>
@@ -3276,15 +3224,6 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="fac8-10fd-615d-a2b7" name="Energy Hammer" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="dfef-5c6c-139b-b20e" name="Energy Hammer" hidden="false" targetId="518e-d8b8-f69f-7d57" type="profile"/>
-        <infoLink id="8783-126d-5d3d-87da" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="6703-fb60-7cf8-b651" name="Heavy Energy Axe" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="8155-55af-0d4b-bc5d" name="Energy Axe" hidden="false" targetId="39ad-81c8-533d-3a8f" type="profile"/>
@@ -3300,16 +3239,6 @@
         <infoLink id="438c-e4ed-785f-d7b6" name="Energy Claw (A3,AP1)" hidden="false" targetId="c4bc-31c1-61aa-840c" type="profile"/>
         <infoLink id="f5cc-11e4-e906-5ab5" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
         <infoLink id="1d36-4a55-1656-d7a7" name="Rending" hidden="false" targetId="9726-accd-9015-f6f6" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="7597-d644-eb04-27a6" name="Energy Claw (A4,AP2)" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="2dd6-fd50-0e55-be56" name="Energy Claw" hidden="false" targetId="9641-428a-a49b-f3f3" type="profile"/>
-        <infoLink id="94e3-bc4e-826c-aefe" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
-        <infoLink id="1b61-30a7-044e-c147" name="Rending" hidden="false" targetId="9726-accd-9015-f6f6" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
@@ -3513,6 +3442,9 @@
               <entryLinks>
                 <entryLink id="afa8-41d0-53ad-5e85" name="Wolf Brothers - Upgrade List H (single unit)" hidden="false" collective="false" import="true" targetId="cf49-d05a-67c9-f7a6" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="ae38-c84e-4a75-23c1" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -3564,6 +3496,9 @@
                 </entryLink>
                 <entryLink id="1dea-4b12-9a69-6f87" name="Wolf Brothers - Upgrade List F (single unit)" hidden="false" collective="false" import="true" targetId="c296-c964-e5e7-c7a8" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="633e-21e3-dfc7-1a49" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -3619,6 +3554,9 @@
                 </entryLink>
                 <entryLink id="6386-e2a5-db24-5851" name="Wolf Brothers - Upgrade List G (single unit)" hidden="false" collective="false" import="true" targetId="ebeb-5197-d5be-559c" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="c567-e19c-7ea0-b37c" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -3741,16 +3679,6 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b06e-0b6c-7bb6-03cb" name="Camo Cloak" hidden="false" collective="true" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="a4a9-2dc6-38a3-1653" name="Scout" hidden="false" targetId="7bc7-a892-49bc-ad88" type="rule"/>
-        <infoLink id="59f7-bd50-d320-8dfe" name="Stealth" hidden="false" targetId="1b59-5d31-4675-c926" type="rule"/>
-        <infoLink id="1863-3fac-661a-4166" name="Camo Cloak" hidden="false" targetId="0490-6b86-214f-c09d" type="profile"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="c068-afcc-2781-0ea4" name="Ancient Banner" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="5288-76a4-821f-dcb0" name="Ancient Banner" hidden="false" targetId="7f89-0213-b236-a3c4" type="profile"/>
@@ -3853,25 +3781,6 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="225.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c379-e61c-9d54-f055" name="Blaster Brother (Heavy Plasma Rifles)" hidden="false" collective="false" import="true" type="upgrade">
-      <entryLinks>
-        <entryLink id="2160-5a9c-80c0-2f23" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="168d-fc4b-a9af-d00f" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d89b-bee7-3c7b-e675" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdc0-3fbf-7926-926d" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="6de5-03f5-3f17-a759" name="Heavy Plasma Rifle" hidden="false" collective="false" import="true" targetId="2b41-316b-ae64-3271" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a17-5ab1-2a45-bad4" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a17d-f31c-8c37-fe2f" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="2b41-316b-ae64-3271" name="Heavy Plasma Rifle" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="b22d-32f2-0d59-5f82" name="Heavy Plasma Rifle" hidden="false" targetId="7ccc-6031-7b24-7377" type="profile"/>
@@ -3895,44 +3804,6 @@
         <infoLink id="4875-7da1-fe8e-3bdc" name="Assault Plasma Rifle" hidden="false" targetId="f7d7-670a-422b-d19a" type="profile"/>
         <infoLink id="840a-e806-69ae-a6f3" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
       </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="b7b5-3a7d-227a-709c" name="Blaster Brother (Light Plasma Cannons)" hidden="false" collective="false" import="true" type="upgrade">
-      <entryLinks>
-        <entryLink id="9696-eb39-ce09-30a8" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="168d-fc4b-a9af-d00f" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1ca-8561-4a21-9f69" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2901-d5cc-96f2-ac9f" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="5771-629b-a092-fd50" name="Light Plasma Cannon" hidden="false" collective="false" import="true" targetId="3cf8-d2f0-20f0-b78f" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1777-4096-505c-a902" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a501-7704-c6f9-cab2" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="d0f1-634c-3177-22b2" name="Blaster Brother (Plasma Auto-Rfiles)" hidden="false" collective="false" import="true" type="upgrade">
-      <entryLinks>
-        <entryLink id="3c61-bb0f-5be6-281c" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="168d-fc4b-a9af-d00f" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="634f-b363-265d-10a2" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb67-5819-4317-6886" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="d44c-9c80-7ac0-a0dc" name="Plasma Auto-Rifle" hidden="false" collective="false" import="true" targetId="855a-d205-3a2e-a218" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63af-dbb3-a6ae-ca1b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d45f-a3e6-c8d9-41f8" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
@@ -4189,15 +4060,6 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="345.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2e14-dd3a-e262-3f43" name="Grenade Launcher" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="1d45-267c-8708-b9ee" name="Grenade Launcher" hidden="false" targetId="cd23-138a-b108-43fa" type="profile"/>
-        <infoLink id="ae7d-dfb3-a205-5cbb" name="Blast(X)" hidden="false" targetId="187f-6414-7037-a542" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="6adc-a2b8-8cec-3fa6" name="Plasma Carbine" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="b7f1-6c22-ebf3-51cd" name="Plasma Carbines" hidden="false" targetId="eb1c-18c1-7411-5fe1" type="profile"/>
@@ -4252,15 +4114,6 @@
       </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="185.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="2ca3-1684-8665-05b0" name="Autocannon" hidden="false" collective="true" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="1ad4-04dd-702c-d1a0" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
-        <infoLink id="66c0-b85f-90ff-3731" name="Autocannon" hidden="false" targetId="a131-08b1-7b13-e56b" type="profile"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4d7d-3f02-6345-2f6c" name="Suppression Squad" hidden="false" collective="false" import="true" type="upgrade">
@@ -4630,14 +4483,6 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6c17-17f3-4027-3c9f" name="Flamethrower Pistol" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="2b4c-2950-dbdb-d6c5" name="Flamethrower Pistol" hidden="false" targetId="b574-ad82-82b6-8486" type="profile"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="cd64-9c2b-796a-a23d" name="Energy Sword (Prime)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="00ef-f624-a250-ca41" name="Energy Sword (Prime)" hidden="false" targetId="bddc-3c21-5d50-b20a" type="profile"/>
@@ -4754,80 +4599,6 @@
         <infoLink id="900e-31e8-bf55-afd2" name="Heavy Laser Cannon" hidden="false" targetId="19dc-21da-bf1d-1f2f" type="profile"/>
         <infoLink id="e2cf-5b4e-8ce5-2116" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
         <infoLink id="b5e5-d1f9-c19f-f999" name="Deadly(X)" hidden="false" targetId="377b-3864-960e-57ac" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="3c67-faf9-889f-bec7" name="Axe (Captain)" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="d552-ee63-711e-02b1" name="Axe (Captain)" hidden="false" targetId="3ee4-fba4-e780-be25" type="profile"/>
-        <infoLink id="600a-35fe-edfc-a413" name="Poison(X)" hidden="false" targetId="2c45-0e1e-fec5-8dbb" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="e4c4-169c-560d-e5a3" name="Axe-Rifle" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="c1ea-b9fc-6b55-d92b" name="Axe-Rifle" hidden="false" targetId="3fc7-654b-36cf-c038" type="profile"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="ff42-7a39-9d57-f334" name="Energy Lance" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="c1d2-a6bd-cac9-0bf2" name="Energy Lance" hidden="false" targetId="9cb7-64e7-06d1-f371" type="profile"/>
-        <infoLink id="23b8-9239-68d9-f934" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
-        <infoLink id="3980-68db-3599-6404" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="d5e6-7c9e-bcf1-d156" name="Jetbike" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="3931-9f4a-6877-dfa5" name="Jetbike" hidden="false" targetId="cdaf-d6ec-0595-9dbc" type="profile"/>
-        <infoLink id="d02a-0b8a-67fa-5412" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
-        <infoLink id="9532-7e75-3db2-5eeb" name="Strider" hidden="false" targetId="9dea-b566-200a-0605" type="rule"/>
-        <infoLink id="2f6f-c457-bb28-1597" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="d104-a3e3-df5b-025c" name="Prosecution Rifle" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="f964-3e6e-3c3d-35a5" name="Prosecution Rifle" hidden="false" targetId="21d6-4c00-d05f-7a38" type="profile"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="f1e1-8f92-4ddb-c443" name="Axe" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="b319-ea27-3b14-d7f4" name="Axe" hidden="false" targetId="db61-dacf-d88c-867b" type="profile"/>
-        <infoLink id="407e-1afd-03a5-4df5" name="Poison(X)" hidden="false" targetId="2c45-0e1e-fec5-8dbb" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="0365-f4b2-3ec0-0693" name="Wrist-GLs" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="0ee3-977c-8656-5cfe" name="Wrist-GLs" hidden="false" targetId="5ee3-f681-2708-c0fe" type="profile"/>
-        <infoLink id="6e60-e304-79a8-2fd3" name="Blast(X)" hidden="false" targetId="187f-6414-7037-a542" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="0fec-c1d9-5bbe-acdd" name="Fusion Missiles" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="3318-d7cc-54b9-bc1b" name="Fusion Missiles" hidden="false" targetId="9257-f4d9-13be-1bb4" type="profile"/>
-        <infoLink id="7351-de10-c0d6-c087" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
-        <infoLink id="b599-a313-3d2e-81ca" name="Deadly(X)" hidden="false" targetId="377b-3864-960e-57ac" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
@@ -5607,18 +5378,13 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3d6f-8204-0d5f-6153" name="Flamethrower Pistol" hidden="false" collective="true" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="8aec-ce26-c580-e100" name="Flamethrower Pistol" hidden="false" targetId="b574-ad82-82b6-8486" type="profile"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="1e94-b758-ffec-0f8d" name="Cyborg Bodies" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="a0ff-9024-7428-6097" name="Cyborg Bodies" hidden="false" targetId="244b-3059-7103-28f8" type="profile"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -6007,7 +5773,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>
-    <selectionEntryGroup id="45ad-36d0-7652-d8bb" name="Battle/Prime Brothers Psychic Spells" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="45ad-36d0-7652-d8bb" name="Psychic Spells - Battle/Prime Brothers " hidden="false" collective="false" import="true">
       <selectionEntries>
         <selectionEntry id="31d5-7733-737d-443c" name="Show Spells" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -6027,7 +5793,7 @@
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="e6bc-e6cc-cdb2-3924" name="Blood Brothers Psychic Spells" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="e6bc-e6cc-cdb2-3924" name="Psychic Spells - Blood Brothers" hidden="false" collective="false" import="true">
       <selectionEntries>
         <selectionEntry id="4df7-eabd-4581-3ad2" name="Show Spells" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -6047,7 +5813,7 @@
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="ef87-9afc-97d0-abdf" name="Knight Brothers Psychic Spells" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="ef87-9afc-97d0-abdf" name="Psychic Spells - Knight Brothers" hidden="false" collective="false" import="true">
       <selectionEntries>
         <selectionEntry id="2db7-08e8-583d-181c" name="Show Spells" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -6067,7 +5833,7 @@
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="b6c7-182d-972d-6ca2" name="Wolf Brothers Psychic Spells" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="b6c7-182d-972d-6ca2" name="Psychic Spells - Wolf Brothers" hidden="false" collective="false" import="true">
       <selectionEntries>
         <selectionEntry id="e1f3-62d9-9e0a-123a" name="Show Spells" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
@@ -6144,7 +5910,7 @@
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
-                    <entryLink id="97c4-784e-fb14-2ba4" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
+                    <entryLink id="97c4-784e-fb14-2ba4" name="Flame Pistol" hidden="false" collective="false" import="true" targetId="db8f-b317-2b7d-2ed3" type="selectionEntry">
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
                       </costs>
@@ -6252,79 +6018,6 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
-    </selectionEntryGroup>
-    <selectionEntryGroup id="b8a5-2300-ea05-b1e8" name="Prime Psychic Spell List" hidden="false" collective="false" import="true" defaultSelectionEntryId="dab3-681f-ed76-8c49">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01d1-4ee3-2107-f08f" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f1c-74ad-085b-028b" type="max"/>
-      </constraints>
-      <selectionEntries>
-        <selectionEntry id="dab3-681f-ed76-8c49" name="Prime Brother Psychic Spells" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="001d-3b8a-e3bd-2674" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="84f5-72d0-85a7-3e9f" name="Prime Brothers Psychic Spells" hidden="false" collective="false" import="true" targetId="f606-1ed3-6344-cd01" type="selectionEntryGroup"/>
-          </entryLinks>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="9ce2-d947-0abb-c08a" name="Blood Brother Psychic Spells" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fc5e-c95a-636b-865d" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a12-b077-c8b8-64ab" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="c61f-9fc2-872b-9e46" name="Blood Brothers Psychic Spells" hidden="false" collective="false" import="true" targetId="e6bc-e6cc-cdb2-3924" type="selectionEntryGroup"/>
-          </entryLinks>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="6969-bd9d-2d46-66a5" name="Knight Brother Psychic Spells" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2f26-c83d-870c-62d5" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="094d-2d46-53f2-d128" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="bc22-0705-2005-c5e3" name="Knight Brothers Psychic Spells" hidden="false" collective="false" import="true" targetId="ef87-9afc-97d0-abdf" type="selectionEntryGroup"/>
-          </entryLinks>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="9cfd-b099-94d9-2430" name="Wolf Brother Psychic Spells" hidden="false" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5afe-d010-2cea-03e5" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d0b-fe20-cbd4-248d" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="5530-ad8b-4ce1-2f06" name="Wolf Brothers Psychic Spells" hidden="false" collective="false" import="true" targetId="b6c7-182d-972d-6ca2" type="selectionEntryGroup"/>
-          </entryLinks>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="d882-5701-85b1-d209" name="Wolf Brothers - Upgrade List A (single unit)" hidden="false" collective="false" import="true">
       <selectionEntryGroups>
@@ -10394,7 +10087,7 @@
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
               </costs>
             </entryLink>
-            <entryLink id="f805-15d0-afd5-fbae" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
+            <entryLink id="f805-15d0-afd5-fbae" name="Flame Pistol" hidden="false" collective="false" import="true" targetId="db8f-b317-2b7d-2ed3" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
               </costs>
@@ -10686,7 +10379,7 @@
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
-                    <entryLink id="3ee3-ed30-8658-250a" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
+                    <entryLink id="3ee3-ed30-8658-250a" name="Flame Pistol" hidden="false" collective="false" import="true" targetId="db8f-b317-2b7d-2ed3" type="selectionEntry">
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
                       </costs>
@@ -12412,7 +12105,7 @@
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
-                    <entryLink id="1b57-969e-b83a-e2c8" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
+                    <entryLink id="1b57-969e-b83a-e2c8" name="Flame Pistol" hidden="false" collective="false" import="true" targetId="db8f-b317-2b7d-2ed3" type="selectionEntry">
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
@@ -12613,7 +12306,7 @@
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
                       </costs>
                     </entryLink>
-                    <entryLink id="5ac5-1996-4db5-a0d2" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
+                    <entryLink id="5ac5-1996-4db5-a0d2" name="Flame Pistol" hidden="false" collective="false" import="true" targetId="db8f-b317-2b7d-2ed3" type="selectionEntry">
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
@@ -12731,7 +12424,7 @@
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
                       </costs>
                     </entryLink>
-                    <entryLink id="92df-1a58-0762-dd2c" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
+                    <entryLink id="92df-1a58-0762-dd2c" name="Flame Pistol" hidden="false" collective="false" import="true" targetId="db8f-b317-2b7d-2ed3" type="selectionEntry">
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
@@ -13077,7 +12770,7 @@
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
-                    <entryLink id="9a84-409a-2749-2e7e" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
+                    <entryLink id="9a84-409a-2749-2e7e" name="Flame Pistol" hidden="false" collective="false" import="true" targetId="db8f-b317-2b7d-2ed3" type="selectionEntry">
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
@@ -14227,7 +13920,7 @@
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
-                    <entryLink id="37d2-b90c-20c5-8192" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
+                    <entryLink id="37d2-b90c-20c5-8192" name="Flame Pistol" hidden="false" collective="false" import="true" targetId="db8f-b317-2b7d-2ed3" type="selectionEntry">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d55e-433e-7db8-4a0c" type="max"/>
                       </constraints>
@@ -14476,7 +14169,7 @@
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
-                    <entryLink id="cbc9-4b3d-06a7-876d" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
+                    <entryLink id="cbc9-4b3d-06a7-876d" name="Flame Pistol" hidden="false" collective="false" import="true" targetId="db8f-b317-2b7d-2ed3" type="selectionEntry">
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
@@ -14833,7 +14526,7 @@
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
-                    <entryLink id="6e4b-9a4e-a974-5501" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
+                    <entryLink id="6e4b-9a4e-a974-5501" name="Flame Pistol" hidden="false" collective="false" import="true" targetId="db8f-b317-2b7d-2ed3" type="selectionEntry">
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
@@ -16239,6 +15932,9 @@
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="ad7d-33c5-de15-8f9d" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -16309,6 +16005,9 @@
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="7433-dc49-e4c2-b04f" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -16401,6 +16100,9 @@
                       <entryLinks>
                         <entryLink id="4d38-902c-a36e-6ae1" name="Wolf Brothers - Upgrade List I - Walker Fist &amp; Storm Rifle" hidden="false" collective="false" import="true" targetId="aa68-1322-ef31-f1d6" type="selectionEntryGroup"/>
                       </entryLinks>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+                      </costs>
                     </selectionEntry>
                   </selectionEntries>
                   <entryLinks>
@@ -16408,6 +16110,9 @@
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="115d-fc6d-50a3-520c" name="Walker Axe &amp; Combat Shield" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -16777,12 +16482,6 @@
         <characteristic name="Details" typeId="e490-3d41-dc85-9d0f">Target friendly unit within 12&quot; may immediately move by up to 6&quot;.</characteristic>
       </characteristics>
     </profile>
-    <profile id="15da-b1f3-bc67-992b" name="Energy Hammer" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
-      <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A2</characteristic>
-        <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(3)</characteristic>
-      </characteristics>
-    </profile>
     <profile id="40a4-12d2-4740-a350" name="Cyclone Missiles – pick one each turn: HE" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
       <characteristics>
         <characteristic name="Range" typeId="79f4-5578-c041-f866">48&quot;</characteristic>
@@ -16795,12 +16494,6 @@
         <characteristic name="Range" typeId="79f4-5578-c041-f866">48&quot;</characteristic>
         <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A2</characteristic>
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(3), Deadly(3)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="9fff-d6d4-8826-e103" name="Combat Drill" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
-      <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A2</characteristic>
-        <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(4)</characteristic>
       </characteristics>
     </profile>
     <profile id="449d-6a5b-0219-ccb1" name="APC" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
@@ -17082,55 +16775,6 @@
         <characteristic name="Details" typeId="e490-3d41-dc85-9d0f">Target enemy unit within 12&quot; gets -2 to defense next time it takes hits.</characteristic>
       </characteristics>
     </profile>
-    <profile id="b425-cb9c-df03-bc13" name="Custodian Captain" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
-      <characteristics>
-        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">3+</characteristic>
-        <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">2+</characteristic>
-        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fearless, Hero, Regeneration, Tough(3)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="780f-7669-8076-5c49" name="Great Sister" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
-      <characteristics>
-        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">4+</characteristic>
-        <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">3+</characteristic>
-        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fearless, Hero, Tough(3)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="c1e7-ff64-4578-657c" name="Custodian Brother" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
-      <characteristics>
-        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">3+</characteristic>
-        <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">2+</characteristic>
-        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fearless, Regeneration</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="cbf5-9b53-0a7c-d5a0" name="Vigilant Sister" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
-      <characteristics>
-        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">4+</characteristic>
-        <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">3+</characteristic>
-        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fearless, Furious</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="57d6-193e-e1a5-9e9d" name="Prosecution Sister" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
-      <characteristics>
-        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">4+</characteristic>
-        <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">3+</characteristic>
-        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fearless, Relentless</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="b391-240e-1c68-e666" name="Hunter Sister" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
-      <characteristics>
-        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">4+</characteristic>
-        <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">3+</characteristic>
-        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fearless, Scout</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="06b4-b2b5-1e33-d835" name="Custodian Walker" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
-      <characteristics>
-        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">3+</characteristic>
-        <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">2+</characteristic>
-        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fear, Fearless, Tough(12), Regeneration</characteristic>
-      </characteristics>
-    </profile>
     <profile id="e8d9-43b8-0ede-5ac8" name="Spear-Rifle" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
       <characteristics>
         <characteristic name="Range" typeId="79f4-5578-c041-f866">24&quot;</characteristic>
@@ -17138,41 +16782,10 @@
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d"/>
       </characteristics>
     </profile>
-    <profile id="2c23-f093-b7c2-29b6" name="Spear (Captain)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
-      <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A6</characteristic>
-        <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(1)</characteristic>
-      </characteristics>
-    </profile>
     <profile id="31bb-640e-201e-24a2" name="Energy Sword (Champion)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
         <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A4</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(1), Rending</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="6c19-c764-d797-32d4" name="Spear (Custodians)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
-      <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
-        <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(1)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="07e7-bc55-a5ff-7e45" name="Sword-Rifle" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="79f4-5578-c041-f866">12&quot;</characteristic>
-        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A2</characteristic>
-        <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d"/>
-      </characteristics>
-    </profile>
-    <profile id="37a2-1941-90a5-7b6a" name="Sword (Captain)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
-      <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A6</characteristic>
-        <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">Rending</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="232e-a3ff-fda4-7f0d" name="Sword" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
-      <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
-        <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">Rending</characteristic>
       </characteristics>
     </profile>
     <profile id="8c52-d534-0d07-7fbc" name="Heavy Minigun" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
@@ -17300,7 +16913,7 @@
         <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fearless, Hero, Tough(3)</characteristic>
       </characteristics>
     </profile>
-    <profile id="3c92-28e7-f9b6-70d8" name="Spear (Watcher)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
+    <profile id="3c92-28e7-f9b6-70d8" name="Spear" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
         <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A2</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(1)</characteristic>
@@ -17357,13 +16970,6 @@
     <profile id="5d1f-3abf-64f7-dd49" name="Cargo Space" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
       <characteristics>
         <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Transport(11)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="313f-3049-cf0c-01d6" name="Death Shotgun" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="79f4-5578-c041-f866">12&quot;</characteristic>
-        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A2</characteristic>
-        <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">Rending</characteristic>
       </characteristics>
     </profile>
     <profile id="13b1-a4ba-24e7-8a92" name="Stalker Rifle" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
@@ -17628,18 +17234,6 @@
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(3)</characteristic>
       </characteristics>
     </profile>
-    <profile id="9641-428a-a49b-f3f3" name="Energy Claw (A4,AP2)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
-      <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A4</characteristic>
-        <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(2), Rending</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="518e-d8b8-f69f-7d57" name="Energy Hammer" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
-      <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A4</characteristic>
-        <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(4)</characteristic>
-      </characteristics>
-    </profile>
     <profile id="2b4c-91de-5249-7aca" name="Walker Claw" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
         <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A6</characteristic>
@@ -17899,13 +17493,6 @@
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d"/>
       </characteristics>
     </profile>
-    <profile id="cd23-138a-b108-43fa" name="Grenade Launcher" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="79f4-5578-c041-f866">18&quot;</characteristic>
-        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A1</characteristic>
-        <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">Blast(3)</characteristic>
-      </characteristics>
-    </profile>
     <profile id="4768-7f60-4606-7bb8" name="Assault Carbine" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
       <characteristics>
         <characteristic name="Range" typeId="79f4-5578-c041-f866">18&quot;</characteristic>
@@ -18038,13 +17625,6 @@
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(1)</characteristic>
       </characteristics>
     </profile>
-    <profile id="b574-ad82-82b6-8486" name="Flamethrower Pistol" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="79f4-5578-c041-f866">12&quot;</characteristic>
-        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A6</characteristic>
-        <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d"/>
-      </characteristics>
-    </profile>
     <profile id="bddc-3c21-5d50-b20a" name="Energy Sword (Prime)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
         <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A4</characteristic>
@@ -18120,71 +17700,6 @@
       <characteristics>
         <characteristic name="Range" typeId="79f4-5578-c041-f866">48&quot;</characteristic>
         <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A2</characteristic>
-        <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(4), Deadly(6)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="3ee4-fba4-e780-be25" name="Axe (Captain)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
-      <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A6</characteristic>
-        <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">Poison</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="3fc7-654b-36cf-c038" name="Axe-Rifle" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="79f4-5578-c041-f866">24&quot;</characteristic>
-        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A1</characteristic>
-        <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d"/>
-      </characteristics>
-    </profile>
-    <profile id="9cb7-64e7-06d1-f371" name="Energy Lance" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
-      <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A6</characteristic>
-        <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(1), Impact(1)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="cdaf-d6ec-0595-9dbc" name="Jetbike" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
-      <characteristics>
-        <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Fast, Impact(1), Strider</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="21d6-4c00-d05f-7a38" name="Prosecution Rifle" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="79f4-5578-c041-f866">24&quot;</characteristic>
-        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A3</characteristic>
-        <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d"/>
-      </characteristics>
-    </profile>
-    <profile id="db61-dacf-d88c-867b" name="Axe" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
-      <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
-        <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">Poison</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="f4e3-6fe2-059d-633c" name="Custodian Destroyer" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
-      <characteristics>
-        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">3+</characteristic>
-        <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">2+</characteristic>
-        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Ambush, Fearless, Regeneration, Tough(3)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="5ee3-f681-2708-c0fe" name="Wrist-GLs" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="79f4-5578-c041-f866">12&quot;</characteristic>
-        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A1</characteristic>
-        <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">Blast(3)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="0efe-cd3b-0181-d9a7" name="Custodian Jetbiker" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
-      <characteristics>
-        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">3+</characteristic>
-        <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">2+</characteristic>
-        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fast, Fearless, Impact(1), Regeneration, Strider</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="9257-f4d9-13be-1bb4" name="Fusion Missiles" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
-      <characteristics>
-        <characteristic name="Range" typeId="79f4-5578-c041-f866">24&quot;</characteristic>
-        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A1</characteristic>
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(4), Deadly(6)</characteristic>
       </characteristics>
     </profile>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -1901,170 +1901,8 @@
         <infoLink id="6709-399f-e743-7b71" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
         <infoLink id="8a97-c30e-379b-f011" name="Furious" hidden="false" targetId="ded5-4f1f-c61d-4659" type="rule"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="0bc8-f7aa-2abf-1fce" name="Upgrades" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4018-a366-73f6-a449" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="273b-0c40-26ca-b0d9" name="Jetpack" hidden="false" collective="false" import="true" targetId="33d6-ea20-9d27-5f4e" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="37ed-3f28-2bcc-95ad" name="Destroyer Armor" hidden="false" collective="false" import="true" targetId="8150-2743-e904-7a5c" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="1968-a8ad-ee2c-94e5" name="Bike" hidden="false" collective="false" import="true" targetId="c47e-3660-de3d-86f7" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="ed8e-53e1-857d-e180" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="c436-ce81-a00c-140b">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bbd-1149-bb74-3921" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b21-05cf-cc55-340a" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="c436-ce81-a00c-140b" name="Assault Rifle &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="deea-7d17-a433-7f6b" name="CCW" hidden="false" collective="false" import="true" defaultSelectionEntryId="1b04-c96d-a3d1-2b13">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e5e-5f65-9fb2-a493" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0749-ce51-6d38-7e3c" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="771d-8339-16b1-d479" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="18e6-d7db-914f-5ad3" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="1b04-c96d-a3d1-2b13" name="CCW (A1)" hidden="false" collective="false" import="true" targetId="4761-1567-afe2-c2ed" type="selectionEntry"/>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks>
-                <entryLink id="b663-9d42-e44a-7723" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69ee-40c5-cdff-4d40" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33c2-5a1a-69b9-5571" type="min"/>
-                  </constraints>
-                  <selectionEntryGroups>
-                    <selectionEntryGroup id="a0d6-5d80-eaa4-0f6b" name="Assault Rifle Attachment" hidden="false" collective="false" import="true">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eab1-c275-48ee-d100" type="max"/>
-                      </constraints>
-                      <entryLinks>
-                        <entryLink id="50e4-96cc-066f-c5ca" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
-                          <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-                          </costs>
-                        </entryLink>
-                        <entryLink id="2e45-0836-023c-fe74" name="Gravity Rifle" hidden="false" collective="false" import="true" targetId="3e4a-da63-fdf2-c5fb" type="selectionEntry">
-                          <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                          </costs>
-                        </entryLink>
-                        <entryLink id="712f-f3d0-130e-62d7" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
-                          <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-                          </costs>
-                        </entryLink>
-                        <entryLink id="645c-a2ba-b2a2-2dd2" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
-                          <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-                          </costs>
-                        </entryLink>
-                      </entryLinks>
-                    </selectionEntryGroup>
-                  </selectionEntryGroups>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="4cc3-0030-7a4c-f009" name="Ranged &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="0d09-8120-b892-89bb" name="CCW" hidden="false" collective="false" import="true" defaultSelectionEntryId="982b-0e9b-7ec7-1d31">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4528-8315-161c-3cbb" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1278-08f0-e541-5a47" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="937d-7180-83ed-b16f" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="5ec2-3314-a275-43d6" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="982b-0e9b-7ec7-1d31" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="3b94-8849-646a-0caa" name="Ranged" hidden="false" collective="false" import="true" defaultSelectionEntryId="cf59-64b9-e259-3e76">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f46-325b-e919-ae25" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="196b-e49f-f761-768f" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="ae38-60ff-705b-6bd5" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="af48-17b1-236c-3718" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="cf59-64b9-e259-3e76" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
-                    <entryLink id="96ae-a9a2-8526-0642" name="Flame Pistol" hidden="false" collective="false" import="true" targetId="db8f-b317-2b7d-2ed3" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="810c-df6f-d42b-a530" name="Gravity Pistol" hidden="false" collective="false" import="true" targetId="f790-2f7c-63a0-1603" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="f4a9-64aa-1913-dc79" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="2071-4cb6-f32c-5d11" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="6f5c-c7fc-ddf0-ee58" name="Holy Chalice" hidden="false" collective="false" import="true" targetId="b974-8328-92d6-2239" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc7d-9fcf-764e-32f3" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="60.0"/>
-          </costs>
-        </entryLink>
+        <entryLink id="bda4-2d1a-73c6-84ea" name="Blood Brothers - Upgrade List A" hidden="false" collective="false" import="true" targetId="48d2-d0d7-06cb-9b7a" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
@@ -15073,6 +14911,183 @@
           <entryLinks>
             <entryLink id="72a9-71c3-1588-cfd6" name="Twin Heavy Autocannon" hidden="false" collective="false" import="true" targetId="945e-15ad-b707-77b4" type="selectionEntry"/>
             <entryLink id="52cd-a292-b6b5-2eb6" name="Twin Laser Talon" hidden="false" collective="false" import="true" targetId="3bd4-96e7-5d0d-10c5" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="48d2-d0d7-06cb-9b7a" name="Blood Brothers - Upgrade List A" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7883-eab2-5268-1e06" name="Replace Assault Rifles &amp; CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="6d37-1db2-b091-2368">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2eb-3de0-c9d5-a820" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e05-f5fd-4220-3a3f" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="e939-c41b-98e3-4c48" name="Pistol &amp; CCW (A2)" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4791-7419-d815-8079" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="fd20-e7df-2c97-94ec" name="Replace one CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="bd9b-bccf-88ad-d5f3">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c827-f12c-191c-2d9b" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8291-6919-1a05-afa4" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="bd9b-bccf-88ad-d5f3" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+                    <entryLink id="f2c9-5237-a10d-3ed5" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="40c7-6a4c-3d01-7e83" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="73d8-fe80-2dc8-9db3" name="Replace one Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="2067-5cfb-93b5-fd8e">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="585b-baeb-479a-ed26" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55ad-b603-14a3-d01b" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="2067-5cfb-93b5-fd8e" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
+                    <entryLink id="e5c5-3336-5276-4b1e" name="Gravity Pistol" hidden="false" collective="false" import="true" targetId="f790-2f7c-63a0-1603" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="c86a-8738-7300-3912" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="2359-e010-1e58-6ced" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="1b57-969e-b83a-e2c8" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="9432-b320-f685-135f" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="2071-4cb6-f32c-5d11" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6d37-1db2-b091-2368" name="Assault Rifle &amp; CCW (A1)" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="330f-2245-e9af-36b6" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="9311-c225-fdbb-0fd3" name="Replace one CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="fe56-f0bc-23ca-00d3">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7244-0b94-7d96-cb4d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ed6-02b1-46f0-9043" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="fe56-f0bc-23ca-00d3" name="CCW (A1)" hidden="false" collective="false" import="true" targetId="4761-1567-afe2-c2ed" type="selectionEntry"/>
+                    <entryLink id="8597-bece-fc55-8449" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="efa7-e0d9-a283-43dc" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="743d-d7bc-79e2-7cd9" name="Take one Assault Rifle attachment:" hidden="false" collective="false" import="true">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3861-23ee-e1fd-bbbc" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="8647-4ef8-ae84-c1a4" name="Gravity Rifle" hidden="false" collective="false" import="true" targetId="3e4a-da63-fdf2-c5fb" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="8f59-ebd8-dcf3-b703" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="fc51-2dea-3512-34a0" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="caa6-5edd-a5e4-947d" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="4d21-2cab-095f-b11e" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5da6-c38e-ce9f-9d97" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56e4-0047-713c-c388" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6d0d-0d89-f0dd-cd10" name="Upgrade with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92d5-4f15-2bbe-9b5c" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="004c-c145-86ad-dad3" name="Jetpack" hidden="false" collective="false" import="true" targetId="33d6-ea20-9d27-5f4e" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="2fad-0722-a0ca-af04" name="Combat Bike" hidden="false" collective="false" import="true" targetId="c47e-3660-de3d-86f7" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="818c-9d11-a7e9-60eb" name="Destroyer Armor" hidden="false" collective="false" import="true" targetId="8150-2743-e904-7a5c" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a0ee-6c14-2421-a618" name="Upgrade with:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="43d8-67d9-5bc6-0312" name="Holy Chalice" hidden="false" collective="false" import="true" targetId="b974-8328-92d6-2239" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a6c-0036-71b0-28b9" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="60.0"/>
+              </costs>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -3674,7 +3674,7 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="50ff-a6f0-26a7-44be" name="Energy Falchions" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="50ff-a6f0-26a7-44be" name="Energy Falchion" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="8b21-c42f-a747-6bd2" name="Energy Falchion" page="" hidden="false" targetId="92ac-4d81-80de-77ef" type="profile"/>
         <infoLink id="9662-554a-805f-bc23" name="Rending" hidden="false" targetId="9726-accd-9015-f6f6" type="rule"/>
@@ -3712,204 +3712,34 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="135.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0976-4e28-a1e6-addf" name="Knight Brother" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="338d-9da4-71c7-9e2a" name="Knight Brothers" hidden="false" targetId="0a8d-b93d-e9ec-3b53" type="profile"/>
-        <infoLink id="5c7a-2b9e-7dec-dc92" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="7fe8-9bbe-0664-0d88" name="Aegis" hidden="false" targetId="ed8b-a6ad-6d94-9c14" type="rule"/>
-      </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="e5c7-df6b-82e7-721b" name="Psychic(1)" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1640-075b-9d68-6e01" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="2479-1886-aaa3-20b8" name="Psychic(1)" hidden="false" targetId="2432-e2b3-c2c4-9482" type="profile"/>
-            <infoLink id="ebfc-5ab5-bca5-f119" name="Psychic(X)" hidden="false" targetId="ba47-b43b-18f8-97c1" type="rule"/>
-          </infoLinks>
-          <entryLinks>
-            <entryLink id="1f24-849d-bd4f-0d5d" name="Knight Brothers Psychic Spells" hidden="false" collective="false" import="true" targetId="ef87-9afc-97d0-abdf" type="selectionEntryGroup"/>
-          </entryLinks>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="e32a-ce4d-ae26-e3e6" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="5123-a694-323a-7723">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2aaa-bb97-6309-58d0" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b411-bef1-4982-5d17" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="1d65-00d0-b7cb-9ad5" name="2x Energy Falchions" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="e040-6790-34ba-807a" name="Energy Falchions" hidden="false" collective="false" import="true" targetId="50ff-a6f0-26a7-44be" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6269-4881-9312-222e" type="min"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa64-964b-d906-3640" type="max"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="5123-a694-323a-7723" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry"/>
-            <entryLink id="a89c-8764-e8c4-3221" name="Energy Staff" hidden="false" collective="false" import="true" targetId="5812-eb85-ab7d-c183" type="selectionEntry"/>
-            <entryLink id="138b-e9a9-5565-2997" name="Energy Halberd" hidden="false" collective="false" import="true" targetId="7b55-7b95-caec-2fe5" type="selectionEntry"/>
-            <entryLink id="3d32-15bf-8542-04c4" name="Daemon Hammer" hidden="false" collective="false" import="true" targetId="10b6-089c-2053-fa2d" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="7daa-4eb8-5b2e-b810" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7739-1105-18e4-43c3" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab31-aa32-24cb-5d0a" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="6bb3-923c-9800-ccc2" name="Knight Brother (Special Weapon)" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="6a7d-846a-e422-a8d7" name="Knight Brothers" hidden="false" targetId="0a8d-b93d-e9ec-3b53" type="profile"/>
-        <infoLink id="8957-90e7-2653-a8ee" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="d3a3-13b9-07a6-0eb8" name="Aegis" hidden="false" targetId="ed8b-a6ad-6d94-9c14" type="rule"/>
-      </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="b1d1-ca93-2151-12a5" name="Psychic(1)" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d44-3f08-9753-3409" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="9c4b-fd98-0cfb-7a24" name="Psychic(1)" hidden="false" targetId="2432-e2b3-c2c4-9482" type="profile"/>
-            <infoLink id="1e5a-73d4-b2b4-17b7" name="Psychic(X)" hidden="false" targetId="ba47-b43b-18f8-97c1" type="rule"/>
-          </infoLinks>
-          <entryLinks>
-            <entryLink id="5c99-d70c-cde4-ed5b" name="Knight Brothers Psychic Spells" hidden="false" collective="false" import="true" targetId="ef87-9afc-97d0-abdf" type="selectionEntryGroup"/>
-          </entryLinks>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="e288-01ab-cff1-7898" name="Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="bdcd-8257-0478-997f">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8446-11b1-0db1-d14d" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c1c-8de3-54a8-0fd3" type="min"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="c108-ecf6-32ff-0b6d" name="Psychic Silencer" hidden="false" collective="false" import="true" targetId="ad33-44fc-7c8b-a775" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="dd00-791a-a2dd-5399" name="Psychic Cannon" hidden="false" collective="false" import="true" targetId="c6a1-a06c-031f-3a28" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="bdcd-8257-0478-997f" name="Incinerator" hidden="false" collective="false" import="true" targetId="10a4-0331-6a0c-0de6" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="cd8e-1a86-5b77-60c1" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="c6f2-0eba-d506-9b21">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="caf3-1096-3817-5e4d" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91a2-c6b2-afb4-8513" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="9ede-0d91-8eaf-1361" name="2x Energy Falchions" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="3ea8-8e53-521b-de80" name="Energy Falchions" hidden="false" collective="false" import="true" targetId="50ff-a6f0-26a7-44be" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63dd-1b0d-b30e-0a14" type="min"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f55-0627-288a-305d" type="max"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="c6f2-0eba-d506-9b21" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry"/>
-            <entryLink id="f34e-d35e-b572-3319" name="Energy Staff" hidden="false" collective="false" import="true" targetId="5812-eb85-ab7d-c183" type="selectionEntry"/>
-            <entryLink id="d9f3-1e08-7114-1030" name="Energy Halberd" hidden="false" collective="false" import="true" targetId="7b55-7b95-caec-2fe5" type="selectionEntry"/>
-            <entryLink id="9601-bde9-50d8-84ff" name="Daemon Hammer" hidden="false" collective="false" import="true" targetId="10b6-089c-2053-fa2d" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="6c50-53ef-fdac-e16b" name="Knight Brothers" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="2f9c-9227-b469-d906" name="Knight Brother" hidden="false" targetId="0a8d-b93d-e9ec-3b53" type="profile"/>
+        <infoLink id="6545-fea2-37e9-6d8f" name="Aegis" hidden="false" targetId="ed8b-a6ad-6d94-9c14" type="rule"/>
+        <infoLink id="15cb-553a-58c2-639b" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
+      </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="034e-1dea-b5a7-bb36" name="Brothers" hidden="false" collective="false" import="true" defaultSelectionEntryId="9654-5243-c932-2260">
+        <selectionEntryGroup id="8b51-300d-7970-ab1b" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="2abd-7f0e-d7c5-d642">
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc37-37b4-bf33-cf4e" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98f5-1f8f-9af5-6547" type="min"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="9654-5243-c932-2260" name="Knight Brother" hidden="false" collective="false" import="true" targetId="0976-4e28-a1e6-addf" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bd0-b5dd-822c-2d74" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="0b78-b9d5-95bc-7be6" name="Knight Brother (Special Weapon)" hidden="false" collective="false" import="true" targetId="6bb3-923c-9800-ccc2" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0c8-7c65-363e-e312" type="max"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="2adb-e0a8-0c37-bf7a" name="Upgrade all:" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fa7-83b5-e00b-961e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1c0-571e-b701-6d45" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b510-aeb9-d895-5063" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="cae1-cca7-36f3-3749" name="Purifiers (Impact(1))" hidden="false" collective="false" import="true" type="upgrade">
-              <infoLinks>
-                <infoLink id="c72e-1638-d383-42c9" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-              </costs>
+            <selectionEntry id="2abd-7f0e-d7c5-d642" name="Single Unit [5 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="0f4c-965a-821d-3e8b" name="Knight Brothers - Upgrade List A (single unit)" hidden="false" collective="false" import="true" targetId="e758-8c7c-e792-b68d" type="selectionEntryGroup"/>
+                <entryLink id="83e8-e517-7a17-0e98" name="Knight Brothers - Upgrade List B (single unit)" hidden="false" collective="false" import="true" targetId="6297-b2b8-a562-607f" type="selectionEntryGroup"/>
+                <entryLink id="5064-436f-43bc-9836" name="Knight Brothers - Upgrade List E (single unit)" hidden="false" collective="false" import="true" targetId="c413-23dc-124c-d1e5" type="selectionEntryGroup"/>
+              </entryLinks>
             </selectionEntry>
-            <selectionEntry id="daab-5b7f-d09e-6e77" name="Strikers (Ambush)" hidden="false" collective="false" import="true" type="upgrade">
-              <infoLinks>
-                <infoLink id="d10e-dbf9-91fb-7242" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
-              </infoLinks>
+            <selectionEntry id="9074-5e7c-f641-f9f5" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="43a4-e9af-dbe1-22ed" name="Knight Brothers - Upgrade List A (combined unit)" hidden="false" collective="false" import="true" targetId="06b8-d987-9dec-c128" type="selectionEntryGroup"/>
+                <entryLink id="092b-432c-41ff-0570" name="Knight Brothers - Upgrade List B (combined unit)" hidden="false" collective="false" import="true" targetId="eb53-19a2-88af-40be" type="selectionEntryGroup"/>
+                <entryLink id="0dca-168f-cc20-d8a3" name="Knight Brothers - Upgrade List E (combined unit)" hidden="false" collective="false" import="true" targetId="bad9-bddd-3169-c1c5" type="selectionEntryGroup"/>
+              </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0d7e-e452-4fb3-dd59" name="Interceptors (Teleport)" hidden="false" collective="false" import="true" type="upgrade">
-              <infoLinks>
-                <infoLink id="232c-eb29-0179-0d7a" name="Teleport" hidden="false" targetId="8569-65c6-aca3-fcf1" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="215.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -7574,6 +7404,24 @@
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="286b-c127-d50e-8862" name="Purifiers" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="297b-2903-b41a-615f" name="Purifiers" hidden="false" targetId="c450-c4c5-a354-1e83" type="profile"/>
+        <infoLink id="a67f-8bf2-59e4-985c" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="da8b-bfad-e6a7-ac2d" name="Strikers" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="df67-46e2-5343-4384" name="Strikers" hidden="false" targetId="8167-75a6-1ff0-5809" type="profile"/>
+        <infoLink id="3e08-8ae9-b788-938a" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="b3c3-5ead-857c-5bce" name="Interceptors" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="e6a3-c91f-4a9c-41c2" name="Interceptors" hidden="false" targetId="e91c-d006-e62c-ad96" type="profile"/>
+        <infoLink id="11a3-ee55-d835-a02b" name="Teleport" hidden="false" targetId="8569-65c6-aca3-fcf1" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -14940,6 +14788,7 @@
               </constraints>
               <infoLinks>
                 <infoLink id="69d7-902d-b06e-022f" name="Psychic(X)" hidden="false" targetId="ba47-b43b-18f8-97c1" type="rule"/>
+                <infoLink id="0267-c2f3-8bad-18e5" name="Psychic(1)" hidden="false" targetId="2432-e2b3-c2c4-9482" type="profile"/>
               </infoLinks>
               <entryLinks>
                 <entryLink id="5a88-b66a-9ccd-5d5d" name="Blood Brothers Psychic Spells" hidden="false" collective="false" import="true" targetId="e6bc-e6cc-cdb2-3924" type="selectionEntryGroup"/>
@@ -15555,6 +15404,240 @@
             </entryLink>
             <entryLink id="4945-fc96-3c5f-2fff" name="Avenger Minigun" hidden="false" collective="false" import="true" targetId="e0e3-5fcc-e09c-d3a2" type="selectionEntry"/>
           </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="e758-8c7c-e792-b68d" name="Knight Brothers - Upgrade List A (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="fa9b-a56f-dfb5-35c2" name="Storm Rifles" hidden="false" collective="false" import="true" defaultSelectionEntryId="6c58-8c14-3bd9-14d4">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fb9-723f-6976-62ff" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b667-e871-a617-43c3" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="6a0a-526f-5abe-71c6" name="Replace one Storm Rifle:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a172-5601-3b01-edf1" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="905b-5def-d533-e59f" name="Incinerator" hidden="false" collective="false" import="true" targetId="10a4-0331-6a0c-0de6" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="d2fc-ba01-551d-b1b3" name="Psychic Silencer" hidden="false" collective="false" import="true" targetId="ad33-44fc-7c8b-a775" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1eea-1f83-96fb-5169" name="Psychic Cannon" hidden="false" collective="false" import="true" targetId="c6a1-a06c-031f-3a28" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="6c58-8c14-3bd9-14d4" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="13bb-5dfa-a946-bf92" name="Replace any Energy Sword:" hidden="false" collective="true" import="true" defaultSelectionEntryId="f1ef-5c28-a712-a020">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="459b-e42c-7142-9453" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92ca-4efc-b660-31f2" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="1c37-951c-b041-baa2" name="2x Energy Falchions" hidden="false" collective="true" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="1c87-c726-a6fe-809b" name="Energy Falchion" hidden="false" collective="false" import="true" targetId="50ff-a6f0-26a7-44be" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0b9-68a8-caa0-7ad3" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d3e-d4cf-c18c-2a90" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="f1ef-5c28-a712-a020" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry"/>
+            <entryLink id="d144-455c-8bd8-cce8" name="Energy Staff" hidden="false" collective="false" import="true" targetId="5812-eb85-ab7d-c183" type="selectionEntry"/>
+            <entryLink id="f55d-ae3a-bf53-e36e" name="Energy Halberd" hidden="false" collective="false" import="true" targetId="7b55-7b95-caec-2fe5" type="selectionEntry"/>
+            <entryLink id="531a-ac64-2c4c-2f87" name="Daemon Hammer" hidden="false" collective="false" import="true" targetId="10b6-089c-2053-fa2d" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="06b8-d987-9dec-c128" name="Knight Brothers - Upgrade List A (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="f39f-1b6b-b05a-3766" name="Storm Rifles" hidden="false" collective="false" import="true" defaultSelectionEntryId="edf5-7e30-a97f-2fef">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2b6-031d-1d8f-3d92" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d98f-93ee-e5ea-c5a7" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b475-e61b-8102-5105" name="Replace two Storm Rifles:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b338-b7a6-e039-2507" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="ff65-7382-e516-0e65" name="Incinerator" hidden="false" collective="false" import="true" targetId="10a4-0331-6a0c-0de6" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="3e37-186e-eb71-94a0" name="Psychic Silencer" hidden="false" collective="false" import="true" targetId="ad33-44fc-7c8b-a775" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="759e-cd0a-88d7-0cb4" name="Psychic Cannon" hidden="false" collective="false" import="true" targetId="c6a1-a06c-031f-3a28" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="edf5-7e30-a97f-2fef" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7c39-4523-9cb0-0059" name="Replace any Energy Sword:" hidden="false" collective="true" import="true" defaultSelectionEntryId="8b87-7818-d19a-3c45">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="182d-3dab-ce6a-52fc" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a37-f615-feca-4075" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="b2e3-5d78-e969-a157" name="2x Energy Falchions" hidden="false" collective="true" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="f549-7cec-ebde-34a3" name="Energy Falchion" hidden="false" collective="false" import="true" targetId="50ff-a6f0-26a7-44be" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b52-e7bb-4325-e6d8" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a2d-8233-9fdc-269e" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="8b87-7818-d19a-3c45" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry"/>
+            <entryLink id="e071-3fb5-1e28-1aa6" name="Energy Staff" hidden="false" collective="false" import="true" targetId="5812-eb85-ab7d-c183" type="selectionEntry"/>
+            <entryLink id="dab9-aec1-0285-354b" name="Energy Halberd" hidden="false" collective="false" import="true" targetId="7b55-7b95-caec-2fe5" type="selectionEntry"/>
+            <entryLink id="b3ca-1fc2-dd57-209d" name="Daemon Hammer" hidden="false" collective="false" import="true" targetId="10b6-089c-2053-fa2d" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="6297-b2b8-a562-607f" name="Knight Brothers - Upgrade List B (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ef5b-e7a5-dea0-0736" name="Upgrade all models with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a0d-56a2-8e4b-0d38" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="818e-9c59-cd75-79b4" name="Purifiers" hidden="false" collective="false" import="true" targetId="286b-c127-d50e-8862" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="5458-8dd5-8901-63ae" name="Strikers" hidden="false" collective="false" import="true" targetId="da8b-bfad-e6a7-ac2d" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="ab27-4799-8084-c46f" name="Interceptors" hidden="false" collective="false" import="true" targetId="b3c3-5ead-857c-5bce" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="eb53-19a2-88af-40be" name="Knight Brothers - Upgrade List B (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="dbbf-0a77-afbc-4d24" name="Upgrade all models with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7625-0b1b-140e-8e64" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="f6ec-e9de-c1aa-e903" name="Purifiers" hidden="false" collective="false" import="true" targetId="286b-c127-d50e-8862" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="fa42-f097-0569-3b44" name="Strikers" hidden="false" collective="false" import="true" targetId="da8b-bfad-e6a7-ac2d" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="f5ad-0920-c921-a131" name="Interceptors" hidden="false" collective="false" import="true" targetId="b3c3-5ead-857c-5bce" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="160.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="c413-23dc-124c-d1e5" name="Knight Brothers - Upgrade List E (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="39fa-12dc-861e-9075" name="Upgrade two models with:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3617-2219-531e-9db9" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="e9de-c747-44e0-d0ff" name="Psychic(1)" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="14de-c3b9-4b8e-70b2" name="Psychic(1)" hidden="false" targetId="2432-e2b3-c2c4-9482" type="profile"/>
+                <infoLink id="362c-c524-e1b5-f786" name="Psychic(X)" hidden="false" targetId="ba47-b43b-18f8-97c1" type="rule"/>
+              </infoLinks>
+              <entryLinks>
+                <entryLink id="bfd6-d0fb-7898-c2ca" name="Knight Brothers Psychic Spells" hidden="false" collective="false" import="true" targetId="ef87-9afc-97d0-abdf" type="selectionEntryGroup"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="bad9-bddd-3169-c1c5" name="Knight Brothers - Upgrade List E (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0533-7157-714c-e82a" name="Upgrade one model with:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="096f-1a71-5a89-95a6" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="0570-dd18-7786-45d8" name="Psychic(1)" hidden="false" collective="false" import="true" type="upgrade">
+              <infoLinks>
+                <infoLink id="5831-5439-3fea-0d9e" name="Psychic(1)" hidden="false" targetId="2432-e2b3-c2c4-9482" type="profile"/>
+                <infoLink id="e92b-89ba-ee53-c018" name="Psychic(X)" hidden="false" targetId="ba47-b43b-18f8-97c1" type="rule"/>
+              </infoLinks>
+              <entryLinks>
+                <entryLink id="42d2-e9c0-f929-160b" name="Knight Brothers Psychic Spells" hidden="false" collective="false" import="true" targetId="ef87-9afc-97d0-abdf" type="selectionEntryGroup"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>
@@ -17473,6 +17556,21 @@
     <profile id="4843-ef34-a0a4-8b68" name="Dark Shroud" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
       <characteristics>
         <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">When this unit is activated you may pick 2 friendly units within 6”, which get Stealth next time they are shot at.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="c450-c4c5-a354-1e83" name="Purifiers" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
+      <characteristics>
+        <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Impact(1)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="8167-75a6-1ff0-5809" name="Strikers" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
+      <characteristics>
+        <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Ambush	</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="e91c-d006-e62c-ad96" name="Interceptors" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
+      <characteristics>
+        <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Teleport</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -3834,107 +3834,6 @@
         <infoLink id="5b93-895b-0d3f-d82c" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
         <infoLink id="4d16-02b6-3259-b469" name="Psychic(X)" hidden="false" targetId="ba47-b43b-18f8-97c1" type="rule"/>
       </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="e250-79f5-9fe9-a431" name="Psychic(1)" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed88-4142-fe1d-5c32" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bc3-1616-5cc7-3ad6" type="min"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="78a8-f633-2580-3f57" name="Psychic(1)" hidden="false" targetId="2432-e2b3-c2c4-9482" type="profile"/>
-            <infoLink id="5775-0556-683e-2f7a" name="Psychic(X)" hidden="false" targetId="ba47-b43b-18f8-97c1" type="rule"/>
-          </infoLinks>
-          <entryLinks>
-            <entryLink id="68af-abbd-4a4c-7c47" name="Knight Brothers Psychic Spells" hidden="false" collective="false" import="true" targetId="ef87-9afc-97d0-abdf" type="selectionEntryGroup"/>
-          </entryLinks>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="74b1-47bc-36ae-6b2c" name="Melee Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="40bd-871d-6b98-63c2">
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdb7-b77f-a4e0-62af" type="max"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aae-a3fc-fb1f-7bbd" type="min"/>
-          </constraints>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="a53d-1303-902c-1fea" name="Replace one Knight Fist:" hidden="false" collective="false" import="true">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e85-b39b-93c5-1414" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="75c1-6720-35dd-1301" name="Energy Greatsword" hidden="false" collective="false" import="true" targetId="fe4c-1fdd-603a-c3b7" type="selectionEntry">
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="6655-8ade-9f32-932a" name="Daemon Hammer" hidden="false" collective="false" import="true" targetId="10b6-089c-2053-fa2d" type="selectionEntry">
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                  </costs>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="40bd-871d-6b98-63c2" name="Knight Fist" hidden="false" collective="false" import="true" targetId="098a-0360-b02a-00eb" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="deb9-37e4-df05-1c9b" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1475-1083-8551-5217" type="min"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="28bb-1779-9a1a-ce2c" name="Upgrades" hidden="false" collective="false" import="true">
-          <selectionEntries>
-            <selectionEntry id="f1c7-cc40-89ce-0aad" name="Teleport" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f4e-1980-b416-8eed" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="e595-3864-89c1-ba2f" name="Teleport" hidden="false" targetId="8569-65c6-aca3-fcf1" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="49ad-32ae-9cb0-184b" name="Regeneration" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b18-e382-da59-00db" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="e242-3f55-3260-628f" name="Regeneration" hidden="false" targetId="dea8-a8f9-1865-4424" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="110.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="7757-1a2c-296a-d333" name="Ranged Weapons [max 2]" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="227e-1cfb-9119-f88b" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="fb96-5d85-f158-ea5e" name="Heayv Psychic Cannon" hidden="false" collective="false" import="true" targetId="8984-f4b7-9bc5-2563" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="70.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="1377-2af0-d814-80bd" name="Heavy Incinerator" hidden="false" collective="false" import="true" targetId="742b-1772-7f3d-6ece" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="5000-3ea9-5e24-eee1" name="Gatling Psychic Silencer" hidden="false" collective="false" import="true" targetId="7b61-1b17-d775-bcbe" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="4ccd-c7ab-d8cf-babc" name="Stomp (Knight Walker)" hidden="false" collective="false" import="true" targetId="88b8-77e2-97f5-b5b3" type="selectionEntry">
           <constraints>
@@ -3942,6 +3841,8 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96cd-044f-bbc2-5da3" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="05f9-2e37-a927-9552" name="Knight Brothers Psychic Spells" hidden="false" collective="false" import="true" targetId="ef87-9afc-97d0-abdf" type="selectionEntryGroup"/>
+        <entryLink id="dae6-bc1f-3594-cd43" name="Knight Brothers - Upgrade List F" hidden="false" collective="false" import="true" targetId="b162-0d84-8413-a859" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="525.0"/>
@@ -15458,6 +15359,105 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>
+    <selectionEntryGroup id="b162-0d84-8413-a859" name="Knight Brothers - Upgrade List F" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7b7e-b520-55f9-632f" name="Upgrade with up to two:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6662-06bc-a492-19a1" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="1e93-c7fa-a83d-09af" name="Heavy Incinerator" hidden="false" collective="false" import="true" targetId="742b-1772-7f3d-6ece" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="ff45-9205-0b7a-de65" name="Gatling Psychic Silencer" hidden="false" collective="false" import="true" targetId="7b61-1b17-d775-bcbe" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="831f-0e00-c39a-0d93" name="Heavy Psychic Cannon" hidden="false" collective="false" import="true" targetId="8984-f4b7-9bc5-2563" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="70.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="cb17-7a64-3d93-4330" name="Knight Fists" hidden="false" collective="false" import="true" defaultSelectionEntryId="5622-e403-9ff6-0366">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="157b-bd01-e007-6137" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4d0-cee7-28a7-3725" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="c938-76c7-f4ea-dc46" name="Replace one Knight Fist:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8c1-e70b-aeb0-1e60" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="ab32-260e-185f-e1c2" name="Energy Greatsword" hidden="false" collective="false" import="true" targetId="fe4c-1fdd-603a-c3b7" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a35e-3174-f409-5a7d" name="Daemon Hammer" hidden="false" collective="false" import="true" targetId="10b6-089c-2053-fa2d" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="5622-e403-9ff6-0366" name="Knight Fist" hidden="false" collective="false" import="true" targetId="098a-0360-b02a-00eb" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bf6-6d45-76e4-92f5" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb9e-aa81-d642-9af0" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="09a6-115a-c151-42ef" name="Upgrade with any:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="67e3-e258-a4c6-5671" name="Teleport" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c450-01d3-71ff-fa99" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="412d-f1b3-6b3d-e882" name="Teleport" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
+                  <characteristics>
+                    <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Teleport</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="3ac4-88d1-0789-e1c6" name="Teleport" hidden="false" targetId="8569-65c6-aca3-fcf1" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="378d-8968-9375-4c08" name="Regeneration" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5b3-899b-4a84-0498" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="d69e-7f42-ac5f-b6f3" name="Regeneration" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
+                  <characteristics>
+                    <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Regeneration</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="f9a4-9d0a-8753-3707" name="Regeneration" hidden="false" targetId="dea8-a8f9-1865-4424" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="110.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
     <rule id="ff04-8ef9-82f1-a88b" name="Shield Wall" publicationId="dead-6af1-a069-5579" hidden="false">
@@ -16309,7 +16309,7 @@
       <characteristics>
         <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">3+</characteristic>
         <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">2+</characteristic>
-        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Aegis, Ambush, Fear, Fearless,Psychic(1), Tough(18)</characteristic>
+        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Aegis, Ambush, Fear, Fearless, Psychic(1), Tough(18)</characteristic>
       </characteristics>
     </profile>
     <profile id="acfc-c875-0b17-ad85" name="6. Purge" hidden="false" typeId="57dc-caf6-641d-327b" typeName="Psychic Power">

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -9175,28 +9175,6 @@
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="19cf-c76b-631a-2f4d" name="Upgrade one model with one:" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02e3-c1c5-519e-19ce" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="4468-d4e8-ba73-397e" name="Camo Cloak" hidden="false" collective="false" import="true" targetId="95b9-f24a-635e-8f6f" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="e97a-01c3-48aa-c583" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="9026-849f-8cb5-8fa2" name="Grave Armor" hidden="false" collective="false" import="true" targetId="3d40-9fa2-76fb-f0c1" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="85.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>
     <selectionEntryGroup id="b8a5-2300-ea05-b1e8" name="Prime Psychic Spell List" hidden="false" collective="false" import="true" defaultSelectionEntryId="dab3-681f-ed76-8c49">
@@ -13273,28 +13251,6 @@
     </selectionEntryGroup>
     <selectionEntryGroup id="abf6-f1d6-acfa-94ac" name="Prime Brothers 1 - Upgrade List A (Judge)" hidden="false" collective="false" import="true">
       <selectionEntryGroups>
-        <selectionEntryGroup id="1d40-0223-e5a2-acb0" name="Upgrade one model with one:" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f9d-d401-8128-0030" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="c55a-64ef-e2f3-f864" name="Camo Cloak" hidden="false" collective="false" import="true" targetId="95b9-f24a-635e-8f6f" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="8304-4351-d294-091b" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="d60d-b928-a583-5029" name="Grave Armor" hidden="false" collective="false" import="true" targetId="3d40-9fa2-76fb-f0c1" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="85.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
         <selectionEntryGroup id="4cd7-c15b-931d-7559" name="Replace one Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ccb4-3e7c-c077-fdf8">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c43-09ea-714e-1a6e" type="min"/>
@@ -13720,28 +13676,6 @@
               </costs>
             </selectionEntry>
           </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="660a-a2db-0a09-5609" name="Upgrade two models with one:" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69d5-b24b-b6e5-d2d5" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="183f-5a49-94c1-b25f" name="Camo Cloak" hidden="false" collective="false" import="true" targetId="95b9-f24a-635e-8f6f" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="7c4b-1bbe-414c-7107" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="ed8d-f4f7-5a4c-3420" name="Grave Armor" hidden="false" collective="false" import="true" targetId="3d40-9fa2-76fb-f0c1" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="85.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -2594,180 +2594,6 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bbc7-304e-efe1-c2c5" name="Watch Brother" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="8968-d09c-6b21-08f2" name="Death Brother" hidden="false" targetId="9040-0c4d-e888-7fac" type="profile"/>
-        <infoLink id="fd7c-a97a-8f30-278e" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-      </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="a6da-e76f-3edc-a437" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="df5e-876e-daae-7787">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aabe-52d0-73f1-cf95" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cde6-c931-d0b1-5ea6" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="53bb-9751-340b-70d9" name="Heavy Energy Hammer" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="ea99-3830-f493-9a27" name="Heavy Energy Hammer" hidden="false" collective="false" import="true" targetId="5cdf-6e92-c1ce-3a65" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9327-25df-163c-b208" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20a8-02ac-b67f-bcc6" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="df5e-876e-daae-7787" name="Ranged &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="4e6b-b0cb-7253-a567" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="a439-bc42-88b4-ca72">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="348e-d7c6-fcab-808b" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5db-11c8-0ab8-e532" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="f36c-96b6-63ce-a3c8" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="0ddd-6f9e-a0d2-cbd4" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="26e3-bd53-11d7-69ad" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="a439-bc42-88b4-ca72" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="3d63-cb8b-9268-ff65" name="Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="f0be-6d2b-837c-5b95">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="555a-ca95-f9bc-9eaa" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e456-bd00-366c-198f" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="9c6e-4daf-482c-4a21" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
-                      <selectionEntryGroups>
-                        <selectionEntryGroup id="eb14-1d06-da08-c0cb" name="Assault Rifle Attachment" hidden="false" collective="false" import="true">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db5c-0f9c-0f01-4ed2" type="max"/>
-                          </constraints>
-                          <entryLinks>
-                            <entryLink id="3401-de71-93b1-ab9f" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
-                              <costs>
-                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="9f02-20b8-29bf-c934" name="Gravity Rifle" hidden="false" collective="false" import="true" targetId="3e4a-da63-fdf2-c5fb" type="selectionEntry">
-                              <costs>
-                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="232a-ae00-efad-565b" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
-                              <costs>
-                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="5d15-412a-c16c-ad72" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
-                              <costs>
-                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-                              </costs>
-                            </entryLink>
-                          </entryLinks>
-                        </selectionEntryGroup>
-                      </selectionEntryGroups>
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="e5f7-2c42-49d4-ee13" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="b786-2208-f550-159f" name="Stalker Rifle" hidden="false" collective="false" import="true" targetId="45c7-c680-df64-25c9" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="f1ba-df4e-aba7-ec6c" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="df4c-b870-24b8-12ea" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="f0be-6d2b-837c-5b95" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
-                    <entryLink id="d63d-7840-28fc-284e" name="Flame Pistol" hidden="false" collective="false" import="true" targetId="db8f-b317-2b7d-2ed3" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="8344-9032-c08d-1115" name="Gravity Rifle" hidden="false" collective="false" import="true" targetId="3e4a-da63-fdf2-c5fb" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="0458-5690-7778-f760" name="Gravity Pistol" hidden="false" collective="false" import="true" targetId="f790-2f7c-63a0-1603" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="f3a3-7dad-fed2-1562" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="0a35-d0b3-fe32-3ae0" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="2071-4cb6-f32c-5d11" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="0f36-f90d-91cc-832f" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="1805-47f2-bb44-2e76" name="Death Shotgun" hidden="false" collective="false" import="true" targetId="62f5-cae0-bd32-ff9e" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ff6f-143e-c0f5-1277" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="7c8a-ddc7-ffe7-2b0b" name="Energy Claw" hidden="false" collective="false" import="true" targetId="71e9-a72c-6160-0673" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f99e-4dc6-0324-c0bd" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f0a-a08a-e2a7-d905" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="5cdf-6e92-c1ce-3a65" name="Heavy Energy Hammer" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="7b56-f3f8-abd9-e725" name="Heavy Energy Hammer" hidden="false" targetId="9d23-0faf-b078-8cc8" type="profile"/>
@@ -2797,111 +2623,32 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="fba0-f4d1-bae3-6baf" name="Watch Brother (Heavy Weapon)" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="b5d0-d678-b3c9-7a97" name="Watch Brothers" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="c1e6-7902-240e-1d04" name="Death Brother" hidden="false" targetId="9040-0c4d-e888-7fac" type="profile"/>
-        <infoLink id="f3b0-6a95-de29-86ed" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
+        <infoLink id="fe07-dba2-e33d-4fe5" name="Watch Brother" hidden="false" targetId="9040-0c4d-e888-7fac" type="profile"/>
+        <infoLink id="32e9-f61c-357d-ef67" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
       </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="04ab-7a95-8246-21f2" name="Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="65f8-2e05-78d5-01e1">
+        <selectionEntryGroup id="5e51-a094-65b2-d342" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="a0e5-5f3b-9da0-7f32">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d80-d8aa-ba8a-07bd" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e09f-8010-fae2-7ef6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11cd-21a1-d0ef-ef03" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="241e-9199-9cf0-851a" type="max"/>
           </constraints>
-          <entryLinks>
-            <entryLink id="18d1-ed1e-13ae-7e71" name="Missile Launcher" hidden="false" collective="false" import="true" targetId="ff1b-714c-6353-221d" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="078a-cbe0-32ee-cad0" name="Heavy Machinegun" hidden="false" collective="false" import="true" targetId="4481-49a4-e4f7-925b" type="selectionEntry">
+          <selectionEntries>
+            <selectionEntry id="a0e5-5f3b-9da0-7f32" name="Single Unit [5 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="8f29-e708-6bfe-3f5a" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf3e-ea45-f9a5-3b4c" type="max"/>
-                  </constraints>
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-                  </costs>
-                </entryLink>
+                <entryLink id="9013-6690-b27d-d3e4" name="Watch Brothers - Upgrade List B (single unit)" hidden="false" collective="false" import="true" targetId="24cd-b48f-b0d1-9e48" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="f8e8-de82-87c2-065e" name="Combined Unit [10 model]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="6cbb-22f9-5ffc-1233" name="Watch Brothers - Upgrade List B (combined unit)" hidden="false" collective="false" import="true" targetId="306c-4c6b-cd96-1e87" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="150.0"/>
               </costs>
-            </entryLink>
-            <entryLink id="65f8-2e05-78d5-01e1" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="f166-1868-9ece-c7e6" name="Frag Blaster" hidden="false" collective="false" import="true" targetId="dcff-7eac-1a79-0535" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="f66a-7edc-ca1c-fbac" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="1293-f4f9-3ebf-4605">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7bf-2678-9fa0-7cca" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f14c-8ff3-a06b-c499" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="c160-5375-715c-a0c3" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="bc3c-0f01-862a-51e2" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="70a2-d41b-cc43-c859" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="1293-f4f9-3ebf-4605" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="b5d0-d678-b3c9-7a97" name="Watch Brothers" hidden="false" collective="false" import="true" type="upgrade">
-      <selectionEntryGroups>
-        <selectionEntryGroup id="cc9f-d889-7e7f-d774" name="Brothers" hidden="false" collective="false" import="true" defaultSelectionEntryId="3d4f-3422-a5a3-201f">
-          <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a484-415b-6db6-f488" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab80-c987-9946-9a4d" type="min"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="3d4f-3422-a5a3-201f" name="Death Brother" hidden="false" collective="false" import="true" targetId="bbc7-304e-efe1-c2c5" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f40a-717e-ae8f-c504" type="max"/>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a3b-7c7d-d65a-5e14" type="min"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="2422-629c-557a-0419" name="Death Brother (Special Weapon)" hidden="false" collective="false" import="true" targetId="fba0-f4d1-bae3-6baf" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0146-fcdf-867a-74a5" type="max"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="6dc1-8f78-5f3a-7fb9" name="Upgrade all:" hidden="false" collective="false" import="true">
-          <entryLinks>
-            <entryLink id="ff35-16fe-46a3-76ad" name="Combat Shield" hidden="false" collective="false" import="true" targetId="f5b9-642f-6bfe-ce58" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="474a-0ee0-24e9-aa59" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
+            </selectionEntry>
+          </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
@@ -15263,11 +15010,17 @@
                       </constraints>
                       <entryLinks>
                         <entryLink id="5489-81ee-2b5b-ad93" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c36-2813-ebde-e991" type="max"/>
+                          </constraints>
                           <costs>
                             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
                           </costs>
                         </entryLink>
                         <entryLink id="bd9e-1abb-3e13-5f73" name="Heavy Machinegun" hidden="false" collective="false" import="true" targetId="4481-49a4-e4f7-925b" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03f0-b641-27b0-575f" type="max"/>
+                          </constraints>
                           <selectionEntryGroups>
                             <selectionEntryGroup id="d6c4-1726-20a5-9dcf" name="Any model may take one Heavy Machinegun attachment:" hidden="false" collective="false" import="true">
                               <constraints>
@@ -15287,11 +15040,17 @@
                           </costs>
                         </entryLink>
                         <entryLink id="a0ba-de51-c62f-d345" name="Missile Launcher" hidden="false" collective="false" import="true" targetId="ff1b-714c-6353-221d" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5146-d359-3eaf-8246" type="max"/>
+                          </constraints>
                           <costs>
                             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
                           </costs>
                         </entryLink>
                         <entryLink id="7917-5bef-223f-2920" name="Frag Blaster" hidden="false" collective="false" import="true" targetId="dcff-7eac-1a79-0535" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd79-ee3b-e912-eb52" type="max"/>
+                          </constraints>
                           <costs>
                             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
                           </costs>
@@ -15300,58 +15059,95 @@
                     </selectionEntryGroup>
                   </selectionEntryGroups>
                   <entryLinks>
-                    <entryLink id="5560-3df6-ec48-d3e8" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
+                    <entryLink id="5560-3df6-ec48-d3e8" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0324-5b28-f242-138e" type="max"/>
+                      </constraints>
+                    </entryLink>
                     <entryLink id="5369-259a-6eaa-467e" name="Gravity Pistol" hidden="false" collective="false" import="true" targetId="f790-2f7c-63a0-1603" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a790-8ebc-3549-ca6d" type="max"/>
+                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="0da6-a2f5-3ab8-d063" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e542-f412-9b78-0bfc" type="max"/>
+                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="37d2-b90c-20c5-8192" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="994d-fac1-9ba4-81aa" type="max"/>
+                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="c919-ecd0-f344-06da" name="Death Shotgun" hidden="false" collective="false" import="true" targetId="62f5-cae0-bd32-ff9e" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac75-94a9-2b8e-7b3a" type="max"/>
+                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="34c7-ca6f-b610-4d1f" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43b6-ef6d-2bce-b48b" type="max"/>
+                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="d4c6-53c4-5b1d-ebab" name="Gravity Rifle" hidden="false" collective="false" import="true" targetId="3e4a-da63-fdf2-c5fb" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d34-1f04-2c75-a443" type="max"/>
+                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="ba38-e840-808b-0025" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42fd-c39c-3fe6-ddc5" type="max"/>
+                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="a27b-fe8f-8557-9536" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="2071-4cb6-f32c-5d11" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b26-8bd5-689a-6c6f" type="max"/>
+                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="616b-d5ea-1e47-c753" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="378b-8d78-1f82-ca73" type="max"/>
+                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="133f-2206-ccc7-ecaf" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed37-9f98-d10d-f055" type="max"/>
+                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
                       </costs>
                     </entryLink>
                     <entryLink id="62d2-fd97-6928-cd7b" name="Stalker Rifle" hidden="false" collective="false" import="true" targetId="45c7-c680-df64-25c9" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1862-9c7f-020d-4492" type="max"/>
+                      </constraints>
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
                       </costs>
@@ -15470,6 +15266,810 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5b66-3a4d-2bf4-44f1" name="Upgrade all models with:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="33ed-7d63-1883-07a0" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb0b-36c2-3105-4c71" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="24cd-b48f-b0d1-9e48" name="Watch Brothers - Upgrade List B (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5232-5bd8-40bb-a0a5" name="Replace any Pistol &amp; CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="45e4-4be6-602c-1346">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b1b-1a87-3ac8-16b2" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7763-22f3-2cb7-ffe2" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="45e4-4be6-602c-1346" name="Pistol &amp; CCW (A2)" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="a9a2-de4c-5571-5bf5" name="Replace any Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="7c69-a1cd-8113-12a0">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85eb-fc9d-49a7-76f0" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c8b-09be-18d5-5f9e" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="7c69-a1cd-8113-12a0" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2d8-ebab-ad66-41f7" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="c72a-e2b9-3b51-24a1" name="Gravity Pistol" hidden="false" collective="false" import="true" targetId="f790-2f7c-63a0-1603" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ab7-13af-2897-b6a1" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="9e91-8e2e-fd1d-4ede" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be9a-75f2-e34c-e4aa" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="cbc9-4b3d-06a7-876d" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e1c-6b23-314e-dff3" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="727c-f79f-e02c-e9ee" name="Death Shotgun" hidden="false" collective="false" import="true" targetId="62f5-cae0-bd32-ff9e" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ed1-a13a-77a1-3d72" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="b5d9-94e2-fbbb-0592" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8177-2800-c092-e91e" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="9438-3613-8be0-a789" name="Gravity Rifle" hidden="false" collective="false" import="true" targetId="3e4a-da63-fdf2-c5fb" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42df-e02a-178e-10ea" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="9cf4-35a7-97e5-152a" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12d1-730d-878c-bcba" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="5e94-eb02-3c7c-9e47" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="2071-4cb6-f32c-5d11" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96bd-ed3b-d33b-c56c" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="1127-fc8d-4779-b5f9" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7b0-72ab-ff7b-735d" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="1fc5-d8f3-4f48-696d" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="834f-7f16-0990-5781" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="7ef8-3c12-a6d3-20aa" name="Stalker Rifle" hidden="false" collective="false" import="true" targetId="45c7-c680-df64-25c9" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4915-e698-70fe-0078" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="ca6b-64a7-3d60-4fcb" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdc6-e618-8943-6375" type="max"/>
+                      </constraints>
+                      <selectionEntryGroups>
+                        <selectionEntryGroup id="ad16-9338-7b49-cf20" name="Any model may take on Assault Rifle attachment:" hidden="false" collective="false" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a32-f305-68f6-596c" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="5d34-5fc6-1138-8813" name="Gravity Rifle" hidden="false" collective="false" import="true" targetId="3e4a-da63-fdf2-c5fb" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="09a2-e016-cb67-18e8" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="2393-c1d0-60a4-5793" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="64c3-3cbd-4ab1-e09f" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+                              </costs>
+                            </entryLink>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                      </selectionEntryGroups>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="9b2d-5daa-5612-4524" name="Replace any CCW" hidden="false" collective="false" import="true" defaultSelectionEntryId="ae74-69a4-e9e4-a1c3">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ab8-d9f2-fd0e-372a" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36a3-b6d5-e197-279a" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="ae74-69a4-e9e4-a1c3" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+                    <entryLink id="1047-1392-fa4a-2de2" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="ad22-a69e-e73b-467e" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="45eb-5619-9891-935d" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntry>
+            <selectionEntry id="1efc-85ff-0b5f-7b8e" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="3d85-6e2d-ca80-13e8" name="Energy Claw" hidden="false" collective="false" import="true" targetId="0ed5-13cf-f02f-9759" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="789a-cf0e-4546-2fc4" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3881-504d-4057-1d09" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ee9b-f059-d074-5e24" name="Replace up to two Pistols:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="61bb-6116-df2f-5f7b" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="be8d-215e-d042-78fd" name="Frag Blaster &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="dfe0-4e55-8790-abe1" name="Replace any CCW" hidden="false" collective="false" import="true" defaultSelectionEntryId="a8cf-b133-ec31-6eeb">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a507-5720-5acb-66d2" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f55-0e26-8ae2-4949" type="max"/>
+                      </constraints>
+                      <entryLinks>
+                        <entryLink id="a8cf-b133-ec31-6eeb" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+                        <entryLink id="6ff1-ef34-264c-b999" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="691a-3acb-5576-b0cb" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="fcee-0065-20cd-f808" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                          </costs>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <entryLinks>
+                    <entryLink id="5716-bb73-19af-494e" name="Frag Blaster" hidden="false" collective="false" import="true" targetId="dcff-7eac-1a79-0535" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1498-9f8f-071e-ce55" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be0d-1308-3a22-aaa5" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="99d5-d499-5706-b2c5" name="Heavy Flamethrower &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="8ae8-381e-fb5b-8f12" name="Replace any CCW" hidden="false" collective="false" import="true" defaultSelectionEntryId="22ca-d73a-fc20-83b6">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3df-a4e4-5f31-073e" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4574-c52b-63a1-80d1" type="max"/>
+                      </constraints>
+                      <entryLinks>
+                        <entryLink id="22ca-d73a-fc20-83b6" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+                        <entryLink id="24eb-c771-41fc-4ac3" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="df90-bcb4-d2db-4dfe" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="386c-0936-5369-3a5e" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                          </costs>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <entryLinks>
+                    <entryLink id="4257-592e-0758-a1bc" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e57-d323-c895-cb28" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="979d-bf43-cdb3-a76c" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="ebbd-5e51-b345-7232" name="Heavy Machinegun &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
+                  <entryLinks>
+                    <entryLink id="a131-d867-d974-b51e" name="Heavy Machinegun" hidden="false" collective="false" import="true" targetId="4481-49a4-e4f7-925b" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b246-ce29-55d0-1376" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebcb-0816-c77d-e497" type="max"/>
+                      </constraints>
+                      <selectionEntryGroups>
+                        <selectionEntryGroup id="2f31-a5dd-103b-39e5" name="Any model may take one Heavy Machinegun attachment:" hidden="false" collective="false" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1dbe-4a66-a6b2-22bf" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="8a58-7f03-e7cf-4c45" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+                              </costs>
+                            </entryLink>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                        <selectionEntryGroup id="2063-a8b5-f768-0842" name="Replace any CCW" hidden="false" collective="false" import="true" defaultSelectionEntryId="8597-f088-0f0a-a730">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cd2-e646-051a-e71f" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45e4-ca1b-aefc-0f39" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="8597-f088-0f0a-a730" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+                            <entryLink id="4352-9616-6bb4-9922" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="c243-3dcc-5974-c552" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="cf74-5acd-3fc1-0b17" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                              </costs>
+                            </entryLink>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                      </selectionEntryGroups>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="8df3-e6f9-5912-ff1d" name="Missile Launcher &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="4b16-6e5f-bdca-defb" name="Replace any CCW" hidden="false" collective="false" import="true" defaultSelectionEntryId="fcd6-888f-ba3e-e5d6">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42a7-8e2c-8b32-10e1" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d4f-608c-8d94-7e23" type="max"/>
+                      </constraints>
+                      <entryLinks>
+                        <entryLink id="fcd6-888f-ba3e-e5d6" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+                        <entryLink id="f65c-e61e-9076-661f" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="32e6-f8c7-997d-c20d" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="f6bf-ee99-aaf5-c103" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                          </costs>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <entryLinks>
+                    <entryLink id="fdc2-dc9c-c9dd-5bb6" name="Missile Launcher" hidden="false" collective="false" import="true" targetId="ff1b-714c-6353-221d" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fb8-ec16-46f2-db95" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e6c-286b-6488-0319" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="a7af-325d-7fbd-a0fe" name="Heavy Energy Hammer" hidden="false" collective="false" import="true" targetId="5cdf-6e92-c1ce-3a65" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2f8e-7dd2-3c17-76e4" name="Upgrade all models with:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="030a-a7cc-ad62-f94b" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="434e-be74-87dd-b665" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="306c-4c6b-cd96-1e87" name="Watch Brothers - Upgrade List B (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6f11-0ad5-399e-d24f" name="Replace any Pistol &amp; CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="d21f-721d-b93f-b8c0">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8f0-cd25-f083-05c0" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6108-5d16-6c1f-0eb5" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="d21f-721d-b93f-b8c0" name="Pistol &amp; CCW (A2)" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="5eb5-5a8f-d385-be56" name="Replace any Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="f1aa-001f-a2d3-b464">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3910-0eed-9f6c-988c" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbf9-fea9-56b8-3dfa" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="f1aa-001f-a2d3-b464" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc94-ac1c-181e-725c" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="5b1e-81a2-0456-6959" name="Gravity Pistol" hidden="false" collective="false" import="true" targetId="f790-2f7c-63a0-1603" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46a2-bd91-85c7-14e5" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="5ce0-3522-292e-3408" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7477-668e-1cd5-6de2" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="6e4b-9a4e-a974-5501" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a1d-6e52-a060-3d86" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="8191-a471-db4f-93e4" name="Death Shotgun" hidden="false" collective="false" import="true" targetId="62f5-cae0-bd32-ff9e" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d34-0bb4-9836-b43f" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="6898-e9f9-445d-4045" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ff7-4e1f-483d-2231" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="a0dc-23b5-3b24-8ad4" name="Gravity Rifle" hidden="false" collective="false" import="true" targetId="3e4a-da63-fdf2-c5fb" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="faab-0d43-f558-74cc" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="5194-d2fc-aa9b-7469" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20b8-4e23-390a-b0e5" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="ad97-ef09-5a24-dbd9" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="2071-4cb6-f32c-5d11" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d928-6983-594a-56c0" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="d8c2-6b21-5484-a6d0" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a45b-04e3-1634-04e7" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="e6ea-406c-08a9-9d05" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4324-1c9a-238c-bdcd" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="8898-6793-8758-5082" name="Stalker Rifle" hidden="false" collective="false" import="true" targetId="45c7-c680-df64-25c9" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65a1-f2aa-9045-eb90" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="8005-d779-d10d-58df" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1275-b366-b282-9c60" type="max"/>
+                      </constraints>
+                      <selectionEntryGroups>
+                        <selectionEntryGroup id="072f-2fad-7fa2-3aa7" name="Any model may take on Assault Rifle attachment:" hidden="false" collective="false" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7950-0611-cab8-794e" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="e5f9-2e7a-3790-8f3b" name="Gravity Rifle" hidden="false" collective="false" import="true" targetId="3e4a-da63-fdf2-c5fb" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="9dd5-8cf1-74f2-a8a0" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="1591-7392-34db-64fc" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="0a50-8d9d-2b59-23db" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+                              </costs>
+                            </entryLink>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                      </selectionEntryGroups>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="74bc-59d4-f7fb-5a86" name="Replace any CCW" hidden="false" collective="false" import="true" defaultSelectionEntryId="8bae-0364-fc25-16a7">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83d5-976f-9182-0921" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ea6-e3a1-8f52-ab39" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="8bae-0364-fc25-16a7" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+                    <entryLink id="ac4e-cebd-3a0b-3e81" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="5434-95d7-ad3b-ce45" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="66ce-e5b8-295c-ce66" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntry>
+            <selectionEntry id="b183-5fd8-88b0-b678" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="36fb-8e4e-f5a2-657a" name="Energy Claw" hidden="false" collective="false" import="true" targetId="0ed5-13cf-f02f-9759" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7895-3b15-9a15-cd56" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad1c-654e-f4c1-c72a" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b1bf-e098-a012-893c" name="Replace up to four Pistols:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="51cc-71e3-ffb9-d0f2" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="fd9d-a7c2-f67d-b250" name="Frag Blaster &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="4f30-1b5e-5d71-8610" name="Replace any CCW" hidden="false" collective="false" import="true">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8dda-7058-a44f-f70c" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6817-95d4-7913-42b3" type="max"/>
+                      </constraints>
+                      <entryLinks>
+                        <entryLink id="1d76-177b-06e7-5d67" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+                        <entryLink id="80bd-eb2b-c280-86b6" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="6665-1ce5-904c-996a" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="f331-1f7d-97bc-e368" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                          </costs>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <entryLinks>
+                    <entryLink id="acb1-caca-5263-e133" name="Frag Blaster" hidden="false" collective="false" import="true" targetId="dcff-7eac-1a79-0535" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67ac-30d1-5e5d-dafd" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1980-4830-9d44-0dae" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="ef48-dba1-0446-eb99" name="Heavy Flamethrower &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="ca93-7a9f-cb30-b69e" name="Replace any CCW" hidden="false" collective="false" import="true">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="adea-1eb1-f758-931f" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad39-8179-70c1-7fa9" type="max"/>
+                      </constraints>
+                      <entryLinks>
+                        <entryLink id="765b-721a-43cb-d426" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+                        <entryLink id="75be-e263-8c5f-fb82" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="59d0-86aa-f162-a7c7" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="46c8-3386-fc1a-6179" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                          </costs>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <entryLinks>
+                    <entryLink id="5262-2be0-e7b2-d330" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e643-2d9a-756a-d0f3" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de3d-ac31-9a1a-cb14" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="afb2-94f3-7674-0597" name="Heavy Machinegun &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
+                  <entryLinks>
+                    <entryLink id="9788-8865-7c3f-aa7c" name="Heavy Machinegun" hidden="false" collective="false" import="true" targetId="4481-49a4-e4f7-925b" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce19-5619-2cde-2e46" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9343-fc2c-c816-c58f" type="max"/>
+                      </constraints>
+                      <selectionEntryGroups>
+                        <selectionEntryGroup id="a9d2-8790-1a49-1012" name="Any model may take one Heavy Machinegun attachment:" hidden="false" collective="false" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="979d-1f41-6edb-0c43" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="e0f6-bfd7-5300-bdce" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+                              </costs>
+                            </entryLink>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                        <selectionEntryGroup id="088a-c7b3-2675-441f" name="Replace any CCW" hidden="false" collective="false" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9341-53da-8f70-f403" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf9a-8b39-652b-1b7a" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="4487-9f47-ed78-9841" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+                            <entryLink id="e248-5e99-c5b2-3be2" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="1b29-6d86-2aab-f232" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="3055-5b92-bde6-cc8d" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                              </costs>
+                            </entryLink>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                      </selectionEntryGroups>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="ca1a-f750-5503-f3dc" name="Missile Launcher &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="31e3-26cd-cac1-490a" name="Replace any CCW" hidden="false" collective="false" import="true">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0875-ae1a-6bb9-4df3" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2356-48bf-346c-2b91" type="max"/>
+                      </constraints>
+                      <entryLinks>
+                        <entryLink id="129b-3bd2-2e24-1c38" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+                        <entryLink id="7b3d-8d90-5565-ada3" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="536a-b2a4-62eb-ad32" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="6ccb-295e-e029-cce3" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                          </costs>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <entryLinks>
+                    <entryLink id="fe01-e5c5-35dd-47d0" name="Missile Launcher" hidden="false" collective="false" import="true" targetId="ff1b-714c-6353-221d" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d796-ef7d-f6d8-d54f" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1320-497c-e73e-d8b6" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="aba9-648a-08b8-ed43" name="Heavy Energy Hammer" hidden="false" collective="false" import="true" targetId="5cdf-6e92-c1ce-3a65" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="071a-85e5-eb68-2040" name="Upgrade all models with:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="e722-d466-51a7-82f9" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffe2-1d21-c5f8-5195" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
               </costs>
             </entryLink>
           </entryLinks>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -3,7 +3,7 @@
   <publications>
     <publication id="dead-6af1-a069-5579" name="Battle Brothers v2.12"/>
     <publication id="a380-f550-5f9a-c792" name="Battle Brothers Detachments v2.14"/>
-    <publication id="339e-d00a-321f-4a00" name="Prime Brothers v2.13"/>
+    <publication id="339e-d00a-321f-4a00" name="Prime Brothers v2.14"/>
   </publications>
   <entryLinks>
     <entryLink id="5e41-31cb-5063-301e" name="Champion" hidden="false" collective="false" import="true" targetId="7708-7d52-a3b5-5a3a" type="selectionEntry">

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -2060,91 +2060,9 @@
         <infoLink id="3b38-c9c8-1219-a2cf" name="Blood Tank" hidden="false" targetId="577a-dafe-b3c4-af0b" type="profile"/>
         <infoLink id="12c9-4dad-f79b-6a2e" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="a1b4-bde0-03fd-11d8" name="Upgrades" hidden="false" collective="false" import="true">
-          <entryLinks>
-            <entryLink id="4942-b858-3911-1bb2" name="Dozer Blade" hidden="false" collective="false" import="true" targetId="5dc2-4ac8-2769-e4ba" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18c0-4494-4f5a-2c14" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="5a91-557a-aecd-0cc4" name="Hunter Missile" hidden="false" collective="false" import="true" targetId="c756-9c2d-beca-986c" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d87-5888-83d3-c9c1" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="dde8-5cd7-d3bb-acc9" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57d1-6b16-c31a-555c" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="186a-370d-d426-8f6a" name="Overcharged Engines" hidden="false" collective="false" import="true" targetId="db5d-0f53-5fb4-8f08" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e03b-07eb-8d4b-c2db" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="c896-6e7e-7f8a-0446" name="Weapon - Turret" hidden="false" collective="false" import="true" defaultSelectionEntryId="9f8d-8047-c6f9-993f">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9365-d442-4343-2562" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e35-46bf-adf7-3d1c" type="min"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="9f8d-8047-c6f9-993f" name="Flamethrower Cannon" hidden="false" collective="false" import="true" targetId="f587-2140-510e-48b8" type="selectionEntry"/>
-            <entryLink id="5c9c-206d-7b52-74ec" name="Twin Minigun" hidden="false" collective="false" import="true" targetId="a8f7-27d2-59eb-c865" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="754d-9455-8f58-514f" name="Weapon - Sponsons" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="327f-c75c-f3df-e2ea" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="b25a-46cc-72ea-354e" name="2x Heavy Machineguns" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="f515-3f1b-546f-da18" name="Heavy Machinegun" hidden="false" collective="false" import="true" targetId="4481-49a4-e4f7-925b" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="672b-04e4-1676-7404" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1548-ec2d-d92d-9f45" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="55.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="9f9e-f008-d006-3580" name="2x Heavy Flamethrowers" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="47fe-2ca3-96e9-e3e9" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca51-f966-de52-13d1" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa48-f159-1ddc-55d0" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="6cd9-e1bb-b1fd-d030" name="Blood Brothers - Upgrade List D" hidden="false" collective="false" import="true" targetId="411a-3ffd-707a-8ed5" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="340.0"/>
       </costs>
@@ -15251,6 +15169,93 @@
             <entryLink id="1223-aab0-8a83-c881" name="Battle Standard" hidden="false" collective="false" import="true" targetId="398c-3d34-79c6-a425" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="411a-3ffd-707a-8ed5" name="Blood Brothers - Upgrade List D" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6dec-274c-e725-0659" name="Upgrade with any:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="cb21-7acf-7011-1c32" name="Dozer Blade" hidden="false" collective="false" import="true" targetId="5dc2-4ac8-2769-e4ba" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="daab-30c8-e3a1-5f2a" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="0fa5-fcb8-d91b-565a" name="Hunter Missiles" hidden="false" collective="false" import="true" targetId="c756-9c2d-beca-986c" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="960a-530e-1950-f4f5" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="dede-a75b-5633-3d21" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e9c-da0c-7957-3b21" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="ca71-dbf4-a281-e04b" name="Overcharged Engines" hidden="false" collective="false" import="true" targetId="db5d-0f53-5fb4-8f08" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39fa-1468-522c-3bb4" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2916-4678-6570-7568" name="Upgrade with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae18-d51d-2a10-52a7" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="5e68-f974-5e77-e60e" name="2x Heavy Machineguns" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="1cfc-f348-e270-1896" name="Heavy Machinegun" hidden="false" collective="false" import="true" targetId="4481-49a4-e4f7-925b" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bce4-77e0-eea7-9736" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4e2-bf06-1af5-4035" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="55.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="721c-f76a-51dd-b9d1" name="2x Heavy Flamethrowers" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="e4fd-a36d-1357-6d2d" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f94-3add-65e8-abce" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d6c-5710-5b43-7656" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="af1b-0d92-77eb-1874" name="Replace Flamethrower Cannon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="9208-97c9-26ef-4496">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1c4-ef2c-7d31-cbea" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="668d-1634-470a-d9da" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="9208-97c9-26ef-4496" name="Flamethrower Cannon" hidden="false" collective="false" import="true" targetId="f587-2140-510e-48b8" type="selectionEntry"/>
+            <entryLink id="1ada-3469-4f7f-c2a6" name="Twin Minigun" hidden="false" collective="false" import="true" targetId="a8f7-27d2-59eb-c865" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
               </costs>
             </entryLink>
           </entryLinks>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -6814,44 +6814,6 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bd8c-ea91-6637-782a" name="Aggro Brother (Fist-Carbine)" hidden="false" collective="false" import="true" type="upgrade">
-      <entryLinks>
-        <entryLink id="7e16-2685-d65e-edb3" name="Energy Fist" hidden="false" collective="false" import="true" targetId="b9d2-571b-92d1-126a" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="466c-aacb-627c-8938" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8bc5-6d41-88b5-8cf5" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="3165-5cd0-d7e3-0da9" name="Fist-Carbine" hidden="false" collective="false" import="true" targetId="d984-2f6e-718a-0ff7" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ae5-7f3a-ea94-d506" type="max"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e16-cbdb-1065-0e20" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="7b57-52b0-8562-2982" name="Aggro Brother (Fist-Flamethrower)" hidden="false" collective="false" import="true" type="upgrade">
-      <entryLinks>
-        <entryLink id="c9f2-d65d-f4e5-b9ec" name="Energy Fist" hidden="false" collective="false" import="true" targetId="b9d2-571b-92d1-126a" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f77-66e9-1cce-7197" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0407-30a6-c949-94e2" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="697e-fd92-0817-4c11" name="Fist-Flamethrower" hidden="false" collective="false" import="true" targetId="efce-8bcd-f1d3-20ca" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3cb8-186a-dfd6-4497" type="max"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1951-e105-79ff-7cd2" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="efce-8bcd-f1d3-20ca" name="Fist-Flamethrower" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="e37e-ba8f-d190-89e0" name="Fist-Flamethrowers" hidden="false" targetId="d5ba-b68f-b386-2cbd" type="profile"/>
@@ -6862,88 +6824,35 @@
     </selectionEntry>
     <selectionEntry id="f10a-0151-35d5-28f9" name="Aggro Squad" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="07e7-133a-7a63-6cf1" name="Aggro Brother" hidden="false" targetId="0760-7de5-6321-ec51" type="profile"/>
+        <infoLink id="07e7-133a-7a63-6cf1" name="Prime Aggro Brother" hidden="false" targetId="0760-7de5-6321-ec51" type="profile"/>
         <infoLink id="9122-6d1b-14cf-a2f3" name="Firstborn" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
         <infoLink id="1904-a8a4-9f18-bb44" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
       </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="5641-67a5-7bba-5f24" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="f5bb-56ae-fa2f-e43a">
+        <selectionEntryGroup id="655e-72e1-2cae-3788" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="7499-74f4-3fe6-91b4">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="812b-9aa3-b172-26d0" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9755-fa31-4037-2e5a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d17-a3b5-3689-6ac7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44ac-7e6f-574c-9920" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="f5bb-56ae-fa2f-e43a" name="Fist-Carbines" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="7499-74f4-3fe6-91b4" name="Single Unit [3 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="1585-6f04-3808-80a3" name="Aggro Brother (Fist-Carbine)" hidden="false" collective="false" import="true" targetId="bd8c-ea91-6637-782a" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1437-8ed3-8881-b729" type="max"/>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98d9-6536-8783-3447" type="min"/>
-                  </constraints>
-                </entryLink>
+                <entryLink id="48d1-076c-5be6-fabe" name="Prime Brothers 1 - Upgrade List L (single unit)" hidden="false" collective="false" import="true" targetId="6281-9b77-c683-ecc6" type="selectionEntryGroup"/>
+                <entryLink id="b206-df28-e151-defa" name="** Detachment Upgrade (Units of [3] with Tough(3), single unit) **" hidden="false" collective="false" import="true" targetId="46f0-6405-967e-2938" type="selectionEntryGroup"/>
               </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
             </selectionEntry>
-            <selectionEntry id="11ec-814e-1b4e-d575" name="Fist-Flamethrowers" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="5099-b698-a625-954a" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="c12e-2816-028f-eebc" name="Aggro Brother (Fist-Flamethrower)" hidden="false" collective="false" import="true" targetId="7b57-52b0-8562-2982" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30b0-bec7-5a2c-ca9c" type="max"/>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a78b-2ac7-a501-5293" type="min"/>
-                  </constraints>
-                </entryLink>
+                <entryLink id="3353-7c81-24d6-de9f" name="Prime Brothers 1 - Upgrade List L (combined unit)" hidden="false" collective="false" import="true" targetId="7211-cfb0-c179-d90a" type="selectionEntryGroup"/>
+                <entryLink id="1cb1-9800-55a1-aff2" name="** Detachment Upgrade (Units of [3] with Tough(3), combined unit) **" hidden="false" collective="false" import="true" targetId="50d3-a71e-21c6-e4d1" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="b4a5-f093-9091-5f0a" name="Upgrade all models with:" hidden="false" collective="false" import="true">
-          <selectionEntries>
-            <selectionEntry id="4c31-7bbb-4114-7719" name="Grenade Launchers" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55fe-18b7-4396-eac8" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="45ca-f9ce-24c1-2c64" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="2e14-dd3a-e262-3f43" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce35-f532-c5ed-6741" type="max"/>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0000-2a4a-ab95-c15d" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="345.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="01f6-f627-82f1-f422" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="8b23-93ad-6700-f700" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="0e13-7c7c-056f-0f64" name="Wolf Brothers - Counter-Attack" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="942a-9999-b15b-fafd" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-      </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="345.0"/>
       </costs>
@@ -14540,18 +14449,18 @@
     </selectionEntryGroup>
     <selectionEntryGroup id="eac9-917e-02f5-35d0" name="Prime Brothers 1 - Upgrade List K (single unit)" hidden="false" collective="false" import="true">
       <selectionEntryGroups>
-        <selectionEntryGroup id="5587-44ca-2af2-e47b" name="Replace all Plasma Carbines:" hidden="false" collective="false" import="true" defaultSelectionEntryId="f6d7-d427-a0de-0877">
+        <selectionEntryGroup id="5587-44ca-2af2-e47b" name="Replace all 2x Plasma Carbines:" hidden="false" collective="false" import="true" defaultSelectionEntryId="f6d7-d427-a0de-0877">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3c6-7a5d-f17e-a686" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be5f-a73d-5ceb-304e" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="f6d7-d427-a0de-0877" name="Plasma Carbines" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="f6d7-d427-a0de-0877" name="2x Plasma Carbines" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
                 <entryLink id="8697-9e7b-0a6d-4d21" name="Plasma Carbine" hidden="false" collective="false" import="true" targetId="6adc-a2b8-8cec-3fa6" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="545f-1a9b-9087-06ce" type="min"/>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e0e-d054-a189-1abe" type="max"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="545f-1a9b-9087-06ce" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e0e-d054-a189-1abe" type="max"/>
                   </constraints>
                 </entryLink>
                 <entryLink id="752d-d4b4-af7c-eca6" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
@@ -14562,7 +14471,7 @@
                 </entryLink>
               </entryLinks>
             </selectionEntry>
-            <selectionEntry id="aca5-a366-024b-b4dc" name="Assault Carbines" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="aca5-a366-024b-b4dc" name="2x Assault Carbines" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
                 <entryLink id="f884-092f-5661-a91a" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
                   <constraints>
@@ -14572,8 +14481,8 @@
                 </entryLink>
                 <entryLink id="a43b-fcc4-ab7b-44da" name="Assault Carbine" hidden="false" collective="false" import="true" targetId="14bf-1db5-882f-d03d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="623d-a2e6-d5f1-7ae4" type="min"/>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c5f-192d-1ded-8c48" type="max"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="623d-a2e6-d5f1-7ae4" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c5f-192d-1ded-8c48" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -14587,18 +14496,18 @@
     </selectionEntryGroup>
     <selectionEntryGroup id="c3be-3b74-0be6-b173" name="Prime Brothers 1 - Upgrade List K (combined unit)" hidden="false" collective="false" import="true">
       <selectionEntryGroups>
-        <selectionEntryGroup id="e4c6-280b-9f73-e5ce" name="Replace all Plasma Carbines:" hidden="false" collective="false" import="true" defaultSelectionEntryId="9f6e-c1ca-fb59-2951">
+        <selectionEntryGroup id="e4c6-280b-9f73-e5ce" name="Replace all 2x Plasma Carbines:" hidden="false" collective="false" import="true" defaultSelectionEntryId="9f6e-c1ca-fb59-2951">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f42-6a6d-6dd9-a88d" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84a2-0774-2b8a-099c" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="9f6e-c1ca-fb59-2951" name="Plasma Carbines" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="9f6e-c1ca-fb59-2951" name="2x Plasma Carbines" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
                 <entryLink id="a240-6db6-b8f3-29bf" name="Plasma Carbine" hidden="false" collective="false" import="true" targetId="6adc-a2b8-8cec-3fa6" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f16-19f6-ba41-d809" type="min"/>
-                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4746-acb2-c03a-3944" type="max"/>
+                    <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f16-19f6-ba41-d809" type="min"/>
+                    <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4746-acb2-c03a-3944" type="max"/>
                   </constraints>
                 </entryLink>
                 <entryLink id="b2c4-9c93-f7cc-cfc1" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
@@ -14609,7 +14518,7 @@
                 </entryLink>
               </entryLinks>
             </selectionEntry>
-            <selectionEntry id="b860-c16c-ba4f-0bfe" name="Assault Carbines" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="b860-c16c-ba4f-0bfe" name="2x Assault Carbines" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
                 <entryLink id="236f-fb55-e478-48e1" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
                   <constraints>
@@ -14619,8 +14528,8 @@
                 </entryLink>
                 <entryLink id="e0c7-5194-618e-b511" name="Assault Carbine" hidden="false" collective="false" import="true" targetId="14bf-1db5-882f-d03d" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be8c-d965-24ee-c226" type="min"/>
-                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5160-7821-595e-344d" type="max"/>
+                    <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be8c-d965-24ee-c226" type="min"/>
+                    <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5160-7821-595e-344d" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -14631,6 +14540,188 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="6281-9b77-c683-ecc6" name="Prime Brothers 1 - Upgrade List L (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d9b7-8b05-9605-4836" name="Replace all 2x Fist-Carbines:" hidden="false" collective="false" import="true" defaultSelectionEntryId="c91d-7177-fad5-a668">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7fc4-1372-2ec0-4ab8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a58b-4d9b-3009-c4b7" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="c91d-7177-fad5-a668" name="2x Fist-Carbines" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="08f9-bba6-a60a-f0fa" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c41d-1bed-1119-b98b" type="min"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bc3-af20-7916-3d2a" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="244e-6bf3-c28c-9825" name="Fist-Carbine" hidden="false" collective="false" import="true" targetId="d984-2f6e-718a-0ff7" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa8f-217b-df09-fc94" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="130f-abb6-9ee6-55f3" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="8699-a033-bb8b-eabe" name="2x Fist-Flamethrowers" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="1891-b911-8c65-9ceb" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b020-583b-157a-fbb9" type="min"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7d3-ea54-9c3a-d84e" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="507e-3b39-b870-79d0" name="Fist-Flamethrower" hidden="false" collective="false" import="true" targetId="efce-8bcd-f1d3-20ca" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a17-03a1-a181-7947" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02e6-061f-5ce1-41b0" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="daed-1425-8cfa-281f" name="Upgrade all models with:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="f3a9-4a3c-1d0b-c22d" name="Grenade Launchers" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9043-a5d1-3244-1484" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="204e-1aa8-cf63-8efc" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="e089-6dd6-ec4e-12e6" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6717-957f-290e-f3c3" type="min"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a79d-eb9c-5b88-b55e" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="7211-cfb0-c179-d90a" name="Prime Brothers 1 - Upgrade List L (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2729-3263-b453-6101" name="Replace all 2x Fist-Carbines:" hidden="false" collective="false" import="true" defaultSelectionEntryId="0108-e93d-c824-927f">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="580e-5b95-c516-e265" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0360-e011-2489-7d7d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="0108-e93d-c824-927f" name="2x Fist-Carbines" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="2bba-10a0-09f8-7209" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77cc-0b2e-e0e1-f45a" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8a1-2f2c-10f2-6e2e" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="7771-5eb0-b525-536d" name="Fist-Carbine" hidden="false" collective="false" import="true" targetId="d984-2f6e-718a-0ff7" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8509-5f67-8075-ffa6" type="min"/>
+                    <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6383-2992-f09d-67f8" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="31f3-3381-2d80-d2c0" name="2x Fist-Flamethrowers" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="7a54-5f40-6040-5479" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="563c-951e-3a50-8fd2" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8e0-9262-21f9-b679" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="9981-4f0d-dc8b-c1a4" name="Fist-Flamethrower" hidden="false" collective="false" import="true" targetId="efce-8bcd-f1d3-20ca" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="083d-135b-918a-5a39" type="min"/>
+                    <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cf0-d4e8-03a2-91ed" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="748b-5f6d-de23-d5f2" name="Upgrade all models with:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="014f-bcc9-dedf-f22d" name="Grenade Launchers" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ddc3-0f4f-7e3c-6e95" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="4d9c-deb5-f0e9-7892" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="e089-6dd6-ec4e-12e6" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6af7-a776-09a7-2d65" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85fb-3478-94c4-d1b0" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="46f0-6405-967e-2938" name="** Detachment Upgrade (Units of [3] with Tough(3), single unit) **" hidden="false" collective="false" import="true">
+      <entryLinks>
+        <entryLink id="8468-b8ea-433c-e7e3" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="0501-55a1-c826-54f1" name="Wolf Brothers - Counter" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="a3b4-0a95-6b0a-8ebb" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="2543-5660-49ae-deab" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+          </costs>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="50d3-a71e-21c6-e4d1" name="** Detachment Upgrade (Units of [3] with Tough(3), combined unit) **" hidden="false" collective="false" import="true">
+      <entryLinks>
+        <entryLink id="52f3-1b49-84f5-887d" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="6b55-cd09-cb07-60f9" name="Wolf Brothers - Counter" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="fe3d-c679-a034-cf91" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="49d5-b0ae-bbf0-cf27" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
+          </costs>
+        </entryLink>
+      </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -219,7 +219,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="63b8-b003-a5cf-d91a" name="New CategoryLink" hidden="false" targetId="b820-6309-e900-c733" primary="true"/>
+        <categoryLink id="1754-c7bb-c1b0-bbaf" name="New CategoryLink" hidden="false" targetId="7528-ccdf-679c-8613" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="50f0-e847-8db4-c8c3" name="Attack Speeder" hidden="false" collective="false" import="true" targetId="f18f-cd4e-3bf2-e502" type="selectionEntry">
@@ -1637,112 +1637,11 @@
         <infoLink id="d368-677a-419a-c513" name="Transport(X)" hidden="false" targetId="3460-57e3-8a15-7977" type="rule"/>
         <infoLink id="ce81-238a-1de9-a418" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="3173-2797-e14c-4a0c" name="Upgrades" hidden="false" collective="false" import="true">
-          <entryLinks>
-            <entryLink id="59ff-abe6-e8a4-c677" name="Dozer Blade" hidden="false" collective="false" import="true" targetId="5dc2-4ac8-2769-e4ba" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6efd-f90f-70f3-5808" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="5baf-6dfc-23dd-d7f9" name="Hunter Missile" hidden="false" collective="false" import="true" targetId="c756-9c2d-beca-986c" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c26a-faaa-2b3e-21f8" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="2ca0-660d-1a0a-089c" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b9d-80aa-3b8a-a5af" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="a06f-e2e3-56e8-9514" name="Heavy Fusion Rifle" hidden="false" collective="false" import="true" targetId="a5f5-d44a-03b0-9a99" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd16-2d66-ce29-53d0" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="c670-e1d6-aec7-7229" name="Weapons - Hull" hidden="false" collective="false" import="true" defaultSelectionEntryId="0f18-c6ed-99cd-a449">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fab-4b64-c606-f508" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e49-6326-907d-d110" type="min"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="0f18-c6ed-99cd-a449" name="Twin Heavy Machinegun" hidden="false" collective="false" import="true" targetId="dae8-3106-6a96-228c" type="selectionEntry"/>
-            <entryLink id="5778-f3c7-f9d8-fa0c" name="Twin Minigun" hidden="false" collective="false" import="true" targetId="a8f7-27d2-59eb-c865" type="selectionEntry"/>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="9915-98d8-dc6c-f22e" name="Weapons - Sponsons" hidden="false" collective="false" import="true" defaultSelectionEntryId="55d8-ab7c-c1b0-0896">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0c7-22fd-eff9-bf19" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="704f-d3d2-2252-548c" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="55d8-ab7c-c1b0-0896" name="2x Assault Rifle Array" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="5346-e990-ac26-89d5" name="Assault Rifle Array" hidden="false" collective="false" import="true" targetId="faa1-761d-0d50-2135" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f16-c770-2d2a-1ab5" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4750-478a-9691-4fe8" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="3ddc-cc1e-a9fd-6812" name="2x Flamethrower Cannons" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="fcbe-09fe-5a46-66e2" name="Flamethrower Cannon" hidden="false" collective="false" import="true" targetId="f587-2140-510e-48b8" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f77-2ae5-acf6-1ae1" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ef0-9f9a-fd99-4577" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="db79-107b-76f4-ce4f" name="2x Twin Laser Cannons" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="ae5c-e36a-d3e9-707c" name="Twin Laser Cannon" hidden="false" collective="false" import="true" targetId="d271-2d81-e640-0040" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f41-0cd6-eadc-bee4" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea4e-f6c2-e544-f0d2" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="145.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="4e07-b81e-9201-0bcf" name="Blood Brothers - Very Fast" hidden="false" collective="false" import="true" targetId="ec17-0396-1d9d-0ad9" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="0738-2935-ba29-9afe" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="55.0"/>
-          </costs>
-        </entryLink>
+        <entryLink id="29b9-ba49-77ac-0219" name="** Detachment Upgrade (Units of [1] with Tough(18) &amp; Fast) **" hidden="false" collective="false" import="true" targetId="ad75-3b37-3d15-05f7" type="selectionEntryGroup"/>
+        <entryLink id="2785-568c-b915-3a7e" name="Battle Brothers 3 - Upgrade List A" hidden="false" collective="false" import="true" targetId="9a2d-b4b4-997a-7075" type="selectionEntryGroup"/>
+        <entryLink id="4123-a80f-932b-d6d8" name="Battle Brothers 3 - Upgrade List B" hidden="false" collective="false" import="true" targetId="6d58-cfaf-3917-e973" type="selectionEntryGroup"/>
+        <entryLink id="746d-6ead-c56a-4290" name="Battle Brothers 3 - Upgrade List D" hidden="false" collective="false" import="true" targetId="06b6-6506-997c-ebae" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="580.0"/>
@@ -14111,6 +14010,102 @@
           </costs>
         </entryLink>
       </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="ad75-3b37-3d15-05f7" name="** Detachment Upgrade (Units of [1] with Tough(18) &amp; Fast) **" hidden="false" collective="false" import="true">
+      <entryLinks>
+        <entryLink id="fcc0-3332-3957-6515" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="9205-cd01-d9ad-2df2" name="Blood Brothers - Very Fast" hidden="false" collective="false" import="true" targetId="ec17-0396-1d9d-0ad9" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="d10f-42f1-0d88-f5cb" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="55.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="5978-450e-b702-79f3" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="9073-fb47-883f-6644" name="Wolf Brothers - Counter" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+          </costs>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="06b6-6506-997c-ebae" name="Battle Brothers 3 - Upgrade List D" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="be87-18e5-8947-acb2" name="Replace 2x Assault Rifle Arrays:" hidden="false" collective="false" import="true" defaultSelectionEntryId="d32f-fdf2-7473-f7a7">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14c9-d990-8c37-a829" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c874-237d-8b0b-b33d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="d32f-fdf2-7473-f7a7" name="2x Assault Rifle Arrays" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="153c-b90f-968d-25ba" name="Assault Rifle Array" hidden="false" collective="false" import="true" targetId="faa1-761d-0d50-2135" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b82-5ebc-fa23-5899" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a209-fd60-dab1-7057" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="6c22-65b8-e8cd-281e" name="2x Flamethrower Cannons" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="87db-c8e5-b4bc-d7fc" name="Flamethrower Cannon" hidden="false" collective="false" import="true" targetId="f587-2140-510e-48b8" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0e9-ed96-8b4d-70c9" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="592a-8ab3-0b35-471f" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="e81d-17f8-8c54-06be" name="2x Twin Laser Cannons" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="bf66-f14b-178f-244e" name="Twin Laser Cannon" hidden="false" collective="false" import="true" targetId="d271-2d81-e640-0040" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f1a-a4df-948e-3654" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2157-5652-1e54-49ba" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="145.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f76c-369f-36da-f0d8" name="Replace Twin Heavy Machinegun:" hidden="false" collective="false" import="true" defaultSelectionEntryId="0f4c-8f61-452f-ac26">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64d4-997f-209f-ff71" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4254-61d6-ba03-9119" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="0f4c-8f61-452f-ac26" name="Twin Heavy Machinegun" hidden="false" collective="false" import="true" targetId="dae8-3106-6a96-228c" type="selectionEntry"/>
+            <entryLink id="c5fe-250b-f6dd-07cd" name="Twin Minigun" hidden="false" collective="false" import="true" targetId="a8f7-27d2-59eb-c865" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2214-68bf-9265-caa8" name="Upgrade with:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="dcc7-67fb-d0b2-7e14" name="Heavy Fusion Rifle" hidden="false" collective="false" import="true" targetId="a5f5-d44a-03b0-9a99" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1087-7fb2-95e2-9466" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -932,6 +932,11 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="4260-efb1-e48e-399a" name="**Army Selection**" hidden="false" collective="false" import="true" targetId="817b-3644-0181-0296" type="selectionEntry"/>
+    <entryLink id="cbce-109e-21af-bf73" name="Prime ATV" hidden="false" collective="false" import="true" targetId="b75e-8917-0c3a-cd0c" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="b84a-b94c-4967-2bc4" name="Vehicles: Light" hidden="false" targetId="3089-78fc-94cc-28a2" primary="true"/>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="40e7-3f33-f159-d98d" name="Captain" hidden="false" collective="false" import="true" type="upgrade">
@@ -8544,6 +8549,34 @@
         <infoLink id="506d-0a1f-f5a3-5230" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
       </infoLinks>
     </selectionEntry>
+    <selectionEntry id="b75e-8917-0c3a-cd0c" name="Prime ATV" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="0d13-8a3c-d068-364a" name="Prime ATV" hidden="false" targetId="efc7-5581-a556-6b60" type="profile"/>
+        <infoLink id="eb4b-0445-e337-bc44" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
+        <infoLink id="4776-fb5d-7068-9522" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
+        <infoLink id="59c6-7e97-d7bd-c8a9" name="Prime" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
+        <infoLink id="d168-5573-dc9a-8e8a" name="Strider" hidden="false" targetId="9dea-b566-200a-0605" type="rule"/>
+        <infoLink id="959d-591b-e8bc-29d9" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
+      </infoLinks>
+      <entryLinks>
+        <entryLink id="a87f-7c10-1969-865a" name="Twin Auto-Rifles" hidden="false" collective="false" import="true" targetId="ad7f-7129-2854-846e" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82d0-5a47-9630-f05e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d412-bf6e-7101-247c" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="37da-baef-64cf-e56b" name="Prime Brothers 1 - Upgrade List N" hidden="false" collective="false" import="true" targetId="c2f5-9c2c-17d4-499e" type="selectionEntryGroup"/>
+        <entryLink id="7d07-c550-1268-a687" name="** Detachment Upgrade (Units of [1] with Tough(3)) **" hidden="false" collective="false" import="true" targetId="fcc5-ad77-d73a-2161" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="170.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ad7f-7129-2854-846e" name="Twin Auto-Rifles" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="863d-e38f-3218-985d" name="Twin Auto-Rifles" hidden="false" targetId="4c65-274d-2ab1-dc68" type="profile"/>
+      </infoLinks>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="763b-1230-bcad-b19d" name="Battle Brothers 1 - Upgrade List A (single unit)" hidden="false" collective="false" import="true" defaultSelectionEntryId="4323-8b88-efda-e548">
@@ -14619,6 +14652,24 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>
+    <selectionEntryGroup id="c2f5-9c2c-17d4-499e" name="Prime Brothers 1 - Upgrade List N" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5820-cc97-3ac8-01e6" name="Replace Gatling Gun:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ed27-df77-04dc-d709">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da7a-3a26-03be-a649" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0224-bfc9-82e9-233c" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="ed27-df77-04dc-d709" name="Gatling Gun" hidden="false" collective="false" import="true" targetId="2680-ae75-416d-93ea" type="selectionEntry"/>
+            <entryLink id="8b28-b7a1-c259-6400" name="Heavy Fusion Rifle" hidden="false" collective="false" import="true" targetId="a5f5-d44a-03b0-9a99" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
     <rule id="ff04-8ef9-82f1-a88b" name="Shield Wall" publicationId="dead-6af1-a069-5579" hidden="false">
@@ -16421,6 +16472,20 @@
     <profile id="ad96-9919-18eb-26bc" name="Orbital Deployment" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
       <characteristics>
         <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Ambush</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="efc7-5581-a556-6b60" name="Prime ATV" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
+      <characteristics>
+        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">3+</characteristic>
+        <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">2+</characteristic>
+        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fast, Impact(3), Prime, Strider, Tough(3)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="4c65-274d-2ab1-dc68" name="Twin Auto-Rifles" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="79f4-5578-c041-f866">24&quot;</characteristic>
+        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A6	</characteristic>
+        <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -3689,67 +3689,6 @@
         <infoLink id="571d-01d8-09e8-19ad" name="Wolf Jet" hidden="false" targetId="7e56-8e44-3706-40a3" type="profile"/>
         <infoLink id="4629-90ba-0381-21bd" name="Aircraft" hidden="false" targetId="187f-6a03-5b99-a4db" type="rule"/>
       </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="386c-ccc4-e258-1302" name="Transport(11)" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e590-9223-89d5-2429" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="57be-2b70-39fd-3926" name="Transport(X)" hidden="false" targetId="3460-57e3-8a15-7977" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="581e-1ee2-3868-4e2d" name="Upgrades" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34e3-22ec-8be3-f902" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="5905-31e7-ee0d-85fe" name="Hammer Missiles" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="ddd1-9702-7d9f-dc1a" name="Hammer Missiles" hidden="false" collective="false" import="true" targetId="2b23-f91f-8f74-d7d9" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c273-35d4-a2f5-5bcd" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fa8-7a1a-16e9-d618" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="64fc-ab82-a21f-a151" name="2x Twin Heavy Machineguns" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="b181-a279-0226-c45d" name="Twin Heavy Machinegun" hidden="false" collective="false" import="true" targetId="dae8-3106-6a96-228c" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9af-4048-b8c4-0f54" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e775-53bc-e4fa-249f" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="110.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8a5b-c196-604d-9677" name="2x Twin Heavy Fusion Rifles" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="da4b-f5bd-770a-2dfc" name="Twin Heavy Fusion Rifle" hidden="false" collective="false" import="true" targetId="7837-57e0-d13e-35ab" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9aa0-3d7f-b284-81a0" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e253-b511-5a07-33fc" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="190.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="3415-bfe8-d628-8173" name="Twin Frost Cannon" hidden="false" collective="false" import="true" targetId="ed3b-99f9-16b3-467c" type="selectionEntry">
           <constraints>
@@ -3763,6 +3702,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0508-14b0-957e-ef2e" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="ce44-12af-b8d0-04a9" name="Wolf Brothers - Upgrade List K" hidden="false" collective="false" import="true" targetId="144a-b7da-4156-98d7" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="305.0"/>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -8655,154 +8655,27 @@
           </constraints>
           <selectionEntries>
             <selectionEntry id="1297-5737-affd-847e" name="Single Unit [5 models]" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="9621-32f7-d7f6-71fa" name="Upgrade one model with:" hidden="false" collective="false" import="true">
-                  <entryLinks>
-                    <entryLink id="e030-af12-eed7-2abf" name="Medical Training" hidden="false" collective="false" import="true" targetId="8352-cbe6-9410-a422" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06fd-137c-a4ae-b3ca" type="max"/>
-                      </constraints>
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="45.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="b1b3-f6e9-23e4-bb4e" name="Prime Assault Brothers" hidden="false" collective="false" import="true">
-                  <selectionEntryGroups>
-                    <selectionEntryGroup id="3b6e-fbbe-2b95-70aa" name="Ranged Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="70f2-c7b9-7d9f-e9ba">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="215a-0e9f-3154-01be" type="min"/>
-                        <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2efe-37a9-968a-7b2e" type="max"/>
-                      </constraints>
-                      <entryLinks>
-                        <entryLink id="70f2-c7b9-7d9f-e9ba" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7625-8072-bb45-d626" type="max"/>
-                            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e239-fab3-9e67-9f99" type="min"/>
-                          </constraints>
-                        </entryLink>
-                        <entryLink id="1785-6eeb-ca6f-76fb" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59ed-7341-cc88-d5f7" type="max"/>
-                          </constraints>
-                          <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                          </costs>
-                        </entryLink>
-                      </entryLinks>
-                    </selectionEntryGroup>
-                  </selectionEntryGroups>
-                  <entryLinks>
-                    <entryLink id="2fae-87e9-ee37-c2a8" name="CCW (A3)" hidden="false" collective="false" import="true" targetId="f2c6-3cc8-1ad8-6e26" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18d8-57a6-a03a-0846" type="min"/>
-                        <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df51-fe9b-dff2-d289" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="41e2-da03-5062-5808" name="Detachment Upgrade" hidden="false" collective="false" import="true">
-                  <entryLinks>
-                    <entryLink id="a23f-f1a7-b4fa-35e3" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="7ebf-1379-8429-d89b" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="4161-d5db-b90b-7980" name="Wolf Brothers - Counter" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="185.0"/>
-              </costs>
+              <entryLinks>
+                <entryLink id="2d4e-523d-3871-ba8b" name="Prime Brothers 1 - Upgrade List F (single unit)" hidden="false" collective="false" import="true" targetId="d9c6-4b93-f479-db17" type="selectionEntryGroup"/>
+                <entryLink id="05ec-96b0-bcff-90c9" name="Prime Brothers 1 - Upgrade List E (single unit)" hidden="false" collective="false" import="true" targetId="0bb9-e22c-0855-349c" type="selectionEntryGroup"/>
+                <entryLink id="9a28-8079-acf5-e272" name="** Detachment Upgrade (Units of [5], single unit) **" hidden="false" collective="false" import="true" targetId="f024-6c76-c658-300a" type="selectionEntryGroup"/>
+              </entryLinks>
             </selectionEntry>
             <selectionEntry id="406c-16fb-4b4b-585a" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="bb1a-db24-53d7-8fab" name="Upgrade up to two models with:" hidden="false" collective="false" import="true">
-                  <entryLinks>
-                    <entryLink id="7416-5408-a9b9-7d85" name="Medical Training" hidden="false" collective="false" import="true" targetId="8352-cbe6-9410-a422" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4196-673a-4018-4359" type="max"/>
-                      </constraints>
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="45.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="440f-f95a-3c5c-9904" name="Prime Assault Brothers" hidden="false" collective="false" import="true">
-                  <selectionEntryGroups>
-                    <selectionEntryGroup id="659e-fc93-d649-0b16" name="Ranged Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="2340-bf00-ff61-0a19">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c01d-1c0d-ce9e-1740" type="min"/>
-                        <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="740a-939e-f420-ce5a" type="max"/>
-                      </constraints>
-                      <entryLinks>
-                        <entryLink id="2340-bf00-ff61-0a19" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0835-a37e-b85c-e48f" type="max"/>
-                            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48ae-3aa7-dbfa-ba1b" type="min"/>
-                          </constraints>
-                        </entryLink>
-                        <entryLink id="7246-5677-3548-28d0" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13a5-4f82-5cc4-e3e6" type="max"/>
-                          </constraints>
-                          <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                          </costs>
-                        </entryLink>
-                      </entryLinks>
-                    </selectionEntryGroup>
-                  </selectionEntryGroups>
-                  <entryLinks>
-                    <entryLink id="af89-36f4-39e6-cb7b" name="CCW (A3)" hidden="false" collective="false" import="true" targetId="f2c6-3cc8-1ad8-6e26" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a85-5fcb-c609-1a61" type="min"/>
-                        <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa56-d031-5ec3-09db" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="2681-a249-6155-61b5" name="Detachment Upgrade" hidden="false" collective="false" import="true">
-                  <entryLinks>
-                    <entryLink id="d824-fbcc-10b2-b10b" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="df32-86f3-2e42-8027" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="259b-80ae-651c-ad12" name="Wolf Brothers - Counter" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="70bb-d453-ac26-559a" name="Prime Brothers 1 - Upgrade List F (combined unit)" hidden="false" collective="false" import="true" targetId="5949-bd89-8a64-02f2" type="selectionEntryGroup"/>
+                <entryLink id="059f-cad2-4122-8965" name="Prime Brothers 1 - Upgrade List E (combined unit)" hidden="false" collective="false" import="true" targetId="1ad2-e3d2-1485-cc14" type="selectionEntryGroup"/>
+                <entryLink id="3c16-02c1-3e90-9858" name="** Detachment Upgrade (Units of [5], combined unit) **" hidden="false" collective="false" import="true" targetId="3ed3-d384-8a43-eb07" type="selectionEntryGroup"/>
+              </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="370.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="185.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="185.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="262a-3a6e-424e-b887" name="Energy Sword (Guards)" hidden="false" collective="true" import="true" type="upgrade">
@@ -14215,6 +14088,132 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="0bb9-e22c-0855-349c" name="Prime Brothers 1 - Upgrade List E (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3f4d-7699-1f19-c443" name="Upgrade one model with:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94da-fe1e-38a5-9612" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="83e8-a84f-fd8d-66ef" name="Medical Training" hidden="false" collective="false" import="true" targetId="8352-cbe6-9410-a422" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="45.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="1ad2-e3d2-1485-cc14" name="Prime Brothers 1 - Upgrade List E (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6c9d-48ba-9b16-43ca" name="Upgrade two models with:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d46-b9de-61ca-09fd" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="ebb7-fea5-3af6-592a" name="Medical Training" hidden="false" collective="false" import="true" targetId="8352-cbe6-9410-a422" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="45.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="d9c6-4b93-f479-db17" name="Prime Brothers 1 - Upgrade List F (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="cadd-a955-d622-5d85" name="Pistols" hidden="false" collective="false" import="true" defaultSelectionEntryId="0c23-3666-200e-7bd9">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d74-ff64-1f0c-6ee7" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b26a-0405-85c4-b35a" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="661e-c473-e1d0-3637" name="Replace one Pistol:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38a5-3b9f-8d10-8525" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="4bee-bdd8-11c7-6166" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="0c23-3666-200e-7bd9" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ee3f-3937-f931-520f" name="Upgrade all models with:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="5a05-9507-300b-25ee" name="Veteran Infantry" hidden="false" collective="false" import="true" targetId="c1fc-c830-141f-e36e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3771-a0d9-dbc6-4dce" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="4fb9-72d7-d601-7a8a" name="CCW (A3)" hidden="false" collective="false" import="true" targetId="f2c6-3cc8-1ad8-6e26" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea10-c541-b23e-daed" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9917-362b-195a-951c" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="5949-bd89-8a64-02f2" name="Prime Brothers 1 - Upgrade List F (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="427e-13c0-09db-58c4" name="Pistols" hidden="false" collective="false" import="true" defaultSelectionEntryId="fe85-a0e3-cdab-d99b">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01ff-caf8-3ca1-9893" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2076-1e4b-eb95-4cd9" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="d84a-9cea-9c6a-fae3" name="Replace two Pistols:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7fa0-0a16-f4b2-180a" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="d6b5-8f28-efb0-7f96" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="fe85-a0e3-cdab-d99b" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e4fd-a313-f158-9e70" name="Upgrade all models with:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="690b-f9e9-0944-df74" name="Veteran Infantry" hidden="false" collective="false" import="true" targetId="c1fc-c830-141f-e36e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1c4-8a65-b9fd-c1aa" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="100.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="cdb0-c63d-0985-5374" name="CCW (A3)" hidden="false" collective="false" import="true" targetId="f2c6-3cc8-1ad8-6e26" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b05a-af4b-09c1-f52c" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4215-6c5b-eb89-9c9c" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -2639,6 +2639,9 @@
               <entryLinks>
                 <entryLink id="9013-6690-b27d-d3e4" name="Watch Brothers - Upgrade List B (single unit)" hidden="false" collective="false" import="true" targetId="24cd-b48f-b0d1-9e48" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="f8e8-de82-87c2-065e" name="Combined Unit [10 model]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -2674,6 +2677,9 @@
               <entryLinks>
                 <entryLink id="d82b-d9ff-29fe-ac6e" name="Watch Brothers - Upgrade List C (single unit)" hidden="false" collective="false" import="true" targetId="4319-a3c9-e906-58cb" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="87ce-21a4-1eac-ebfb" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -3079,6 +3085,9 @@
                 <entryLink id="83e8-e517-7a17-0e98" name="Knight Brothers - Upgrade List B (single unit)" hidden="false" collective="false" import="true" targetId="6297-b2b8-a562-607f" type="selectionEntryGroup"/>
                 <entryLink id="5064-436f-43bc-9836" name="Knight Brothers - Upgrade List E (single unit)" hidden="false" collective="false" import="true" targetId="c413-23dc-124c-d1e5" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="9074-5e7c-f641-f9f5" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -3116,6 +3125,9 @@
                 <entryLink id="f374-9a61-aaac-1764" name="Knight Brothers - Upgrade List C (single unit)" hidden="false" collective="false" import="true" targetId="745a-57a6-863e-226e" type="selectionEntryGroup"/>
                 <entryLink id="f2ff-f460-b87f-c98f" name="Knight Brothers - Upgrade List E (single unit)" hidden="false" collective="false" import="true" targetId="c413-23dc-124c-d1e5" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="ecea-56a5-0649-cb7f" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -3154,6 +3166,9 @@
                 <entryLink id="6bbf-ad87-08c4-b104" name="Knight Brothers - Upgrade List E (single unit)" hidden="false" collective="false" import="true" targetId="c413-23dc-124c-d1e5" type="selectionEntryGroup"/>
                 <entryLink id="2756-c327-8ed1-24a8" name="Knight Brothers - Upgrade List D (single unit)" hidden="false" collective="false" import="true" targetId="8f26-05e3-fe29-7e49" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="fb00-036c-80b9-2715" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -3372,6 +3387,9 @@
                 <entryLink id="c9dc-c6d7-3b2d-dee1" name="Wolf Brothers - Upgrade List A (single unit)" hidden="false" collective="false" import="true" targetId="d882-5701-85b1-d209" type="selectionEntryGroup"/>
                 <entryLink id="6804-e546-91e4-67ab" name="Wolf Brothers - Upgrade List C (single unit)" hidden="false" collective="false" import="true" targetId="af3b-9e7e-0448-ab7e" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="69f7-5cb6-de6e-ecc8" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -3408,6 +3426,9 @@
                 <entryLink id="3ba9-6411-f5dd-214d" name="Wolf Brothers - Upgrade List C (single unit)" hidden="false" collective="false" import="true" targetId="af3b-9e7e-0448-ab7e" type="selectionEntryGroup"/>
                 <entryLink id="0644-6f80-1e48-0531" name="Wolf Brothers - Upgrade List D (single unit)" hidden="false" collective="false" import="true" targetId="4e1f-09a7-914a-8301" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="ad85-6096-609a-aa93" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -3445,6 +3466,9 @@
               <entryLinks>
                 <entryLink id="0d65-b230-6a9a-6897" name="Wolf Brothers - Upgrade List E (single unit)" hidden="false" collective="false" import="true" targetId="7477-ff5c-6f4e-4a94" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="5af2-d371-87fa-31c1" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -3470,173 +3494,35 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="195f-d182-f268-2b20" name="Wolf Destroyer" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="755a-e4c3-4679-b56d" name="Wolf Destroyer" hidden="false" targetId="01b6-2903-ae07-393a" type="profile"/>
-        <infoLink id="a6c8-d92f-45e7-e273" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
-        <infoLink id="3e23-ee4d-af58-ffe3" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="f41f-59bf-a43c-8c8e" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
-        <infoLink id="be57-7f97-2d29-6e49" name="Counter-Attack" hidden="false" targetId="5c24-d8ee-b4ed-4c8d" type="rule"/>
-      </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="81fc-b9b6-bc3e-7357" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="bc2a-ae2f-9770-1f9c">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e73b-f2bc-f7b2-099a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7961-cf3a-33ad-7c9f" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="bc2a-ae2f-9770-1f9c" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry"/>
-            <entryLink id="8623-33d2-a723-0c10" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="7bb6-f6f7-ede7-1772" name="Chainsaw Fist" hidden="false" collective="false" import="true" targetId="ee7c-53ab-fcc5-afdb" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="f1aa-4ea1-13b9-086c" name="Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="8795-9eee-bc88-e9f0">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e634-6be6-4039-581a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="997f-1516-17f3-dfe0" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="8795-9eee-bc88-e9f0" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry"/>
-            <entryLink id="6ba2-f053-7991-691a" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="3b25-b889-c821-0d75" name="Assault Rifle Attachment" hidden="false" collective="false" import="true">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e078-0444-3218-1871" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="1a29-6ec1-72b5-26b5" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="cebe-3c98-3c3c-036c" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="b639-1b4a-ee82-f52f" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="-5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="bc60-ab86-b697-ecb6" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="f1fb-7a54-d665-bcb8" name="Minigun" hidden="false" collective="false" import="true" targetId="7b99-9f38-072e-e027" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="55c6-7512-ca80-929d" name="Wolf Destroyer (Hammer &amp; Shield)" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="872f-c46f-95d6-5043" name="Wolf Destroyer" hidden="false" targetId="01b6-2903-ae07-393a" type="profile"/>
-        <infoLink id="4290-7262-7234-71e4" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
-        <infoLink id="a50a-1bed-69c7-bfc7" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="869f-f7d6-ae2a-3579" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
-        <infoLink id="f643-fad2-6327-a14a" name="Counter-Attack" hidden="false" targetId="5c24-d8ee-b4ed-4c8d" type="rule"/>
-      </infoLinks>
-      <entryLinks>
-        <entryLink id="76ac-9879-c35b-b674" name="Combat Shield" hidden="false" collective="false" import="true" targetId="f5b9-642f-6bfe-ce58" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d8f-a4cb-64ef-5a47" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ef4-c621-97e9-e3db" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="0892-7bb7-f376-146b" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ecd-9f59-95e1-9b62" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0474-1b84-6f57-df1e" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="62c2-f1ea-72ee-01f2" name="Wolf Destroyers" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="7861-a9de-e9d7-d7f3" name="Wolf Destroyer" hidden="false" targetId="01b6-2903-ae07-393a" type="profile"/>
+        <infoLink id="d329-c351-59a2-848b" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
+        <infoLink id="a8d2-de47-b3aa-bf13" name="Counter" hidden="false" targetId="5c24-d8ee-b4ed-4c8d" type="rule"/>
+        <infoLink id="7012-7a73-ec02-2f32" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
+        <infoLink id="7a19-9d87-3658-63c5" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
+      </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="6a85-cf69-c3bb-f1e6" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="895d-de3e-7d6d-420e">
+        <selectionEntryGroup id="5c4b-66da-905b-c0d4" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="25c0-7cfc-957a-1cef">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3cb7-ece9-434b-68e9" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0df2-e5b8-36dd-f1ac" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ba0-0af3-39de-a7af" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08dd-7a1f-d382-d11f" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="895d-de3e-7d6d-420e" name="Ranged &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="25c0-7cfc-957a-1cef" name="Single Unit [5 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="fb62-6174-0876-41cf" name="Wolf Destroyer" hidden="false" collective="false" import="true" targetId="195f-d182-f268-2b20" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2b7-6ae1-6c0c-c546" type="max"/>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a3f-13fe-2578-b0b5" type="min"/>
-                  </constraints>
-                </entryLink>
+                <entryLink id="afa8-41d0-53ad-5e85" name="Wolf Brothers - Upgrade List H (single unit)" hidden="false" collective="false" import="true" targetId="cf49-d05a-67c9-f7a6" type="selectionEntryGroup"/>
               </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
             </selectionEntry>
-            <selectionEntry id="1c0f-984a-4cf3-9972" name="Energy Hammers &amp; Combat Shields" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="ae38-c84e-4a75-23c1" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="6217-e9ea-ff0c-84e4" name="Wolf Destroyer (Shields)" hidden="false" collective="false" import="true" targetId="55c6-7512-ca80-929d" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cb0-ee85-08f8-0986" type="max"/>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9eb-5282-70c4-773d" type="min"/>
-                  </constraints>
-                </entryLink>
+                <entryLink id="04d5-2fa3-861b-b8bd" name="Wolf Brothers - Upgrade List H (combined unit)" hidden="false" collective="false" import="true" targetId="8988-7da6-59b1-2f64" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="01d3-8401-3972-38cc" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="bb6d-b2c6-037b-61ed" name="Wolf Destroyer (Shields)" hidden="false" collective="false" import="true" targetId="55c6-7512-ca80-929d" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cfa-8e2d-60a6-56a9" type="max"/>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a56-c16b-2597-9089" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="495.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="8b8d-2517-bb60-60f9" name="Upgrade one model with:" hidden="false" collective="false" import="true">
-          <entryLinks>
-            <entryLink id="2372-aaeb-46ef-b5ef" name="Cyclone Missiles" hidden="false" collective="false" import="true" targetId="de20-063e-ab3f-d5cb" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0972-e4b5-6425-cb26" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
@@ -5386,26 +5272,6 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bba9-1bd4-20c7-921a" name="Wolf Destroyer (Energy Claws)" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="f91a-4a4f-afb7-09c2" name="Wolf Destroyer" hidden="false" targetId="01b6-2903-ae07-393a" type="profile"/>
-        <infoLink id="46b2-2bba-5d2b-c2a4" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
-        <infoLink id="85db-706b-52ff-ff2a" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="03b8-43b5-55ee-3f79" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
-        <infoLink id="4b07-1774-8dd6-f2ab" name="Counter-Attack" hidden="false" targetId="5c24-d8ee-b4ed-4c8d" type="rule"/>
-      </infoLinks>
-      <entryLinks>
-        <entryLink id="9887-62d8-66c3-ba6c" name="Energy Claw" hidden="false" collective="false" import="true" targetId="71e9-a72c-6160-0673" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f7f-5d79-d316-64d5" type="max"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e015-9f8e-d5c5-ae10" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="5f1b-580c-f736-839d" name="Shred Pistol" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="3c98-3d63-0fe0-1317" name="Shred Pistol" hidden="false" targetId="fb33-6b8e-cff1-430d" type="profile"/>
@@ -6084,29 +5950,44 @@
         <infoLink id="297b-2903-b41a-615f" name="Purifiers" hidden="false" targetId="c450-c4c5-a354-1e83" type="profile"/>
         <infoLink id="a67f-8bf2-59e4-985c" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="da8b-bfad-e6a7-ac2d" name="Strikers" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="df67-46e2-5343-4384" name="Strikers" hidden="false" targetId="8167-75a6-1ff0-5809" type="profile"/>
         <infoLink id="3e08-8ae9-b788-938a" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="b3c3-5ead-857c-5bce" name="Interceptors" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="e6a3-c91f-4a9c-41c2" name="Interceptors" hidden="false" targetId="e91c-d006-e62c-ad96" type="profile"/>
         <infoLink id="11a3-ee55-d835-a02b" name="Teleport" hidden="false" targetId="8569-65c6-aca3-fcf1" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="7567-fa46-e49e-c0aa" name="Paladins" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="0457-fe2c-cc7c-4de7" name="Paladins" hidden="false" targetId="622f-f793-edf3-3f22" type="profile"/>
         <infoLink id="9e9f-7fa6-1de5-3e9d" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="3d6f-8204-0d5f-6153" name="Flamethrower Pistol" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="8aec-ce26-c580-e100" name="Flamethrower Pistol" hidden="false" targetId="b574-ad82-82b6-8486" type="profile"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -14864,6 +14745,9 @@
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="08dd-3deb-7ea6-418e" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
@@ -15066,6 +14950,9 @@
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="1efc-85ff-0b5f-7b8e" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -15420,6 +15307,9 @@
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="b183-5fd8-88b0-b678" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -16241,6 +16131,9 @@
                           </constraints>
                         </entryLink>
                       </entryLinks>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+                      </costs>
                     </selectionEntry>
                   </selectionEntries>
                   <entryLinks>
@@ -16317,6 +16210,9 @@
                           </constraints>
                         </entryLink>
                       </entryLinks>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+                      </costs>
                     </selectionEntry>
                   </selectionEntries>
                   <entryLinks>
@@ -16362,6 +16258,266 @@
             <entryLink id="dc21-888a-8a98-48d6" name="Backpack Grenade Launcher" hidden="false" collective="false" import="true" targetId="6bdb-e95c-d214-ad71" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="cf49-d05a-67c9-f7a6" name="Wolf Brothers - Upgrade List H (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2608-2546-c664-f1ea" name="Replace all Storm Rifles &amp; Energy Fists:" hidden="false" collective="false" import="true" defaultSelectionEntryId="f608-c2dc-e986-99a9">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebd5-7d29-7706-1007" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eaff-a723-f170-5b28" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f608-c2dc-e986-99a9" name="Storm Rifles &amp; Energy Fists" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="7c8a-2b66-50b2-043c" name="Replace any Storm Rifle:" hidden="false" collective="false" import="true" defaultSelectionEntryId="8056-f111-8b83-49d2">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e42e-3a2b-940e-58f5" type="min"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef4e-2163-c3f9-012e" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="8056-f111-8b83-49d2" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry"/>
+                    <entryLink id="d3fa-0e4d-8bbb-ee6e" name="Minigun" hidden="false" collective="false" import="true" targetId="7b99-9f38-072e-e027" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="bd0f-cf35-5c7d-0fdd" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="c779-8dbd-e2a8-da09" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
+                      <selectionEntryGroups>
+                        <selectionEntryGroup id="1cee-14b0-f75e-f302" name="Any model may take one Assault Rifle attachment:" hidden="false" collective="false" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d661-d380-d3cb-d75e" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="a23e-3090-9fa8-19b2" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="2618-8a55-4848-beb3" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="7112-149f-21c7-945c" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+                              </costs>
+                            </entryLink>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                      </selectionEntryGroups>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="-5.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="556b-3d51-50be-0683" name="Replace any Energy Sword:" hidden="false" collective="false" import="true" defaultSelectionEntryId="27df-c627-71ed-6fe0">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4dd-cd7c-e8c1-1a03" type="min"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e98f-e3ae-2672-1dbc" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="dd6b-0241-fea0-6457" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="27df-c627-71ed-6fe0" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry"/>
+                    <entryLink id="3585-1c58-11b8-be9a" name="Chainsaw Fist" hidden="false" collective="false" import="true" targetId="ee7c-53ab-fcc5-afdb" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c8c1-6090-08de-9004" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="ccc4-578c-5b7d-55c3" name="Energy Claw" hidden="false" collective="false" import="true" targetId="71e9-a72c-6160-0673" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8264-9bc9-5ab4-3943" type="min"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd32-9c33-e0dc-8cab" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="c6f5-f1bf-ecfd-e059" name="Energy Hammers &amp; Combat Shields" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="22ed-542f-58d5-be57" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c88f-a209-fd08-1a31" type="min"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bf6-afdb-ac77-d859" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="9957-d116-75c5-7f52" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc4c-7ce0-51a0-ccb8" type="min"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5298-91c7-0e61-d10a" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="77a2-ae83-fb99-eb49" name="Upgrade one model with:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e16c-e1fe-baf8-90fb" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="9c7c-c40d-2d63-14b9" name="Cyclone Missiles" hidden="false" collective="false" import="true" targetId="de20-063e-ab3f-d5cb" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="8988-7da6-59b1-2f64" name="Wolf Brothers - Upgrade List H (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="70ef-d7fa-a332-19af" name="Replace all Storm Rifles &amp; Energy Fists:" hidden="false" collective="false" import="true" defaultSelectionEntryId="3d00-f017-4d97-aecf">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea77-3f36-6d13-0574" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e09-3c73-02ba-9cae" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3d00-f017-4d97-aecf" name="Storm Rifles &amp; Energy Fists" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="b319-34ff-8b4f-852b" name="Replace any Storm Rifle:" hidden="false" collective="false" import="true" defaultSelectionEntryId="9e46-2592-92b5-c8f8">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="855d-f78e-4b67-3bc1" type="min"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d997-b811-8615-c84f" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="9e46-2592-92b5-c8f8" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry"/>
+                    <entryLink id="246c-5287-382b-b6e7" name="Minigun" hidden="false" collective="false" import="true" targetId="7b99-9f38-072e-e027" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="fd3d-c280-61a1-e411" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="24b4-64f2-1fe9-f5f3" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
+                      <selectionEntryGroups>
+                        <selectionEntryGroup id="42dd-0fcf-504e-d650" name="Any model may take one Assault Rifle attachment:" hidden="false" collective="false" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f5a-ab2e-5e48-5663" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="409c-97fc-4b94-c577" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="f990-ec96-3aaa-48fb" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="20b3-8e0d-b80d-e6f7" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+                              </costs>
+                            </entryLink>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                      </selectionEntryGroups>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="-5.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="2975-7950-984d-7bc7" name="Replace any Energy Sword:" hidden="false" collective="false" import="true" defaultSelectionEntryId="83ff-5932-ca28-ec99">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8804-6735-7077-95e7" type="min"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a76d-677a-0607-c69f" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="dd34-cba4-f7a1-f868" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="83ff-5932-ca28-ec99" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry"/>
+                    <entryLink id="5b6b-f57e-4364-0584" name="Chainsaw Fist" hidden="false" collective="false" import="true" targetId="ee7c-53ab-fcc5-afdb" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="352e-f2be-ed96-e06d" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="3a46-9773-fb60-289f" name="Energy Claw" hidden="false" collective="false" import="true" targetId="71e9-a72c-6160-0673" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05b5-0e57-d285-2a33" type="min"/>
+                    <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0010-6e8f-e36d-73f2" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="cf93-295d-5458-c4f6" name="Energy Hammers &amp; Combat Shields" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="0640-b52f-6f0b-4fd2" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22c5-7ced-c799-4afc" type="min"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53ca-c727-2840-d8a2" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="8830-b21d-720b-8fd3" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33d5-699c-a99c-a9a5" type="min"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c800-286c-3c41-d76a" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5acb-5314-6869-a730" name="Upgrade two models with:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa15-5313-6f52-b1e1" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="feee-c2ac-712e-76de" name="Cyclone Missiles" hidden="false" collective="false" import="true" targetId="de20-063e-ab3f-d5cb" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
               </costs>
             </entryLink>
           </entryLinks>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -3668,101 +3668,6 @@
         <infoLink id="aae5-ff22-1877-45d7" name="Fang Gunship" hidden="false" targetId="a335-8e56-3229-f0c3" type="profile"/>
         <infoLink id="09f5-3694-942a-a83b" name="Aircraft" hidden="false" targetId="187f-6a03-5b99-a4db" type="rule"/>
       </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="d5e7-8562-1eda-6e01" name="Transport(11)" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8041-2567-5b8f-cfac" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="5dee-5156-1a04-f4a5" name="Transport(X)" hidden="false" targetId="3460-57e3-8a15-7977" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="d12b-26e8-1576-abdb" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="cb3e-2740-a3e2-e22c">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f8d-5cba-7e8d-6f92" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b3e-95b5-c8d6-d026" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="cb3e-2740-a3e2-e22c" name="Storm Missiles" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="3896-fd6b-1d8e-2964" name="Storm Missiles" hidden="false" collective="false" import="true" targetId="ae99-efd2-91f4-19d6" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d71-b597-ec1c-b358" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1509-77a5-ba4d-5548" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="1811-c9ed-7ace-f1b4" name="Twin Laser Cannon" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="8533-caba-ae49-143e" name="Twin Laser Cannon" hidden="false" collective="false" import="true" targetId="d271-2d81-e640-0040" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="430a-a56c-66dc-8826" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1b5-8bf1-3aed-9fb5" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="55.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="5ce8-7520-8dea-df5d" name="Upgrades" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d592-8313-2597-6ce2" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="1620-6837-5158-0773" name="Hammer Missiles" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="d6d3-e6d0-6768-c154" name="Hammer Missiles" hidden="false" collective="false" import="true" targetId="2b23-f91f-8f74-d7d9" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84e2-add6-2cc5-0d94" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fe8-4c68-dc64-8dca" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="600d-6b63-1c64-af85" name="2x Twin Heavy Machineguns" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="6e60-e665-3c25-b35f" name="Twin Heavy Machinegun" hidden="false" collective="false" import="true" targetId="dae8-3106-6a96-228c" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c47f-0d53-ba03-19a3" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6c7-5196-0799-3287" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="110.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="4b17-5917-c0e4-5efb" name="2x Twin Heavy Fusion Rifles" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="004d-2cbb-4e45-a0c4" name="Twin Heavy Fusion Rifle" hidden="false" collective="false" import="true" targetId="7837-57e0-d13e-35ab" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6db-f1eb-d388-28c3" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab1a-a3d5-c327-cfb7" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="190.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="02b4-816c-3e36-1451" name="Heavy Frost Cannon" hidden="false" collective="false" import="true" targetId="7a6a-8d82-a5e1-7775" type="selectionEntry">
           <constraints>
@@ -3770,6 +3675,8 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4654-577a-eb42-8642" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="49d3-2d0e-1e8a-2eef" name="Wolf Brothers - Upgrade List K" hidden="false" collective="false" import="true" targetId="144a-b7da-4156-98d7" type="selectionEntryGroup"/>
+        <entryLink id="527a-40db-9661-c6bd" name="Wolf Brothers - Upgrade List J" hidden="false" collective="false" import="true" targetId="2ad4-05f9-291e-cc21" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="245.0"/>
@@ -16611,6 +16518,96 @@
             <entryLink id="ec52-aa65-942f-5848" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="144a-b7da-4156-98d7" name="Wolf Brothers - Upgrade List K" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2aa7-b44f-ed36-57fe" name="Upgrade with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39fd-a16c-192e-bd07" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8ab9-c3d5-3eab-ee53" name="Hammer Missiles" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="f680-032a-16d6-729c" name="Hammer Missiles" hidden="false" collective="false" import="true" targetId="2b23-f91f-8f74-d7d9" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e971-b932-2569-7fa5" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be39-c37f-35af-2e55" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3cec-9888-40a0-2726" name="2x Twin Heavy Machineguns" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="fad5-98bb-e7a6-21a2" name="Twin Heavy Machinegun" hidden="false" collective="false" import="true" targetId="dae8-3106-6a96-228c" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebad-20cd-179e-c754" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76d9-772f-a8af-8a4e" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="110.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9c84-e0e1-2299-aa1f" name="2x Twin Heavy Fusion Rifles" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="2179-7469-bf78-9b03" name="Twin Heavy Fusion Rifle" hidden="false" collective="false" import="true" targetId="7837-57e0-d13e-35ab" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5a5-82b0-79e0-f37b" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a66-26ff-5c14-d7e4" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="190.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="3b48-27ee-6dd6-02ae" name="Upgrade with:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="807f-5488-e28e-3693" name="Transport(11)" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3bb-ac70-e1b2-18aa" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="fd51-e21e-7b4c-56ee" name="Transport(11)" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
+                  <characteristics>
+                    <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Transport(11)	</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="318c-919a-34a2-0d79" name="Transport(X)" hidden="false" targetId="3460-57e3-8a15-7977" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="2ad4-05f9-291e-cc21" name="Wolf Brothers - Upgrade List J" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8465-51ff-3b18-e224" name="Replace Storm Missiles:" hidden="false" collective="false" import="true" defaultSelectionEntryId="45f6-d990-9f92-e696">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5174-5866-5d16-0ccf" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a3e-c979-c479-7300" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="45f6-d990-9f92-e696" name="Storm Missiles" hidden="false" collective="false" import="true" targetId="ae99-efd2-91f4-19d6" type="selectionEntry"/>
+            <entryLink id="8efe-e7ba-0c1b-ecd1" name="Twin Laser Cannon" hidden="false" collective="false" import="true" targetId="d271-2d81-e640-0040" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="55.0"/>
               </costs>
             </entryLink>
           </entryLinks>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -844,7 +844,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="15cb-0485-976c-7ca8" name="New CategoryLink" hidden="false" targetId="b820-6309-e900-c733" primary="true"/>
+        <categoryLink id="d4af-0a41-c3a4-fa97" name="New CategoryLink" hidden="false" targetId="7528-ccdf-679c-8613" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="075b-7412-c0f0-671f" name="Anti-Grav Destroyer Tank" page="" hidden="false" collective="false" import="true" targetId="49e2-29e2-9ef6-6348" type="selectionEntry">
@@ -856,7 +856,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="db09-3247-2877-6b65" name="New CategoryLink" hidden="false" targetId="b820-6309-e900-c733" primary="true"/>
+        <categoryLink id="2655-0db4-2575-3f88" name="New CategoryLink" hidden="false" targetId="7528-ccdf-679c-8613" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="56e5-e899-3d9a-2bbb" name="Anti-Grav APC" hidden="false" collective="false" import="true" targetId="6861-14d1-eb2c-c1dc" type="selectionEntry">
@@ -935,6 +935,11 @@
     <entryLink id="cbce-109e-21af-bf73" name="Prime ATV" hidden="false" collective="false" import="true" targetId="b75e-8917-0c3a-cd0c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b84a-b94c-4967-2bc4" name="Vehicles: Light" hidden="false" targetId="3089-78fc-94cc-28a2" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="26ae-fc2a-de79-c248" name="Anti-Grav Tank" hidden="false" collective="false" import="true" targetId="c708-237a-9145-77d2" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="d9bd-f830-cce0-1015" name="New CategoryLink" hidden="false" targetId="b820-6309-e900-c733" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -7290,7 +7295,7 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="63df-d87e-1506-01cc" name="Anti-Grav Transport Tank" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="63df-d87e-1506-01cc" name="Heavy Anti-Grav Transport Tank" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="edc5-1366-79f2-1357" name="Firstborn" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
         <infoLink id="3ad1-2c6f-0af8-0ea5" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
@@ -7479,7 +7484,7 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="520.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="49e2-29e2-9ef6-6348" name="Anti-Grav Destroyer Tank" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="49e2-29e2-9ef6-6348" name="Heavy Anti-Grav Destroyer Tank" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="e7ca-8c0a-cbf7-f679" name="Firstborn" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
         <infoLink id="c6f3-5d94-d92a-963b" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
@@ -7751,72 +7756,9 @@
         <infoLink id="8272-8201-a516-c281" name="Transport(X)" hidden="false" targetId="3460-57e3-8a15-7977" type="rule"/>
         <infoLink id="edbd-b1c4-2f1e-3731" name="Strider" hidden="false" targetId="9dea-b566-200a-0605" type="rule"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="6874-79fc-0f73-c698" name="Weapon - Sponsons" hidden="false" collective="false" import="true" defaultSelectionEntryId="8a77-c2cd-9863-9385">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c93b-ce98-205b-c606" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="467a-975b-3205-29b4" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="8a77-c2cd-9863-9385" name="Twin Storm Rifle" hidden="false" collective="false" import="true" targetId="c262-f674-c03e-dcae" type="selectionEntry"/>
-            <entryLink id="7215-c282-29ea-10d5" name="Twin HE-Launcher" hidden="false" collective="false" import="true" targetId="fbc3-5a79-7946-6bd8" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="16a5-5ab3-8ec9-07ee" name="Weapon - Pintle Mount" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf51-37d2-0208-28aa" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="b2e2-0b06-fbbe-d687" name="Light Machinegun" hidden="false" collective="false" import="true" targetId="6bf9-8992-7b02-5764" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="0f82-dc6a-7f7f-e2d9" name="Upgrade with one:" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f9a-1fb1-3a74-8c7d" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="e1a6-e816-1b76-6d24" name="Twin AA-Machinegun" hidden="false" collective="false" import="true" targetId="5666-6954-7608-c6cd" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="45.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="408c-52c2-6363-2bfb" name="Artillery Relay" hidden="false" collective="false" import="true" targetId="171b-0217-6993-bfb9" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="5c2c-fdef-23fb-7efc" name="Missile Array" hidden="false" collective="false" import="true" targetId="d552-19c2-322e-8f4a" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="145.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="557d-3953-c8a0-a1b1" name="Shield Projector" hidden="false" collective="false" import="true" targetId="4b26-fe51-2a7b-4778" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="70.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="ef33-e9c0-488b-10dd" name="Blood Brothers - Very Fast" hidden="false" collective="false" import="true" targetId="ec17-0396-1d9d-0ad9" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="aa10-747b-0040-a5ca" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
-          </costs>
-        </entryLink>
+        <entryLink id="1592-a1ab-e13e-8614" name="Prime Brothers 2 - Upgrade List A" hidden="false" collective="false" import="true" targetId="472d-f0c5-87b0-9e6a" type="selectionEntryGroup"/>
+        <entryLink id="dfae-6d7f-aaf8-d55a" name="** Detachment Upgrade (Units of [1] with Tough(6) &amp; Fast) **" hidden="false" collective="false" import="true" targetId="dd6c-df9e-3bed-5be4" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="240.0"/>
@@ -8575,6 +8517,45 @@
     <selectionEntry id="ad7f-7129-2854-846e" name="Twin Auto-Rifles" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="863d-e38f-3218-985d" name="Twin Auto-Rifles" hidden="false" targetId="4c65-274d-2ab1-dc68" type="profile"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="c708-237a-9145-77d2" name="Anti-Grav Tank" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="9465-bc7d-ab02-abed" name="Anti-Grav Tank" hidden="false" targetId="a17d-6598-4967-a41d" type="profile"/>
+        <infoLink id="bf35-2e09-73a8-7b0d" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
+        <infoLink id="ab32-93d5-156f-d151" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
+        <infoLink id="04be-459e-24f0-0794" name="Prime" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
+        <infoLink id="6587-652c-03e8-f9e4" name="Strider" hidden="false" targetId="9dea-b566-200a-0605" type="rule"/>
+        <infoLink id="e292-a50f-666f-8ec1" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
+      </infoLinks>
+      <entryLinks>
+        <entryLink id="f44a-d141-cc30-dad1" name="Prime Brothers 2 - Upgrade List B" hidden="false" collective="false" import="true" targetId="799d-1323-0842-401d" type="selectionEntryGroup"/>
+        <entryLink id="cf64-18f8-5b29-e4bf" name="** Detachment Upgrade (Units of [1] with Tough(12) &amp; Fast) **" hidden="false" collective="false" import="true" targetId="a235-3a7c-ad55-1c1b" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="d4aa-cfa3-aa0e-5f13" name="Twin Heavy Laser Cannon" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="e5f2-377f-333b-1a78" name="Twin Heavy Laser Cannon" hidden="false" targetId="6bba-1167-39c3-bbae" type="profile"/>
+        <infoLink id="26f9-7721-7fb2-f3cd" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
+        <infoLink id="ce68-950f-0ff1-2329" name="Deadly(X)" hidden="false" targetId="377b-3864-960e-57ac" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="35f5-f6d4-f7a9-4a09" name="Twin Heavy Gatling Gun" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="c3f3-92c0-a7d5-5418" name="Twin Heavy Gatling Gun" hidden="false" targetId="cb17-3f52-a513-af8d" type="profile"/>
+        <infoLink id="7be5-de7b-c97d-f387" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="2fa7-fdb5-c20c-e6a9" name="Tempest Rifle" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="8072-9fc3-d357-9cfc" name="Tempest Rifle" hidden="false" targetId="0af6-57af-191d-8d1f" type="profile"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="3bd4-96e7-5d0d-10c5" name="Twin Laser Talon" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="d3e0-ba0f-0438-5196" name="Twin Laser Talon" hidden="false" targetId="5cba-b79a-ca51-9c8a" type="profile"/>
+        <infoLink id="dbb4-b434-902d-669a" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
+        <infoLink id="f800-8965-b9c4-aec2" name="Deadly(X)" hidden="false" targetId="377b-3864-960e-57ac" type="rule"/>
       </infoLinks>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -14670,6 +14651,160 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>
+    <selectionEntryGroup id="472d-f0c5-87b0-9e6a" name="Prime Brothers 2 - Upgrade List A" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="13a5-b2e9-8d3b-9f0e" name="Replace Twin Storm Rifle:" hidden="false" collective="false" import="true" defaultSelectionEntryId="efe8-8d86-f190-4d3b">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f394-5ec9-1320-4922" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="438e-84bc-7b98-a60b" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="efe8-8d86-f190-4d3b" name="Twin Storm Rifle" hidden="false" collective="false" import="true" targetId="c262-f674-c03e-dcae" type="selectionEntry"/>
+            <entryLink id="68ca-9035-fb2a-1d3b" name="Twin HE-Launcher" hidden="false" collective="false" import="true" targetId="fbc3-5a79-7946-6bd8" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="3f68-f076-ee46-4e03" name="Upgrade with:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="3971-02ff-96b1-a0ba" name="Machinegun" hidden="false" collective="false" import="true" targetId="6bf9-8992-7b02-5764" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f196-e24f-fc64-c323" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f39a-99e7-3ee0-c7ec" name="Upgrade with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0448-a176-3ef5-1218" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="d22b-4689-cce0-ce2b" name="Missile Array" hidden="false" collective="false" import="true" targetId="d552-19c2-322e-8f4a" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="145.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="4711-8a30-239f-309c" name="Artillery Relay" hidden="false" collective="false" import="true" targetId="171b-0217-6993-bfb9" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="c48a-4373-25dc-23e3" name="Shield Projector" hidden="false" collective="false" import="true" targetId="4b26-fe51-2a7b-4778" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="70.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="ab38-1ed2-7b57-e252" name="Twin AA-Machinegun" hidden="false" collective="false" import="true" targetId="5666-6954-7608-c6cd" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="45.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="799d-1323-0842-401d" name="Prime Brothers 2 - Upgrade List B" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3d47-89b6-eb17-c772" name="Replace Twin Laser Talon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="1141-2cd7-c166-a7e2">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3dd-7b26-9e89-e824" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e879-6c20-bd17-c09c" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="1141-2cd7-c166-a7e2" name="Twin Laser Talon" hidden="false" collective="false" import="true" targetId="3bd4-96e7-5d0d-10c5" type="selectionEntry"/>
+            <entryLink id="837e-9262-bd5b-f0e3" name="Twin Heavy Gatling Gun" hidden="false" collective="false" import="true" targetId="35f5-f6d4-f7a9-4a09" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="85.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="6851-5343-323a-efe2" name="Twin Heavy Laser Cannon" hidden="false" collective="false" import="true" targetId="d4aa-cfa3-aa0e-5f13" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="95.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7972-b870-6914-accd" name="Replace 2x Storm Rifles:" hidden="false" collective="false" import="true" defaultSelectionEntryId="aa51-fd40-c993-0916">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9db6-6196-2988-6b5d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c27d-b275-fe1e-093a" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="aa51-fd40-c993-0916" name="2x Storm Rifles" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="60a1-c938-3552-d17d" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06bf-b516-e24e-594d" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3469-ef6a-c131-b27d" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="aef4-9a4b-d6ff-4c71" name="2x HE-Launchers" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="7299-82d0-1eae-2a89" name="HE-Launcher" hidden="false" collective="false" import="true" targetId="3599-2d43-1180-9d59" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20f9-6b24-7868-c7c3" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d38b-3eee-5b07-a57f" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="0833-1825-95ad-1816" name="2x Tempest Rifles" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="1ded-25fc-14a3-601f" name="Tempest Rifle" hidden="false" collective="false" import="true" targetId="2fa7-fdb5-c20c-e6a9" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ff8-ab2e-a819-711d" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72d1-3421-fb31-6ea3" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a086-5b11-a01f-3d01" name="2x Heavy Fusion Rifles" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="cd3f-6854-999c-ebf6" name="Heavy Fusion Rifle" hidden="false" collective="false" import="true" targetId="a5f5-d44a-03b0-9a99" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="19ac-81b6-8447-fd40" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bc2-0d5d-4284-e827" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f6c5-3dd1-44dc-e308" name="Upgrade with any:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="f698-34c4-8e4c-25e8" name="AA-Rocket Pod" hidden="false" collective="false" import="true" targetId="5ce3-bc25-e242-c85c" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87bc-c4a9-e182-1287" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="597f-04b9-f7ee-1843" name="Machinegun" hidden="false" collective="false" import="true" targetId="6bf9-8992-7b02-5764" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="534b-cb9a-c016-b9f7" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
     <rule id="ff04-8ef9-82f1-a88b" name="Shield Wall" publicationId="dead-6af1-a069-5579" hidden="false">
@@ -16485,6 +16620,41 @@
       <characteristics>
         <characteristic name="Range" typeId="79f4-5578-c041-f866">24&quot;</characteristic>
         <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A6	</characteristic>
+        <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d"/>
+      </characteristics>
+    </profile>
+    <profile id="a17d-6598-4967-a41d" name="Anti-Grav Tank" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
+      <characteristics>
+        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">3+</characteristic>
+        <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">2+</characteristic>
+        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fast, Impact(6), Prime, Strider, Tough(12)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="5cba-b79a-ca51-9c8a" name="Twin Laser Talon" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="79f4-5578-c041-f866">24&quot;</characteristic>
+        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A4</characteristic>
+        <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(4), Deadly(3)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="cb17-3f52-a513-af8d" name="Twin Heavy Gatling Gun" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="79f4-5578-c041-f866">30&quot;</characteristic>
+        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A24</characteristic>
+        <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(1)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="6bba-1167-39c3-bbae" name="Twin Heavy Laser Cannon" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="79f4-5578-c041-f866">48&quot;</characteristic>
+        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A2</characteristic>
+        <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(4), Deadly(6)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="0af6-57af-191d-8d1f" name="Tempest Rifle" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="79f4-5578-c041-f866">24&quot;</characteristic>
+        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A4	</characteristic>
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d"/>
       </characteristics>
     </profile>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -1840,76 +1840,6 @@
         <infoLink id="ce97-c478-c6f8-6695" name="Aircraft" hidden="false" targetId="187f-6a03-5b99-a4db" type="rule"/>
         <infoLink id="9dee-b9db-8121-d566" name="Transport(X)" hidden="false" targetId="3460-57e3-8a15-7977" type="rule"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="c25e-5f94-9e5a-6637" name="Weapon 1" hidden="false" collective="false" import="true" defaultSelectionEntryId="fc0e-3290-39e1-1420">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6dfc-254b-1272-1761" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a269-9199-1c0f-5460" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="fc0e-3290-39e1-1420" name="Twin Minigun" hidden="false" collective="false" import="true" targetId="a8f7-27d2-59eb-c865" type="selectionEntry"/>
-            <entryLink id="322c-1148-dda1-523b" name="Twin Laser Cannon" hidden="false" collective="false" import="true" targetId="d271-2d81-e640-0040" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="d5f6-6a75-765d-882d" name="Twin Plasma Cannon" hidden="false" collective="false" import="true" targetId="c214-91e2-a10a-62c7" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="9dc6-428f-5bb5-3683" name="Weapon 2" hidden="false" collective="false" import="true" defaultSelectionEntryId="bdbb-7f8b-dc2d-c3f2">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="797c-6561-ecd2-c490" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6311-bdcc-2aae-dc4b" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="d5eb-be31-24c9-d750" name="Twin Heavy Fusion Rifle" hidden="false" collective="false" import="true" targetId="7837-57e0-d13e-35ab" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="bdbb-7f8b-dc2d-c3f2" name="Twin Heavy Machinegun" hidden="false" collective="false" import="true" targetId="dae8-3106-6a96-228c" type="selectionEntry"/>
-            <entryLink id="7984-4885-90a0-07e5" name="Typhoon Missiles" hidden="false" collective="false" import="true" targetId="8aef-9844-eaa7-e640" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="2100-12ac-f340-9cba" name="Upgrades" hidden="false" collective="false" import="true">
-          <selectionEntries>
-            <selectionEntry id="31c2-006b-7f1f-ae88" name="2x Assault Rifle Arrays" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0df-379f-1b5b-6b54" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="c475-143f-101c-51dd" name="Assault Rifle Array" hidden="false" collective="false" import="true" targetId="faa1-761d-0d50-2135" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4214-d3b0-186a-d487" type="min"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f25-f800-dd6d-20e1" type="max"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="a095-0e19-6ade-5cfe" name="Raer Grapples" hidden="false" collective="false" import="true" targetId="a235-c4af-fa56-fc97" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0467-7a38-79bc-5941" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="17b2-1020-faf5-6160" name="Storm Missiles" hidden="false" collective="false" import="true" targetId="ae99-efd2-91f4-19d6" type="selectionEntry">
           <constraints>
@@ -1917,6 +1847,8 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="430b-a023-24b8-88a7" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="e625-2cad-28ea-6829" name="** Detachment Upgrade (Units of [1] with Tough(12)) **" hidden="false" collective="false" import="true" targetId="b007-c0d8-b1e0-23d9" type="selectionEntryGroup"/>
+        <entryLink id="42ad-5978-d09f-f4a2" name="Battle Brothers 3 - Upgrade List G" hidden="false" collective="false" import="true" targetId="9a11-c3af-079b-bdd3" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="465.0"/>
@@ -14144,6 +14076,78 @@
               </costs>
             </entryLink>
             <entryLink id="8752-8c12-ea8e-9cc4" name="Typhoon Missiles" hidden="false" collective="false" import="true" targetId="8aef-9844-eaa7-e640" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="9a11-c3af-079b-bdd3" name="Battle Brothers 3 - Upgrade List G" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ceee-a37c-309c-d7cb" name="Upgrade with any:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="668e-3aa1-7658-4623" name="2x Assault Rifle Arrays" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ecb-939e-dcbc-77d9" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="60cb-3ea6-700c-216f" name="Assault Rifle Array" hidden="false" collective="false" import="true" targetId="faa1-761d-0d50-2135" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17e9-74e7-3be3-eec9" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1dbf-ea8a-c83e-064c" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="bb04-e7f5-3683-327f" name="Rear Grapples" hidden="false" collective="false" import="true" targetId="a235-c4af-fa56-fc97" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85d3-432d-6ec4-610b" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0740-1b07-99df-a489" name="Replace Twin Minigun:" hidden="false" collective="false" import="true" defaultSelectionEntryId="17e5-b595-7307-fb9c">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9032-95de-25fb-8c00" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8884-e057-2a3f-c400" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="17e5-b595-7307-fb9c" name="Twin Minigun" hidden="false" collective="false" import="true" targetId="a8f7-27d2-59eb-c865" type="selectionEntry"/>
+            <entryLink id="1dc2-842b-3b4e-afec" name="Twin Laser Cannon" hidden="false" collective="false" import="true" targetId="d271-2d81-e640-0040" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="1918-e989-68e1-1d0e" name="Twin Plasma Cannon" hidden="false" collective="false" import="true" targetId="c214-91e2-a10a-62c7" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="fad7-93ce-7979-486c" name="Replace Twin Heavy Machinegun:" hidden="false" collective="false" import="true" defaultSelectionEntryId="36ea-773b-e564-f436">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4153-66fd-8533-1f2e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09b1-01d0-4979-8a13" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="a183-df42-f447-3eda" name="Twin Heavy Fusion Rifle" hidden="false" collective="false" import="true" targetId="7837-57e0-d13e-35ab" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="36ea-773b-e564-f436" name="Twin Heavy Machinegun" hidden="false" collective="false" import="true" targetId="dae8-3106-6a96-228c" type="selectionEntry"/>
+            <entryLink id="7d1b-023f-3782-7914" name="Typhoon Missiles" hidden="false" collective="false" import="true" targetId="8aef-9844-eaa7-e640" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
               </costs>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -2393,31 +2393,10 @@
         <infoLink id="c7f6-4f15-aaa3-3054" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
         <infoLink id="37e1-1acc-3190-8d52" name="Dark Resolve" hidden="false" targetId="5dec-9937-47f8-7cf4" type="rule"/>
       </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="6015-b8e8-88d0-9cbb" name="Dark Shroud" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4f9-abd3-bf73-a1f9" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="742a-b7fa-517d-cd59" name="Dark Shroud" hidden="false" targetId="0bda-37f1-caad-15db" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="e098-1daf-dba0-0bc6" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="004e-dbcf-05ae-b542">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00ec-743f-405c-a13e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb67-7a24-5739-51ea" type="min"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="e3be-091e-d9d1-85ea" name="Minigun" hidden="false" collective="false" import="true" targetId="7b99-9f38-072e-e027" type="selectionEntry"/>
-            <entryLink id="004e-dbcf-05ae-b542" name="Heavy Machinegun" hidden="false" collective="false" import="true" targetId="4481-49a4-e4f7-925b" type="selectionEntry"/>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="257f-c6c6-f9c8-75e6" name="Dark Brothers - Upgrade List E" hidden="false" collective="false" import="true" targetId="4ade-bd63-6621-8604" type="selectionEntryGroup"/>
+        <entryLink id="2ae5-f912-d86e-25a2" name="Dark Brothers - Upgrade List F" hidden="false" collective="false" import="true" targetId="6f74-1c0e-a94f-64ce" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="240.0"/>
       </costs>
@@ -7574,6 +7553,12 @@
     <selectionEntry id="85a4-c097-3957-7879" name="Turret Crew" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="1859-a1e6-c0c5-ca8f" name="Turret Crew" hidden="false" targetId="6840-c3ac-1e90-97a2" type="profile"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="e5f6-edd1-35f4-918e" name="Dark Shroud" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="c6c3-5806-e404-78c8" name="Dark Shroud" hidden="false" targetId="4843-ef34-a0a4-8b68" type="profile"/>
+        <infoLink id="6bd3-7a72-69aa-a916" name="Stealth" hidden="false" targetId="1b59-5d31-4675-c926" type="rule"/>
       </infoLinks>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -15496,6 +15481,36 @@
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
+    <selectionEntryGroup id="4ade-bd63-6621-8604" name="Dark Brothers - Upgrade List E" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="08c5-5fc5-7ec0-386b" name="Replace Heavy Machinegun:" hidden="false" collective="false" import="true" defaultSelectionEntryId="aa2d-a48c-0160-9200">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2315-2b16-9027-c907" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1ea-0076-110c-83a3" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="aff3-a1e0-fb14-f726" name="Minigun" hidden="false" collective="false" import="true" targetId="7b99-9f38-072e-e027" type="selectionEntry"/>
+            <entryLink id="aa2d-a48c-0160-9200" name="Heavy Machinegun" hidden="false" collective="false" import="true" targetId="4481-49a4-e4f7-925b" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="6f74-1c0e-a94f-64ce" name="Dark Brothers - Upgrade List F" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5526-115e-5fae-2b80" name="Upgrade with:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="855d-fcbe-8d37-a58e" name="Dark Shroud" hidden="false" collective="false" import="true" targetId="e5f6-edd1-35f4-918e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3fc-93eb-9a01-fc61" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
     <rule id="ff04-8ef9-82f1-a88b" name="Shield Wall" publicationId="dead-6af1-a069-5579" hidden="false">
@@ -15527,9 +15542,6 @@
     </rule>
     <rule id="5dec-9937-47f8-7cf4" name="Grim" publicationId="a380-f550-5f9a-c792" hidden="false">
       <description>This unit counts as having Fearless and whenever it fails a morale test roll one die, on a 4+ it passes instead.	</description>
-    </rule>
-    <rule id="0bda-37f1-caad-15db" name="Dark Shroud" publicationId="a380-f550-5f9a-c792" hidden="false">
-      <description>When this unit is activated you may pick 2 friendly units within 6”, which get Stealth next time they are shot at.</description>
     </rule>
     <rule id="df74-e3da-9464-fc6f" name="Tactical Master" publicationId="a380-f550-5f9a-c792" hidden="false">
       <description>When the hero and his unit shoots Pistols, Assault Rifles or Storm Rifles, pick on of the following ammo types, and they get one of these special rules until the end of the round:
@@ -17409,6 +17421,11 @@
       <characteristics>
         <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022"/>
+      </characteristics>
+    </profile>
+    <profile id="4843-ef34-a0a4-8b68" name="Dark Shroud" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
+      <characteristics>
+        <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">When this unit is activated you may pick 2 friendly units within 6”, which get Stealth next time they are shot at.</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -703,30 +703,6 @@
         <categoryLink id="5f9a-6d34-c94d-70ee" name="New CategoryLink" hidden="false" targetId="4b4e-fbe0-5211-ae65" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8b9b-dd1e-e37c-eeed" name="Prime Lieutenant" hidden="false" collective="false" import="true" targetId="a8c0-b29d-a0d7-f0be" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="dc7a-12df-d69b-ed72" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="49d0-1e47-c8e2-a086" name="New CategoryLink" hidden="false" targetId="4b4e-fbe0-5211-ae65" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="a5e7-0295-4b1e-db8a" name="Prime Ancient" hidden="false" collective="false" import="true" targetId="fcc9-41d7-d66f-d81c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="dc7a-12df-d69b-ed72" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="7c55-995a-a979-36f5" name="New CategoryLink" hidden="false" targetId="4b4e-fbe0-5211-ae65" primary="true"/>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="6b72-ef41-06c6-94a7" name="Prime Psychic" hidden="false" collective="false" import="true" targetId="c8d6-faca-d622-5fa7" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
@@ -883,18 +859,6 @@
         <categoryLink id="db09-3247-2877-6b65" name="New CategoryLink" hidden="false" targetId="b820-6309-e900-c733" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="f8ed-a680-cc16-2de7" name="Prime Grave Captain" hidden="false" collective="false" import="true" targetId="7092-baf4-8ce7-475a" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="dc7a-12df-d69b-ed72" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="5892-40d3-166e-5e57" name="New CategoryLink" hidden="false" targetId="4b4e-fbe0-5211-ae65" primary="true"/>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="56e5-e899-3d9a-2bbb" name="Anti-Grav APC" hidden="false" collective="false" import="true" targetId="6861-14d1-eb2c-c1dc" type="selectionEntry">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
@@ -1000,7 +964,7 @@
     </selectionEntry>
     <selectionEntry id="c47e-3660-de3d-86f7" name="Combat Bike" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="d867-227d-f5c5-5c06" name="Bike" hidden="false" targetId="590a-3248-2bec-96f7" type="profile"/>
+        <infoLink id="d867-227d-f5c5-5c06" name="Combat Bike" hidden="false" targetId="590a-3248-2bec-96f7" type="profile"/>
         <infoLink id="8f1e-8ea1-1b21-f797" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
         <infoLink id="8853-e4db-7730-3766" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
       </infoLinks>
@@ -6438,38 +6402,9 @@
         <infoLink id="f79a-7997-36f0-cb7d" name="Firstborn" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
       </infoLinks>
       <entryLinks>
-        <entryLink id="46c8-502e-52b7-92be" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="fdb2-adac-4335-ede3" name="Death Brothers - Tactical Master" hidden="false" collective="false" import="true" targetId="f2e2-ff33-227d-9876" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="d7da-a7f8-7386-264d" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="e932-b708-1f59-e99d" name="Wolf Brothers - Counter-Attack" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="cef1-9b6e-4470-a028" name="Prime Leader Weapons" hidden="false" collective="false" import="true" targetId="d455-2126-cc2a-5f47" type="selectionEntryGroup"/>
-        <entryLink id="7d48-d393-c979-e42f" name="Dark Brothers - Dark Assault" hidden="false" collective="false" import="true" targetId="cf31-8c37-3347-79a3" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="bc63-1edb-1777-8bb1" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="1f5b-ff9c-149e-5937" name="Prime Leader Upgrades" hidden="false" collective="false" import="true" targetId="48b6-7b0b-4908-7375" type="selectionEntryGroup"/>
+        <entryLink id="cef1-9b6e-4470-a028" name="Prime Brothers 1 - Upgrade List A" hidden="false" collective="false" import="true" targetId="d455-2126-cc2a-5f47" type="selectionEntryGroup"/>
+        <entryLink id="3237-2fcb-ad20-5c8d" name="Prime Brothers 1 - Upgrade List B" hidden="false" collective="false" import="true" targetId="9b9b-2dc9-35a9-7953" type="selectionEntryGroup"/>
+        <entryLink id="2ded-e6b3-6eea-707d" name="Prime Brothers 1 - Upgrade List C" hidden="false" collective="false" import="true" targetId="fe39-67bd-4fc1-28da" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="105.0"/>
@@ -6499,117 +6434,6 @@
       </infoLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="a8c0-b29d-a0d7-f0be" name="Prime Lieutenant" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="0077-de16-2644-11a6" name="Prime Lieutenant" hidden="false" targetId="4911-e8fe-8cf4-dded" type="profile"/>
-        <infoLink id="fb14-61a5-9025-9adc" name="Hero" hidden="false" targetId="5065-c3a4-a9cf-db27" type="rule"/>
-        <infoLink id="386d-72d8-416d-2ede" name="Firstborn" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
-        <infoLink id="8832-9335-c649-54a5" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
-      </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="6c1c-1a53-cb40-4410" name="Upgrades" hidden="false" collective="false" import="true">
-          <selectionEntries>
-            <selectionEntry id="927e-d5eb-58d3-680f" name="Precision Shots" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="318f-7409-2987-4772" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="745f-efc6-377b-5634" name="Precision Shots" hidden="false" targetId="626a-c071-1a4b-7188" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="45.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="48d0-7ae8-d3a4-6fce" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="5665-c1f5-304b-9b26" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="9ce8-92c0-096d-ae56" name="Death Brothers - Tactical Master" hidden="false" collective="false" import="true" targetId="f2e2-ff33-227d-9876" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="ca24-407a-3a47-929e" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="97a1-4e99-9828-a6b3" name="Wolf Brothers - Counter" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="fc89-7407-827d-8a62" name="Prime Leader Weapons" hidden="false" collective="false" import="true" targetId="d455-2126-cc2a-5f47" type="selectionEntryGroup"/>
-        <entryLink id="56fa-8a49-8cb2-341b" name="Prime Leader Upgrades" hidden="false" collective="false" import="true" targetId="48b6-7b0b-4908-7375" type="selectionEntryGroup"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="105.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="fcc9-41d7-d66f-d81c" name="Prime Ancient" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="5694-1d20-1e1c-ea89" name="Prime Ancient" hidden="false" targetId="d630-cc2c-3534-aaa1" type="profile"/>
-        <infoLink id="8e00-78c5-4827-4573" name="Hero" hidden="false" targetId="5065-c3a4-a9cf-db27" type="rule"/>
-        <infoLink id="623d-c628-6c92-2797" name="Firstborn" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
-        <infoLink id="b813-67aa-91fa-2984" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
-      </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="ff50-7fe6-2ad8-f15a" name="Upgrades" hidden="false" collective="false" import="true">
-          <entryLinks>
-            <entryLink id="362d-6b67-fb41-5e5f" name="Ancient Banner" hidden="false" collective="false" import="true" targetId="c068-afcc-2781-0ea4" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb8b-9f73-0cc1-bac7" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="54cc-56be-4e39-f781" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="2bc1-05ce-3d97-af6d" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="e83a-09e6-9b69-8f75" name="Death Brothers - Tactical Master" hidden="false" collective="false" import="true" targetId="f2e2-ff33-227d-9876" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="025f-2210-9a61-ab61" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="107c-c656-83b7-15b6" name="Wolf Brothers - Counter-Attack" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="49ab-fa35-c045-3183" name="Prime Leader Weapons" hidden="false" collective="false" import="true" targetId="d455-2126-cc2a-5f47" type="selectionEntryGroup"/>
-        <entryLink id="9a17-8097-df84-8ff6" name="Prime Leader Upgrades" hidden="false" collective="false" import="true" targetId="48b6-7b0b-4908-7375" type="selectionEntryGroup"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="105.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c068-afcc-2781-0ea4" name="Ancient Banner" hidden="false" collective="false" import="true" type="upgrade">
@@ -6678,13 +6502,12 @@
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
           </costs>
         </entryLink>
-        <entryLink id="d3f7-3178-a536-21be" name="Wolf Brothers - Counter-Attack" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
+        <entryLink id="d3f7-3178-a536-21be" name="Wolf Brothers - Counter" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
           </costs>
         </entryLink>
-        <entryLink id="caec-c8a0-495b-0b0b" name="Prime Leader Weapons" hidden="false" collective="false" import="true" targetId="d455-2126-cc2a-5f47" type="selectionEntryGroup"/>
-        <entryLink id="efa5-4983-f204-751a" name="Prime Leader Upgrades" hidden="false" collective="false" import="true" targetId="48b6-7b0b-4908-7375" type="selectionEntryGroup"/>
+        <entryLink id="caec-c8a0-495b-0b0b" name="Prime Brothers 1 - Upgrade List A" hidden="false" collective="false" import="true" targetId="d455-2126-cc2a-5f47" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="125.0"/>
@@ -8323,37 +8146,6 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7092-baf4-8ce7-475a" name="Prime Grave Captain" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="a08b-ad64-3469-e6ef" name="Prime Grave Captain" hidden="false" targetId="59d7-8d08-5bcc-9305" type="profile"/>
-        <infoLink id="e14d-9fcd-e75c-4600" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
-        <infoLink id="8d8d-31b0-43f7-deec" name="Hero" hidden="false" targetId="5065-c3a4-a9cf-db27" type="rule"/>
-        <infoLink id="9ef3-aa63-d9a6-412d" name="Firstborn" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
-      </infoLinks>
-      <entryLinks>
-        <entryLink id="509b-dfee-758c-a3d7" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cbe-27bf-4907-5dfc" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1463-b4f8-1ebe-d218" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="18f8-593d-de69-2670" name="Fist-Pistol" hidden="false" collective="false" import="true" targetId="baef-7852-49ca-c43c" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aff-c9b2-5948-b4d7" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27c1-0958-1b30-2a46" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="eab2-4187-d991-db6e" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="856e-aca2-a733-37e2" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9626-e038-c26b-3533" type="max"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="200.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="25db-4cd3-f542-cba6" name="Heavy Carbine" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="bc36-6123-6c6e-ee63" name="Heavy Carbine" hidden="false" targetId="0065-92af-3416-e66c" type="profile"/>
@@ -8419,8 +8211,7 @@
     </selectionEntry>
     <selectionEntry id="44eb-c1e6-0855-4e65" name="Prime Brother (Leader)" hidden="false" collective="false" import="true" type="upgrade">
       <entryLinks>
-        <entryLink id="b018-6367-3c19-cb35" name="Prime Leader Weapons" hidden="false" collective="false" import="true" targetId="d455-2126-cc2a-5f47" type="selectionEntryGroup"/>
-        <entryLink id="deef-684b-c737-6989" name="Prime Leader Upgrades" hidden="false" collective="false" import="true" targetId="48b6-7b0b-4908-7375" type="selectionEntryGroup"/>
+        <entryLink id="b018-6367-3c19-cb35" name="Prime Brothers 1 - Upgrade List A" hidden="false" collective="false" import="true" targetId="d455-2126-cc2a-5f47" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
@@ -9598,6 +9389,56 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="3d40-9fa2-76fb-f0c1" name="Grave Armor" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="0c82-7bb7-000b-8ace" name="Grave Armor" hidden="false" targetId="03e2-9f50-3f86-e757" type="profile"/>
+        <infoLink id="1a83-b04a-761d-a1c7" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="17ef-0557-9b2e-366c" name="Combat Bike (Prime)" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="2903-a6f3-f5df-dfb1" name="Combat Bike (Prime)" hidden="false" targetId="05b7-bc5e-01dd-4678" type="profile"/>
+        <infoLink id="1120-7f7f-cf5a-6db2" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
+        <infoLink id="bd43-6383-8037-006a" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
+      </infoLinks>
+      <entryLinks>
+        <entryLink id="f0b8-1a58-cbfc-777f" name="Twin Rifle" hidden="false" collective="false" import="true" targetId="706a-f3fe-b249-493c" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1c1-1789-fa48-ae2d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f7a-d9c9-36ac-81d1" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3845-01f3-e396-8597" name="Repair" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="f857-f561-4c6f-14bf" name="Repair" hidden="false" targetId="dd47-0bc0-e158-c5c7" type="profile"/>
+        <infoLink id="7639-2b67-2e43-1f29" name="Repair" page="" hidden="false" targetId="e5ed-cad2-4eba-2fbc" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2966-a919-749d-6bad" name="Battle Rites" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="775e-2888-6f54-ccff" name="Battle Rites" hidden="false" targetId="9346-feb6-452d-1174" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="df07-8f31-d6a2-a22b" name="Precision Shots" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="4be1-3628-df26-1dd9" name="Precision Shots" hidden="false" targetId="67dc-309b-3fb7-ac62" type="profile"/>
+        <infoLink id="b0fe-45df-aecb-f42f" name="AP(X)" page="" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="763b-1230-bcad-b19d" name="Battle Brothers 1 - Upgrade List A (single unit)" hidden="false" collective="false" import="true" defaultSelectionEntryId="4323-8b88-efda-e548">
@@ -10085,128 +9926,179 @@
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="d455-2126-cc2a-5f47" name="Prime Leader Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="0ee9-d16f-3e23-fea0">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="093c-f09c-d403-0b95" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b303-1ace-c806-7451" type="max"/>
-      </constraints>
-      <selectionEntries>
-        <selectionEntry id="0ee9-d16f-3e23-fea0" name="Rifle &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntryGroup id="d455-2126-cc2a-5f47" name="Prime Brothers 1 - Upgrade List A" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8e8d-6322-86ec-9d5c" name="Replace one Auto-Rifle &amp; CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="167a-ed75-9325-9bba">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e8a-7c0d-2a73-53a2" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="613f-2235-ca7b-6db9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="490f-a11b-44e1-371a" type="max"/>
           </constraints>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="53c3-eb1b-e141-2883" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="999d-495a-68b1-386a">
+          <selectionEntries>
+            <selectionEntry id="3004-f378-17de-8747" name="Pistol &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2d8-cc5c-be96-3ab8" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd86-bf9d-10c4-291d" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e470-4cb1-fd2e-82a1" type="max"/>
               </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="020f-6088-abd5-6498" name="Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="50ab-b3d5-a4fb-cf2e">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4304-3824-3f5a-da1a" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bf5-f14d-a26f-35a6" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="50ab-b3d5-a4fb-cf2e" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
+                    <entryLink id="074b-c5d9-2849-8766" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="abb8-b976-c973-c074" name="Heavy Carbine" hidden="false" collective="false" import="true" targetId="25db-4cd3-f542-cba6" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="9b1f-9931-6bb3-61d0" name="Rifle (A2)" hidden="false" collective="false" import="true" targetId="893b-7055-5ccb-3592" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="3d72-1314-a146-f474" name="Precision Rifle" hidden="false" collective="false" import="true" targetId="141f-9981-66b1-32bd" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="97c4-784e-fb14-2ba4" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="f3a6-f771-ece1-77e0" name="Shred Pistol" hidden="false" collective="false" import="true" targetId="5f1b-580c-f736-839d" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="6c73-7574-0668-9129" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="8de5-d071-5b28-023e">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8f9-7c91-78bb-55d4" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3da4-bb4b-1401-5858" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="8de5-d071-5b28-023e" name="CCW (A4)" hidden="false" collective="false" import="true" targetId="b37c-f7c4-5111-1731" type="selectionEntry"/>
+                    <entryLink id="8b2c-a66a-dae5-2235" name="Energy Sword (Prime)" hidden="false" collective="false" import="true" targetId="cd64-9c2b-796a-a23d" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="70a8-5f38-6654-f7c1" name="Energy Fist (Prime)" hidden="false" collective="false" import="true" targetId="14b5-9b15-044f-e126" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="e567-f736-1f75-964a" name="Energy Hammer (Prime)" hidden="false" collective="false" import="true" targetId="a618-db4a-13f7-92a3" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="-10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="167a-ed75-9325-9bba" name="Auto-Rifle &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f913-c147-a133-5a81" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="34d6-341f-4015-742e" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="da06-60ef-d80c-f99c">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9a0-78b1-62d8-86d6" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdb7-bb7c-bd38-9ccd" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="da06-60ef-d80c-f99c" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+                    <entryLink id="5e06-891f-c4f1-3159" name="Energy Sword (A4,Rending)" hidden="false" collective="false" import="true" targetId="cd64-9c2b-796a-a23d" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="7482-ac42-ce6d-0e4e" name="Energy Fist (Prime)" hidden="false" collective="false" import="true" targetId="14b5-9b15-044f-e126" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="019d-b498-2f1f-150c" name="Energy Hammer (Prime)" hidden="false" collective="false" import="true" targetId="a618-db4a-13f7-92a3" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="999d-495a-68b1-386a" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
-                <entryLink id="a45b-24be-dce5-c610" name="Energy Sword (Prime)" hidden="false" collective="false" import="true" targetId="cd64-9c2b-796a-a23d" type="selectionEntry">
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="4ace-3ef8-2b3e-190e" name="Energy Fist (Prime)" hidden="false" collective="false" import="true" targetId="14b5-9b15-044f-e126" type="selectionEntry">
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="e0b1-815f-54f9-b56e" name="Energy Hammer (Prime)" hidden="false" collective="false" import="true" targetId="a618-db4a-13f7-92a3" type="selectionEntry">
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-                  </costs>
+                <entryLink id="b9bb-cdbf-39c1-be24" name="Auto-Rifle" hidden="false" collective="false" import="true" targetId="f2a7-6ad7-5096-a448" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ca7-1d9c-62c5-17e2" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8028-db74-657e-1ef0" type="min"/>
+                  </constraints>
                 </entryLink>
               </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="fe38-4dac-c861-fbcd" name="Energy Sword, Energy Fist &amp; Fist-Pistol" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="14cf-6142-6ffd-89ea" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc5c-0685-c588-4540" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ea2-b069-5dff-7178" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="de0f-1dea-9873-13a0" name="Fist-Pistol" hidden="false" collective="false" import="true" targetId="baef-7852-49ca-c43c" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e19-8ae0-8773-1224" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23c6-0e85-c096-777c" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="52cd-04e5-9883-b837" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b38c-14fc-7f6e-dd9c" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f93a-9a80-e46a-48ba" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="19cf-c76b-631a-2f4d" name="Upgrade one model with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02e3-c1c5-519e-19ce" type="max"/>
+          </constraints>
           <entryLinks>
-            <entryLink id="12c5-73d2-57ee-162b" name="Auto-Rifle" hidden="false" collective="false" import="true" targetId="f2a7-6ad7-5096-a448" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eccc-06d8-cac7-d041" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0013-7bda-8de0-57d0" type="min"/>
-              </constraints>
+            <entryLink id="4468-d4e8-ba73-397e" name="Camo Cloak" hidden="false" collective="false" import="true" targetId="95b9-f24a-635e-8f6f" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="e97a-01c3-48aa-c583" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="9026-849f-8cb5-8fa2" name="Grave Armor" hidden="false" collective="false" import="true" targetId="3d40-9fa2-76fb-f0c1" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="85.0"/>
+              </costs>
             </entryLink>
           </entryLinks>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="e084-b012-0a76-e2f6" name="Pistol &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4382-0415-7335-1484" type="max"/>
-          </constraints>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="1993-ad98-435d-430c" name="Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="fa5c-84ae-eb73-892e">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3dd-1323-f264-de88" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2389-125b-d549-f966" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="fa5c-84ae-eb73-892e" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
-                <entryLink id="083e-81da-6e15-fbfc" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="fae8-8277-f5a7-bc6f" name="Heavy Carbine" hidden="false" collective="false" import="true" targetId="25db-4cd3-f542-cba6" type="selectionEntry">
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="ca65-9903-4772-a495" name="Rifle (A2)" hidden="false" collective="false" import="true" targetId="893b-7055-5ccb-3592" type="selectionEntry">
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="c3e3-15b2-1c55-5e39" name="Precision Rifle" hidden="false" collective="false" import="true" targetId="141f-9981-66b1-32bd" type="selectionEntry">
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="c000-2a34-979d-26fb" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="7ba0-2575-9eea-61d8" name="Shred Pistol" hidden="false" collective="false" import="true" targetId="5f1b-580c-f736-839d" type="selectionEntry">
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                  </costs>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="649e-319b-55b6-7d01" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="9e0d-f2e7-f925-0642">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="504b-43d4-e04a-d629" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c92f-fb46-ca4c-79a2" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="9e0d-f2e7-f925-0642" name="CCW (A4)" hidden="false" collective="false" import="true" targetId="b37c-f7c4-5111-1731" type="selectionEntry"/>
-                <entryLink id="3720-6a3d-7721-1884" name="Energy Sword (Prime)" hidden="false" collective="false" import="true" targetId="cd64-9c2b-796a-a23d" type="selectionEntry">
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="fe9b-2ea5-e763-6352" name="Energy Fist (Prime)" hidden="false" collective="false" import="true" targetId="14b5-9b15-044f-e126" type="selectionEntry">
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="8099-dd46-0abd-2cf0" name="Energy Hammer (Prime)" hidden="false" collective="false" import="true" targetId="a618-db4a-13f7-92a3" type="selectionEntry">
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-                  </costs>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="-10.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
     </selectionEntryGroup>
     <selectionEntryGroup id="b8a5-2300-ea05-b1e8" name="Prime Psychic Spell List" hidden="false" collective="false" import="true" defaultSelectionEntryId="dab3-681f-ed76-8c49">
       <constraints>
@@ -10380,29 +10272,6 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-    </selectionEntryGroup>
-    <selectionEntryGroup id="48b6-7b0b-4908-7375" name="Prime Leader Upgrades" hidden="false" collective="false" import="true">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="383b-33ad-c5da-ff91" type="max"/>
-      </constraints>
-      <entryLinks>
-        <entryLink id="6fd8-6eb3-7dd8-03d6" name="Camo Cloak" hidden="false" collective="false" import="true" targetId="95b9-f24a-635e-8f6f" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c65e-08ad-c8d7-078a" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="0fe2-7c59-1964-fc14" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eada-dab5-cbc1-6beb" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-      </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="1053-1e3d-6ca4-6012" name="Battle Brothers 1 - Upgrade List B" hidden="false" collective="false" import="true">
       <selectionEntryGroups>
@@ -14156,6 +14025,85 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>
+    <selectionEntryGroup id="9b9b-2dc9-35a9-7953" name="Prime Brothers 1 - Upgrade List B" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0ae2-f7af-59bc-7895" name="Upgrade with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9766-7bb6-ee79-2b64" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="02f9-0c44-a89d-5fae" name="Camo Cloak" hidden="false" collective="false" import="true" targetId="95b9-f24a-635e-8f6f" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="8f97-a3c9-60a5-3fb8" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="28ca-3d53-ad99-12de" name="Grave Armor" hidden="false" collective="false" import="true" targetId="3d40-9fa2-76fb-f0c1" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="85.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="0477-417c-143e-a2ef" name="Combat Bike (Prime)" hidden="false" collective="false" import="true" targetId="17ef-0557-9b2e-366c" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="35ec-a324-6b5c-a884" name="Upgrade with:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="ff64-b74e-f74a-c777" name="Veteran Infantry" hidden="false" collective="false" import="true" targetId="c1fc-c830-141f-e36e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26aa-9c64-6920-c24f" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="fe39-67bd-4fc1-28da" name="Prime Brothers 1 - Upgrade List C" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9607-6db8-88ea-6464" name="Upgrade with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08c4-94e2-786f-ecba" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="8389-7f36-af7a-25d3" name="Repair" hidden="false" collective="false" import="true" targetId="3845-01f3-e396-8597" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="46e1-1264-b6a5-298f" name="War Chant" hidden="false" collective="false" import="true" targetId="bf85-06cc-c402-61e6" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="d5fd-adb1-25c8-6ef5" name="Battle Rites" hidden="false" collective="false" import="true" targetId="2966-a919-749d-6bad" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="d395-f546-f0ef-baee" name="Ancient Banner" hidden="false" collective="false" import="true" targetId="c068-afcc-2781-0ea4" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="3dd4-f84e-98f7-4dd4" name="Precision Shots" hidden="false" collective="false" import="true" targetId="df07-8f31-d6a2-a22b" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="45.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
     <rule id="ff04-8ef9-82f1-a88b" name="Shield Wall" publicationId="dead-6af1-a069-5579" hidden="false">
@@ -14206,12 +14154,6 @@
     </rule>
     <rule id="5c24-d8ee-b4ed-4c8d" name="Counter" publicationId="a380-f550-5f9a-c792" hidden="false">
       <description>This model gets +1 melee attack with a weapon of your choice when charged.</description>
-    </rule>
-    <rule id="f5ec-4c00-c9e8-f999" name="Battle Rites" publicationId="dead-6af1-a069-5579" hidden="false">
-      <description>The hero and his unit get +1 to their melee rolls.</description>
-    </rule>
-    <rule id="626a-c071-1a4b-7188" name="Precision Shots" publicationId="dead-6af1-a069-5579" hidden="false">
-      <description>The hero and his unit get AP(+1) when shooting.</description>
     </rule>
     <rule id="e5ed-cad2-4eba-2fbc" name="Repair" publicationId="dead-6af1-a069-5579" hidden="false">
       <description>Once per turn, if within 2&quot; of a unit with Tough, roll one die. On a 4+ you may repair one wound from the target.</description>
@@ -15351,20 +15293,6 @@
         <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Hero, Prime, Tough(3)</characteristic>
       </characteristics>
     </profile>
-    <profile id="4911-e8fe-8cf4-dded" name="Prime Lieutenant" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
-      <characteristics>
-        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">3+</characteristic>
-        <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">2+</characteristic>
-        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Hero, Prime, Tough(3)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="d630-cc2c-3534-aaa1" name="Prime Ancient" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
-      <characteristics>
-        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">3+</characteristic>
-        <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">2+</characteristic>
-        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Hero, Prime, Tough(3)</characteristic>
-      </characteristics>
-    </profile>
     <profile id="a35d-ed47-ab3c-7dfd" name="Prime Psychic" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
       <characteristics>
         <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">3+</characteristic>
@@ -15646,13 +15574,6 @@
       <characteristics>
         <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A2</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(1)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="59d7-8d08-5bcc-9305" name="Prime Grave Captain" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
-      <characteristics>
-        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">3+</characteristic>
-        <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">2+</characteristic>
-        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Hero, Prime, Tough(6)</characteristic>
       </characteristics>
     </profile>
     <profile id="0065-92af-3416-e66c" name="Heavy Carbine" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
@@ -15938,6 +15859,31 @@
     <profile id="a83a-15ac-32a0-f793" name="Veteran Walker" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
       <characteristics>
         <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">This model gets +1 to its attack rolls for melee and shooting.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="03e2-9f50-3f86-e757" name="Grave Armor" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
+      <characteristics>
+        <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Tough(+3)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="05b7-bc5e-01dd-4678" name="Combat Bike (Prime)" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
+      <characteristics>
+        <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Fast, Impact(1), Twin Rifle</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="dd47-0bc0-e158-c5c7" name="Repair" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
+      <characteristics>
+        <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Repair	</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="9346-feb6-452d-1174" name="Battle Rites" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
+      <characteristics>
+        <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">The hero and his unit get +1 to their melee rolls.	</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="67dc-309b-3fb7-ac62" name="Precision Shots" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
+      <characteristics>
+        <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">The hero and his unit get AP(+1) when shooting.</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -6701,73 +6701,61 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="205.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="06ab-90de-30e2-fc37" name="Infiltration Brother" hidden="false" collective="false" import="true" type="upgrade">
-      <entryLinks>
-        <entryLink id="cf50-cfef-ae1b-29b3" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="168d-fc4b-a9af-d00f" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d99-6193-b00c-fc36" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6e1-bf98-3fd6-ebd1" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="0ed4-345c-94cb-2400" name="Heavy Carbine" hidden="false" collective="false" import="true" targetId="25db-4cd3-f542-cba6" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="923e-a6c3-e34c-ae23" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d435-3f76-b325-60de" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="05cc-7b76-fd6d-5a0d" name="Infiltration Squad" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="2022-fdb4-22d7-2cfb" name="Infiltration Brothers" hidden="false" targetId="e103-87eb-0ab6-75f6" type="profile"/>
+        <infoLink id="2022-fdb4-22d7-2cfb" name="Prime Infiltration Brother" hidden="false" targetId="e103-87eb-0ab6-75f6" type="profile"/>
         <infoLink id="adc7-bde9-5b35-0899" name="Firstborn" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
         <infoLink id="2ff3-a5f6-104b-c80b" name="Scout" hidden="false" targetId="7bc7-a892-49bc-ad88" type="rule"/>
       </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="63db-69aa-5c10-be06" name="Upgrade one:" hidden="false" collective="false" import="true">
-          <entryLinks>
-            <entryLink id="ceb7-43c3-303b-d942" name="Medical Training" hidden="false" collective="false" import="true" targetId="8352-cbe6-9410-a422" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9a8-884b-acae-4b5e" type="max"/>
-              </constraints>
+        <selectionEntryGroup id="a17c-16b7-314d-8022" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="780a-f83b-dcd8-ea86">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de85-b150-724c-8b32" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae3e-e4e0-f866-6e70" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="780a-f83b-dcd8-ea86" name="Single Unit [5 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="81ee-a4ab-8fdb-febb" name="** Detachment Upgrade (Units of [5], single unit) **" hidden="false" collective="false" import="true" targetId="f024-6c76-c658-300a" type="selectionEntryGroup"/>
+                <entryLink id="665a-a100-9e96-ba52" name="Prime Brothers 1 - Upgrade List E (single unit)" hidden="false" collective="false" import="true" targetId="0bb9-e22c-0855-349c" type="selectionEntryGroup"/>
+                <entryLink id="4631-aa8b-90d3-7718" name="Heavy Carbine" hidden="false" collective="false" import="true" targetId="25db-4cd3-f542-cba6" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6598-856e-a5b2-f696" type="min"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a3d-be16-cea2-6768" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="2e78-3ed6-1803-8874" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d8c-2a11-d0ec-a126" type="min"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="374d-6a37-b62a-19fb" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="e42c-5077-49bd-3c72" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="3acd-a07e-5e29-2e90" name="** Detachment Upgrade (Units of [5], combined unit) **" hidden="false" collective="false" import="true" targetId="3ed3-d384-8a43-eb07" type="selectionEntryGroup"/>
+                <entryLink id="6df4-f66d-de34-1955" name="Prime Brothers 1 - Upgrade List E (combined unit)" hidden="false" collective="false" import="true" targetId="1ad2-e3d2-1485-cc14" type="selectionEntryGroup"/>
+                <entryLink id="60f3-6b52-8c3d-a479" name="Heavy Carbine" hidden="false" collective="false" import="true" targetId="25db-4cd3-f542-cba6" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3226-4f45-0aa5-716c" type="min"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42c4-464a-0eeb-fd69" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="d16b-c8f8-654d-9b80" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5d6-2b7f-019a-ed32" type="min"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e815-bfd2-0506-17c0" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="45.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="230.0"/>
               </costs>
-            </entryLink>
-          </entryLinks>
+            </selectionEntry>
+          </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="2f0b-dd90-7380-54a7" name="Infiltration Brother" hidden="false" collective="false" import="true" targetId="06ab-90de-30e2-fc37" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56dc-804e-2534-fb37" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c77-e82f-ee35-d536" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="ada5-0664-6685-cc2f" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="a4ba-0eaf-e8db-81aa" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="14f2-b2a3-21ed-eda8" name="Wolf Brothers - Counter-Attack" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="3e5f-e698-1f23-64c1" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-      </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="230.0"/>
       </costs>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -2253,6 +2253,7 @@
       </infoLinks>
       <entryLinks>
         <entryLink id="795d-c995-17bb-1553" name="Dark Brothers - Upgrade List A" hidden="false" collective="false" import="true" targetId="f950-3ba7-5f90-d23d" type="selectionEntryGroup"/>
+        <entryLink id="f28f-1b20-815c-f9a7" name="** Detachment Upgrade (Heroes) **" hidden="false" collective="false" import="true" targetId="64f3-fff6-95b2-f27b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="105.0"/>
@@ -2306,32 +2307,31 @@
       <infoLinks>
         <infoLink id="ba2c-e933-3c03-e567" name="Destroyer Knight" hidden="false" targetId="1095-a5b6-8960-00f2" type="profile"/>
         <infoLink id="40a6-8fa9-8d10-771d" name="Dark Assault" hidden="false" targetId="2f63-3966-49eb-3601" type="rule"/>
-        <infoLink id="57b4-f2f7-c516-5073" name="Dark Resolve" hidden="false" targetId="5dec-9937-47f8-7cf4" type="rule"/>
+        <infoLink id="57b4-f2f7-c516-5073" name="Grim" hidden="false" targetId="5dec-9937-47f8-7cf4" type="rule"/>
         <infoLink id="3bcb-e362-e026-b3a6" name="Shield Wall" hidden="false" targetId="ff04-8ef9-82f1-a88b" type="rule"/>
         <infoLink id="6b51-d5f3-921e-9969" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
       </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="8cc7-aec5-38d1-3268" name="Melee Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="11d0-724c-b9ae-76b7">
+        <selectionEntryGroup id="5e76-9085-567c-3f60" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="6257-c193-6152-65b0">
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be1b-ba07-67d6-2d21" type="min"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="adff-a6ed-4af5-36fa" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4842-0326-0f00-e574" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ef7-0bbb-beee-88b2" type="max"/>
           </constraints>
-          <entryLinks>
-            <entryLink id="11d0-724c-b9ae-76b7" name="Heavy Mace" hidden="false" collective="false" import="true" targetId="1231-61b7-e02f-3361" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdfb-7213-e4ab-255f" type="max"/>
-                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="542f-b171-3864-d654" type="min"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="dcaf-ae34-84fc-9164" name="Heavy Flail" hidden="false" collective="false" import="true" targetId="87a3-d290-9631-54dc" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="067c-9616-8d7c-23d1" type="max"/>
-              </constraints>
+          <selectionEntries>
+            <selectionEntry id="6257-c193-6152-65b0" name="Single Unit [5 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="3f96-0a69-efff-bee6" name="Dark Brothers - Upgrade List C (single unit)" hidden="false" collective="false" import="true" targetId="66db-87d3-f028-93a8" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="7aa2-e897-eb07-783d" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="f84f-bd56-4a3b-51ed" name="Dark Brothers - Upgrade List C (combined unit)" hidden="false" collective="false" import="true" targetId="7188-335b-606e-d5c7" type="selectionEntryGroup"/>
+              </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="605.0"/>
               </costs>
-            </entryLink>
-          </entryLinks>
+            </selectionEntry>
+          </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
@@ -8517,6 +8517,11 @@
             </modifier>
             <modifier type="set" field="hidden" value="true">
               <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f729-b6f1-70a7-ab93" type="instanceOf"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
                 <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8150-2743-e904-7a5c" type="greaterThan"/>
               </conditions>
             </modifier>
@@ -8535,6 +8540,11 @@
             <modifier type="set" field="hidden" value="false">
               <conditions>
                 <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d40-9fa2-76fb-f0c1" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f729-b6f1-70a7-ab93" type="instanceOf"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -15350,6 +15360,58 @@
             <entryLink id="0b7f-f9bf-0c72-ab8a" name="Cyclone Missiles" hidden="false" collective="false" import="true" targetId="de20-063e-ab3f-d5cb" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="66db-87d3-f028-93a8" name="Dark Brothers - Upgrade List C (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7071-21be-30dd-b5e0" name="Replace one Heavy Mace:" hidden="false" collective="false" import="true" defaultSelectionEntryId="dcd2-4d02-2d3e-60e1">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51d6-6d64-532e-68ca" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab09-43dd-3eab-6c5c" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="dcd2-4d02-2d3e-60e1" name="Heavy Mace" hidden="false" collective="false" import="true" targetId="1231-61b7-e02f-3361" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bd7-6fde-2ab5-956c" type="max"/>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9d2-e1b1-7b2e-5afb" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="710f-7114-404f-f3f4" name="Heavy Flail" hidden="false" collective="false" import="true" targetId="87a3-d290-9631-54dc" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03e7-625a-f7b5-28a6" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="7188-335b-606e-d5c7" name="Dark Brothers - Upgrade List C (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="f984-a85d-c19e-350a" name="Replace two Heavy Maces:" hidden="false" collective="false" import="true" defaultSelectionEntryId="5795-7058-b4e3-de18">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a35-2f42-7e04-e0e1" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29aa-9a81-e74c-96c9" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5795-7058-b4e3-de18" name="Heavy Mace" hidden="false" collective="false" import="true" targetId="1231-61b7-e02f-3361" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6eae-1cfe-b507-0fcd" type="max"/>
+                <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fff4-a5bf-dfd6-cd06" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="67a1-805f-03fe-f97c" name="Heavy Flail" hidden="false" collective="false" import="true" targetId="87a3-d290-9631-54dc" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2da7-ba88-b6ea-7c46" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
               </costs>
             </entryLink>
           </entryLinks>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -1935,6 +1935,9 @@
               <entryLinks>
                 <entryLink id="bd10-0bae-4392-e85a" name="Blood Brothers - Upgrade List B (single unit)" hidden="false" collective="false" import="true" targetId="459c-bde6-0f63-d0bf" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="6ce9-cd44-c825-3447" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -2036,6 +2039,9 @@
               <entryLinks>
                 <entryLink id="b83d-b44b-bf66-0cef" name="Blood Brothers - Upgrade List C (single unit)" hidden="false" collective="false" import="true" targetId="ebd0-c4fc-2ee9-942c" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="5fc3-17d5-a325-4755" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -2198,10 +2204,11 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="375a-5ae7-23b5-4350" name="Energy Sword (A4)" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="375a-5ae7-23b5-4350" name="Energy Sword (Champion)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="003f-d591-dc4e-c42a" name="Energy Sword" hidden="false" targetId="31bb-640e-201e-24a2" type="profile"/>
+        <infoLink id="003f-d591-dc4e-c42a" name="Energy Sword (A4)" hidden="false" targetId="31bb-640e-201e-24a2" type="profile"/>
         <infoLink id="db45-919d-98dc-cb1a" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
+        <infoLink id="e7ec-b6f4-a669-5ba4" name="Rending" hidden="false" targetId="9726-accd-9015-f6f6" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
@@ -2277,6 +2284,9 @@
               <entryLinks>
                 <entryLink id="8a54-cea2-6a60-67f6" name="Dark Brothers - Upgrade List B (single unit)" hidden="false" collective="false" import="true" targetId="5b91-c09c-1a1c-198d" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="c0f4-fde5-041f-ad52" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -2322,6 +2332,9 @@
               <entryLinks>
                 <entryLink id="3f96-0a69-efff-bee6" name="Dark Brothers - Upgrade List C (single unit)" hidden="false" collective="false" import="true" targetId="66db-87d3-f028-93a8" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="7aa2-e897-eb07-783d" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -2357,6 +2370,9 @@
               <entryLinks>
                 <entryLink id="5df4-dfe5-b0da-ca46" name="Dark Brothers - Upgrade List D (single unit)" hidden="false" collective="false" import="true" targetId="9256-e441-3d5e-dd53" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="7bf0-8163-40b4-06c3" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -3685,7 +3701,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="887b-4359-f3ff-faf6" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="7cb7-e67a-f09b-8117" name="Energy Sword" hidden="false" collective="false" import="true" targetId="375a-5ae7-23b5-4350" type="selectionEntry">
+        <entryLink id="7cb7-e67a-f09b-8117" name="Energy Sword (A4)" hidden="false" collective="false" import="true" targetId="375a-5ae7-23b5-4350" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d0c-be6a-d4cf-7d5b" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2aa6-3910-77d7-c753" type="min"/>
@@ -7468,6 +7484,9 @@
         <infoLink id="cd98-227a-90f2-c068" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
         <infoLink id="4e9d-6c6f-372b-839f" name="Deadly(X)" hidden="false" targetId="377b-3864-960e-57ac" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="682b-440e-a942-5986" name="Heavy Laser Talon" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -7475,6 +7494,9 @@
         <infoLink id="f91c-709d-67d6-02e1" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
         <infoLink id="9115-920a-7cf6-7786" name="Deadly(X)" hidden="false" targetId="377b-3864-960e-57ac" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="5e0c-bc57-d643-ad5c" name="Twin AA-Rocket Pod" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -7482,6 +7504,9 @@
         <infoLink id="59a2-8767-f480-03f4" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
         <infoLink id="640a-e3d5-bffe-6c76" name="Anti-Air" hidden="false" targetId="1875-13ee-b0ef-5a65" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="89bd-59e9-b651-bc16" name="Strike Missiles" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -7489,6 +7514,9 @@
         <infoLink id="624e-3e28-554a-727b" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
         <infoLink id="569e-a674-9e30-fd99" name="Deadly(X)" hidden="false" targetId="377b-3864-960e-57ac" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="b462-6a11-cedb-7b97" name="Fury Missiles" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -7496,12 +7524,18 @@
         <infoLink id="c6b2-e620-c2dd-50b4" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
         <infoLink id="0e0b-22e8-a7af-cd9b" name="Deadly(X)" hidden="false" targetId="377b-3864-960e-57ac" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="945e-15ad-b707-77b4" name="Twin Heavy Autocannon" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="a0f9-cf78-6d32-891b" name="Twin Heavy Autocannon" hidden="false" targetId="30a2-e84d-af91-24f9" type="profile"/>
         <infoLink id="96fe-d446-5e60-e290" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="1f0b-73f9-9cf0-c69d" name="Support Turret" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -7528,12 +7562,18 @@
       <infoLinks>
         <infoLink id="1859-a1e6-c0c5-ca8f" name="Turret Crew" hidden="false" targetId="6840-c3ac-1e90-97a2" type="profile"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="e5f6-edd1-35f4-918e" name="Dark Shroud" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="c6c3-5806-e404-78c8" name="Dark Shroud" hidden="false" targetId="4843-ef34-a0a4-8b68" type="profile"/>
         <infoLink id="6bd3-7a72-69aa-a916" name="Stealth" hidden="false" targetId="1b59-5d31-4675-c926" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -14456,6 +14496,9 @@
                   </constraints>
                 </entryLink>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="fbbe-57d4-066f-b2a8" name="Pistols &amp; CCWs (A2)" hidden="false" collective="false" import="true" type="upgrade">
               <selectionEntryGroups>
@@ -14508,6 +14551,9 @@
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -14568,6 +14614,9 @@
                   </constraints>
                 </entryLink>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="45f4-85d2-fdb9-7e76" name="Pistols &amp; CCWs (A2)" hidden="false" collective="false" import="true" type="upgrade">
               <selectionEntryGroups>
@@ -14620,6 +14669,9 @@
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -14864,6 +14916,9 @@
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
@@ -16093,10 +16148,10 @@
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(1)</characteristic>
       </characteristics>
     </profile>
-    <profile id="31bb-640e-201e-24a2" name="Energy Sword (A4)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
+    <profile id="31bb-640e-201e-24a2" name="Energy Sword (Champion)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
         <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A4</characteristic>
-        <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(1)</characteristic>
+        <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(1), Rending</characteristic>
       </characteristics>
     </profile>
     <profile id="6c19-c764-d797-32d4" name="Spear (Custodians)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -3538,109 +3538,50 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9627-1fe7-1def-44b6" name="Wolf Rider" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="76b4-a768-c417-8f21" name="Wolf Riders" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="b1e3-2b9f-372c-3434" name="Wolf Rider" hidden="false" targetId="783f-130a-4f6b-f763" type="profile"/>
-        <infoLink id="af44-7e6c-250c-4ed0" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="3914-71d5-ec6d-712f" name="Counter-Attack" hidden="false" targetId="5c24-d8ee-b4ed-4c8d" type="rule"/>
-        <infoLink id="cf91-69a7-3dcb-dded" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
-        <infoLink id="607b-d1bf-23c9-b094" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
-        <infoLink id="a21d-adc1-9e32-eedf" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
+        <infoLink id="9e72-3b96-1a6e-af80" name="Wolf Rider" hidden="false" targetId="783f-130a-4f6b-f763" type="profile"/>
+        <infoLink id="5fa5-6997-3a33-a806" name="Counter" hidden="false" targetId="5c24-d8ee-b4ed-4c8d" type="rule"/>
+        <infoLink id="f109-faad-7071-4f4d" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
+        <infoLink id="83f8-4e17-ad23-a5cd" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
+        <infoLink id="1a01-789f-3e2d-48ba" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
+        <infoLink id="1995-f901-5f39-cfb0" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
       </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="575a-5bad-4d50-10ca" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="f512-7621-8f6b-3aaa">
+        <selectionEntryGroup id="5605-9813-76f5-172b" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="8d34-ae65-8e71-e816">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7300-9dcb-bf8f-e489" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fefb-a6ba-9e15-a2ad" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f62c-44f1-1cb5-ec53" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3aea-ece4-0f2d-6e91" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="f512-7621-8f6b-3aaa" name="Ranged &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="873e-ed11-9405-19d9" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="962b-c485-ef9f-585e">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ab5-cf22-ffc6-3077" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8318-d408-da4f-ca10" type="min"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="962b-c485-ef9f-585e" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
-                    <entryLink id="80f4-abee-5078-59d3" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="ae52-e304-42ac-462a" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="07fe-06c6-61d3-61c0" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="13f9-2d9e-7c57-88e0" name="Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="8cdd-d594-bda8-880d">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d7c-03d6-79b1-138f" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea00-be06-0ed5-896d" type="min"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="8cdd-d594-bda8-880d" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
-                    <entryLink id="7e98-8725-398e-0cb3" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="ef26-c337-d3b6-1b49" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="361e-0aa4-ea1c-eeda" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="8d34-ae65-8e71-e816" name="Single Unit [3 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="2dd0-ef39-9da8-ce2c" name="Energy Claw" hidden="false" collective="false" import="true" targetId="71e9-a72c-6160-0673" type="selectionEntry">
+                <entryLink id="0e92-f022-3ea1-9ba8" name="Claws (Great Wolf)" hidden="false" collective="false" import="true" targetId="b3f8-ec99-741a-436e" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f42-3423-f35c-821d" type="min"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1840-58de-dd1c-8dfe" type="max"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="351b-d729-95f3-dc86" type="min"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8925-f3dc-7680-c0c3" type="max"/>
                   </constraints>
                 </entryLink>
+                <entryLink id="1dea-4b12-9a69-6f87" name="Wolf Brothers - Upgrade List F (single unit)" hidden="false" collective="false" import="true" targetId="c296-c964-e5e7-c7a8" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="633e-21e3-dfc7-1a49" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="6fd5-5370-4cda-2d13" name="Claws (Great Wolf)" hidden="false" collective="false" import="true" targetId="b3f8-ec99-741a-436e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0d9-d8b2-e8d8-13aa" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="563d-7972-7ca8-0f4f" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="0ad2-d5a0-ec91-abaf" name="Wolf Brothers - Upgrade List F (combined unit)" hidden="false" collective="false" import="true" targetId="db09-30b5-ef95-9dcb" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="315.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="e05f-32d2-8302-25d5" name="Claws" hidden="false" collective="false" import="true" targetId="a8f4-d9ee-4670-fd42" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d987-02fe-4ff3-cbb9" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1002-4604-c676-eb35" type="max"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="76b4-a768-c417-8f21" name="Wolf Riders" hidden="false" collective="false" import="true" type="upgrade">
-      <entryLinks>
-        <entryLink id="405e-05a9-55fe-645b" name="Wolf Rider" hidden="false" collective="false" import="true" targetId="9627-1fe7-1def-44b6" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ba4-84e1-de82-e07f" type="max"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99c4-854a-b5d4-02ed" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="315.0"/>
       </costs>
@@ -5262,7 +5203,7 @@
     </selectionEntry>
     <selectionEntry id="b3f8-ec99-741a-436e" name="Claws (Great Wolf)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="206e-eb89-2dca-6b05" name="Claws (AP1)" hidden="false" targetId="4bfd-85ee-240c-f5f9" type="profile"/>
+        <infoLink id="206e-eb89-2dca-6b05" name="Claws (Great Wolf)" hidden="false" targetId="4bfd-85ee-240c-f5f9" type="profile"/>
         <infoLink id="e442-0b40-71c7-3670" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
       </infoLinks>
       <costs>
@@ -16555,6 +16496,146 @@
               </costs>
             </entryLink>
           </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="c296-c964-e5e7-c7a8" name="Wolf Brothers - Upgrade List F (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8dd8-c0dc-1730-37e2" name="Replace any Pistol &amp; CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="8576-9376-edbb-6f1b">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e99-fee6-0d38-bd1d" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f99-e824-75c1-34f5" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8576-9376-edbb-6f1b" name="Pistol &amp; CCW(A2)" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="f2a6-92c1-d862-419e" name="Replace any Pistol:" hidden="false" collective="true" import="true" defaultSelectionEntryId="240c-8066-591d-53e6">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acf6-f030-1291-ecef" type="min"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="240c-8066-591d-53e6" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
+                    <entryLink id="0b0a-ff3d-53e3-8196" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="5fa9-51f3-067f-e4b8" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="4d6d-744e-b1e4-5ac7" name="Replace any CCW:" hidden="false" collective="true" import="true" defaultSelectionEntryId="8c4d-3d04-a873-c3bd">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba20-068c-20db-e5cd" type="min"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="8c4d-3d04-a873-c3bd" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+                    <entryLink id="c27b-6c92-eceb-7d30" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="9f7e-890d-9432-42f8" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="ccde-7ad9-3180-f5c0" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntry>
+            <selectionEntry id="ad7d-33c5-de15-8f9d" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="db5f-02f8-d849-92ec" name="Energy Claw" hidden="false" collective="false" import="true" targetId="0ed5-13cf-f02f-9759" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab9d-f613-31e7-cab2" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7338-9586-bae4-6c85" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="db09-30b5-ef95-9dcb" name="Wolf Brothers - Upgrade List F (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e74f-2152-7175-127c" name="Replace any Pistol &amp; CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="b0d5-2fa6-e938-af8b">
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ca3-8f63-81c2-8660" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="34e7-38a5-0058-8cf1" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="b0d5-2fa6-e938-af8b" name="Pistol &amp; CCW(A2)" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="eae6-e67c-c14a-7f4e" name="Replace any Pistol:" hidden="false" collective="true" import="true" defaultSelectionEntryId="5288-028f-f8fc-3b00">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a19-f8a5-7181-3e3d" type="min"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="5288-028f-f8fc-3b00" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
+                    <entryLink id="1f3e-e727-1069-146b" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="0192-c69c-1ce2-94e0" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="29da-be8a-bc61-3db2" name="Replace any CCW:" hidden="false" collective="true" import="true" defaultSelectionEntryId="a894-8850-0b28-da1e">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2f2-59e7-f2f8-0043" type="min"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="a894-8850-0b28-da1e" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+                    <entryLink id="47ed-96e5-a6af-ea86" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="1c8b-2b1c-2cd1-3fcc" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="41b2-c039-b0d8-a8db" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntry>
+            <selectionEntry id="7433-dc49-e4c2-b04f" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="724b-b825-91b3-f27f" name="Energy Claw" hidden="false" collective="false" import="true" targetId="0ed5-13cf-f02f-9759" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="495a-b180-1746-eb17" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b53-b3ff-6575-518b" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -1808,42 +1808,6 @@
         <infoLink id="138d-3aa7-e8aa-151c" name="Hawk Interceptor" hidden="false" targetId="3a06-70eb-92f5-58ee" type="profile"/>
         <infoLink id="b55e-0ad0-4bed-f922" name="Aircraft" hidden="false" targetId="187f-6a03-5b99-a4db" type="rule"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="153c-113f-af87-442c" name="Weapon 1" hidden="false" collective="false" import="true" defaultSelectionEntryId="c0a5-9256-d3ac-b7a4">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a58-01a0-d5ac-8d97" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="505d-4bd7-3441-39db" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="c0a5-9256-d3ac-b7a4" name="Laser Talon" hidden="false" collective="false" import="true" targetId="a799-464d-ce26-f29b" type="selectionEntry"/>
-            <entryLink id="167d-c50f-6cc9-412d" name="Storm Cannon" hidden="false" collective="false" import="true" targetId="114d-53c3-1207-7a35" type="selectionEntry"/>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="fe96-1f2f-156b-3a5a" name="Weapon 2" hidden="false" collective="false" import="true" defaultSelectionEntryId="be6f-ed25-efdb-1d0c">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6579-ea51-3c1b-8e73" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8f5-ca50-7ff2-d38f" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="8f1f-fe71-e60f-a229" name="Hammer Missiles" hidden="false" collective="false" import="true" targetId="2b23-f91f-8f74-d7d9" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="-5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="be6f-ed25-efdb-1d0c" name="Twin Heavy Machinegun" hidden="false" collective="false" import="true" targetId="dae8-3106-6a96-228c" type="selectionEntry"/>
-            <entryLink id="dcd5-d4d0-1558-8456" name="Twin Laser Cannon" hidden="false" collective="false" import="true" targetId="d271-2d81-e640-0040" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="8826-9878-a3ed-d601" name="Typhoon Missiles" hidden="false" collective="false" import="true" targetId="8aef-9844-eaa7-e640" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="f7db-09a9-322c-7713" name="Twin Minigun" hidden="false" collective="false" import="true" targetId="a8f7-27d2-59eb-c865" type="selectionEntry">
           <constraints>
@@ -1851,6 +1815,8 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ef2-7856-114c-b78d" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="1e11-b64b-5df0-15ee" name="Battle Brothers 3 - Upgrade List F" hidden="false" collective="false" import="true" targetId="b318-fdf6-1539-0b03" type="selectionEntryGroup"/>
+        <entryLink id="2446-1cf0-af2a-3a08" name="** Detachment Upgrade (Units of [1] with Tough(6) **" hidden="false" collective="false" import="true" targetId="35c2-8df3-f833-4949" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="310.0"/>
@@ -14140,6 +14106,44 @@
               </costs>
             </entryLink>
             <entryLink id="80f1-52ea-bee1-cddd" name="Typhoon Missiles" hidden="false" collective="false" import="true" targetId="8aef-9844-eaa7-e640" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="b318-fdf6-1539-0b03" name="Battle Brothers 3 - Upgrade List F" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ef87-7d7b-b07c-e10b" name="Replace Laser Talon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="c1dc-4c05-de58-a7c4">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60e7-fe48-b6b4-38b4" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecd3-7a1d-5407-2e3b" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="c1dc-4c05-de58-a7c4" name="Laser Talon" hidden="false" collective="false" import="true" targetId="a799-464d-ce26-f29b" type="selectionEntry"/>
+            <entryLink id="96ef-d1ca-3633-d1c3" name="Storm Cannon" hidden="false" collective="false" import="true" targetId="114d-53c3-1207-7a35" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a162-93bd-ae9c-2f6c" name="Replace Twin Heavy Machinegun:" hidden="false" collective="false" import="true" defaultSelectionEntryId="5bb8-8aef-dcdd-a7c9">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="814f-6ab0-de7e-94c8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b08-e769-b694-ff63" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="c429-8db7-5f3a-54c8" name="Hammer Missiles" hidden="false" collective="false" import="true" targetId="2b23-f91f-8f74-d7d9" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="-5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="5bb8-8aef-dcdd-a7c9" name="Twin Heavy Machinegun" hidden="false" collective="false" import="true" targetId="dae8-3106-6a96-228c" type="selectionEntry"/>
+            <entryLink id="62de-a2f9-4dab-f091" name="Twin Laser Cannon" hidden="false" collective="false" import="true" targetId="d271-2d81-e640-0040" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="8752-8c12-ea8e-9cc4" name="Typhoon Missiles" hidden="false" collective="false" import="true" targetId="8aef-9844-eaa7-e640" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
               </costs>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -956,6 +956,18 @@
         <categoryLink id="d9bd-f830-cce0-1015" name="New CategoryLink" hidden="false" targetId="b820-6309-e900-c733" primary="true"/>
       </categoryLinks>
     </entryLink>
+    <entryLink id="835a-391c-e158-d001" name="Prime Speeder" hidden="false" collective="false" import="true" targetId="cac1-714c-f9c2-7edb" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="dc7a-12df-d69b-ed72" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="8d10-24e1-7505-c91c" name="New CategoryLink" hidden="false" targetId="3089-78fc-94cc-28a2" primary="true"/>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="40e7-3f33-f159-d98d" name="Captain" hidden="false" collective="false" import="true" type="upgrade">
@@ -8406,6 +8418,59 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="cac1-714c-f9c2-7edb" name="Prime Speeder" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="c05f-a2aa-ecb0-37db" name="Prime Speeder" hidden="false" targetId="1711-674c-8591-616a" type="profile"/>
+        <infoLink id="8937-1b29-2f91-4bf9" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
+        <infoLink id="7e9a-c038-f59c-1c86" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
+        <infoLink id="33f9-92be-4fb2-91ae" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
+        <infoLink id="46b3-c651-3753-3368" name="Prime" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
+        <infoLink id="a0ce-63d9-d3a7-5da5" name="Strider" hidden="false" targetId="9dea-b566-200a-0605" type="rule"/>
+        <infoLink id="3797-5c7b-40ce-266b" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
+      </infoLinks>
+      <entryLinks>
+        <entryLink id="c18a-eb73-b2b8-8346" name="** Detachment Upgrade (Units of [1] with Tough(6) &amp; Fast) **" hidden="false" collective="false" import="true" targetId="dd6c-df9e-3bed-5be4" type="selectionEntryGroup"/>
+        <entryLink id="5a70-5bbc-8588-3878" name="Prime Brothers 2 - Upgrade List E" hidden="false" collective="false" import="true" targetId="7fb3-aa14-e643-9310" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="250.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6293-e55e-e6c5-1ec0" name="Fusion Destroyer" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="79b3-92df-0963-e607" name="Fusion Destroyer" hidden="false" targetId="ef6d-eb63-0aeb-6e39" type="profile"/>
+        <infoLink id="cd98-227a-90f2-c068" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
+        <infoLink id="4e9d-6c6f-372b-839f" name="Deadly(X)" hidden="false" targetId="377b-3864-960e-57ac" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="682b-440e-a942-5986" name="Heavy Laser Talon" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="26ad-9750-fabc-c5c6" name="Heavy Laser Talon" hidden="false" targetId="40bf-6f02-e53a-8587" type="profile"/>
+        <infoLink id="f91c-709d-67d6-02e1" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
+        <infoLink id="9115-920a-7cf6-7786" name="Deadly(X)" hidden="false" targetId="377b-3864-960e-57ac" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="5e0c-bc57-d643-ad5c" name="Twin AA-Rocket Pod" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="8d82-95ff-5a5f-177e" name="Twin AA-Rocket Pod" hidden="false" targetId="8696-2a36-d8d5-791c" type="profile"/>
+        <infoLink id="59a2-8767-f480-03f4" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
+        <infoLink id="640a-e3d5-bffe-6c76" name="Anti-Air" hidden="false" targetId="1875-13ee-b0ef-5a65" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="89bd-59e9-b651-bc16" name="Strike Missiles" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="4452-a74b-2ba4-e5af" name="Strike Missiles" hidden="false" targetId="f269-c8d7-1227-1527" type="profile"/>
+        <infoLink id="624e-3e28-554a-727b" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
+        <infoLink id="569e-a674-9e30-fd99" name="Deadly(X)" hidden="false" targetId="377b-3864-960e-57ac" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="b462-6a11-cedb-7b97" name="Fury Missiles" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="c91c-941d-74ab-bb7e" name="Fury Missiles" hidden="false" targetId="5e73-a0d5-917e-8b4d" type="profile"/>
+        <infoLink id="c6b2-e620-c2dd-50b4" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
+        <infoLink id="0e0b-22e8-a7af-cd9b" name="Deadly(X)" hidden="false" targetId="377b-3864-960e-57ac" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="763b-1230-bcad-b19d" name="Battle Brothers 1 - Upgrade List A (single unit)" hidden="false" collective="false" import="true" defaultSelectionEntryId="4323-8b88-efda-e548">
@@ -14888,6 +14953,91 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>
+    <selectionEntryGroup id="7fb3-aa14-e643-9310" name="Prime Brothers 2 - Upgrade List E" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="cb84-d29f-b3ae-46da" name="Replace Gatling Gun:" hidden="false" collective="false" import="true" defaultSelectionEntryId="59a4-14c0-bc15-9a17">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1f1-bbec-08af-9ceb" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="19b7-cd4a-53fb-7f07" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="59a4-14c0-bc15-9a17" name="Gatling Gun" hidden="false" collective="false" import="true" targetId="2680-ae75-416d-93ea" type="selectionEntry"/>
+            <entryLink id="8d25-077f-df5d-860c" name="Fusion Destroyer" hidden="false" collective="false" import="true" targetId="6293-e55e-e6c5-1ec0" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="9d09-0712-55e9-86a0" name="Heavy Laser Talon" hidden="false" collective="false" import="true" targetId="682b-440e-a942-5986" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6d60-6f31-33d5-0634" name="Upgrade with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="277f-58af-12f0-ca4d" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="87e4-27a0-dc5e-c65e" name="Twin Machinegun" hidden="false" collective="false" import="true" targetId="1c25-3e6f-44c9-92da" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="eba4-a11b-e6c0-1ab4" name="Twin AA-Rocket Pod" hidden="false" collective="false" import="true" targetId="5e0c-bc57-d643-ad5c" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="8c73-f786-21db-8899" name="Strike Missiles" hidden="false" collective="false" import="true" targetId="89bd-59e9-b651-bc16" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="95.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0d68-43d3-8d0e-1d69" name="Upgrade with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0a1-432a-46f6-4b62" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="ffad-da8a-ddef-fdd3" name="2x HE-Launchers" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="2769-383f-0a97-ef0f" name="HE-Launcher" hidden="false" collective="false" import="true" targetId="3599-2d43-1180-9d59" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbfa-2719-73be-4580" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e11e-6b19-b3d8-90fc" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ad0e-017a-f62b-a323" name="2x AT-Launchers" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="1837-481f-5c8a-3019" name="AT-Launcher" hidden="false" collective="false" import="true" targetId="0e41-7739-d286-fce8" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e38-e015-06bb-4376" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7b0-f7ad-503b-2aa9" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="70.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="a74e-012e-9f93-d254" name="Fury Missiles" hidden="false" collective="false" import="true" targetId="b462-6a11-cedb-7b97" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
     <rule id="ff04-8ef9-82f1-a88b" name="Shield Wall" publicationId="dead-6af1-a069-5579" hidden="false">
@@ -16739,6 +16889,48 @@
         <characteristic name="Range" typeId="79f4-5578-c041-f866">24&quot;</characteristic>
         <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A4	</characteristic>
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d"/>
+      </characteristics>
+    </profile>
+    <profile id="1711-674c-8591-616a" name="Prime Speeder" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
+      <characteristics>
+        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">3+</characteristic>
+        <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">2+</characteristic>
+        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Ambush, Fast, Impact(6), Prime, Strider, Tough(6)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="ef6d-eb63-0aeb-6e39" name="Fusion Destroyer" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="79f4-5578-c041-f866">24&quot;</characteristic>
+        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A1</characteristic>
+        <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(4), Deadly(6)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="40bf-6f02-e53a-8587" name="Heavy Laser Talon" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="79f4-5578-c041-f866">36&quot;</characteristic>
+        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A2</characteristic>
+        <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(4), Deadly(3)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="8696-2a36-d8d5-791c" name="Twin AA-Rocket Pod" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="79f4-5578-c041-f866">24&quot;</characteristic>
+        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A2</characteristic>
+        <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(2), Anti-Air</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="f269-c8d7-1227-1527" name="Strike Missiles" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="79f4-5578-c041-f866">36&quot;</characteristic>
+        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A2</characteristic>
+        <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(3), Deadly(3)	</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="5e73-a0d5-917e-8b4d" name="Fury Missiles" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="79f4-5578-c041-f866">48&quot;</characteristic>
+        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A1</characteristic>
+        <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(4), Deadly(6)</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -400,7 +400,7 @@
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink id="c015-c517-6eae-f2d8" name="New CategoryLink" hidden="false" targetId="dfbf-5076-f148-2f58" primary="true"/>
+        <categoryLink id="bf12-3649-742d-4435" name="New CategoryLink" hidden="false" targetId="3089-78fc-94cc-28a2" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="be96-de35-b8ef-c75f" name="Shroud Speeder" hidden="false" collective="false" import="true" targetId="2f10-5c73-0512-ee66" type="selectionEntry">
@@ -2339,91 +2339,41 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="d6f1-a4b0-78ba-9010" name="Black Bikers" hidden="false" collective="false" import="true" type="upgrade">
-      <selectionEntries>
-        <selectionEntry id="1569-5d95-971f-8f11" name="Upgrade Bike Weapons" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="e903-15fc-6867-61fc" name="Black Biker" hidden="false" targetId="4853-6b39-96ed-a9eb" type="profile"/>
+        <infoLink id="ac09-f2fc-d7a8-fb7e" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
+        <infoLink id="1684-920a-e57e-a717" name="Grim" hidden="false" targetId="5dec-9937-47f8-7cf4" type="rule"/>
+        <infoLink id="3071-bacb-e9dc-0254" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
+        <infoLink id="f2e8-f493-285e-225a" name="Scout" hidden="false" targetId="7bc7-a892-49bc-ad88" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0302-2aa8-2963-e6e8" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="6a60-9cef-890c-455f">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9bd-a0aa-da2b-5ded" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3c6-f71d-f8bd-64cb" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d4f-fc08-78eb-5e76" type="max"/>
           </constraints>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="7609-3c94-40cb-b6fa" name="Bike Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="0df0-4b4a-2222-96d7">
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a37a-0df5-cfa0-01b9" type="min"/>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="739c-7232-b8ff-9b0e" type="max"/>
-              </constraints>
+          <selectionEntries>
+            <selectionEntry id="6a60-9cef-890c-455f" name="Single Unit [3 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="0df0-4b4a-2222-96d7" name="Twin Plasma Carbine" hidden="false" collective="false" import="true" targetId="81ca-8223-37eb-73ae" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3564-cfca-f200-5908" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdae-0633-7d57-be05" type="min"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="7940-cf04-1e03-7997" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="e089-6dd6-ec4e-12e6" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e9a-560d-698b-3974" type="max"/>
-                  </constraints>
-                </entryLink>
+                <entryLink id="5df4-dfe5-b0da-ca46" name="Dark Brothers - Upgrade List D (single unit)" hidden="false" collective="false" import="true" targetId="9256-e441-3d5e-dd53" type="selectionEntryGroup"/>
               </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <entryLinks>
-        <entryLink id="f151-dee3-b29c-b79d" name="Black Knight Biker" hidden="false" collective="false" import="true" targetId="87b2-868a-ce21-4d83" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="162c-2ee2-dad5-a050" type="max"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2115-8e23-002a-52d5" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="7bf0-8163-40b4-06c3" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="4fb6-4798-ec79-8939" name="Dark Brothers - Upgrade List D (combined unit)" hidden="false" collective="false" import="true" targetId="398d-1f27-899d-fb44" type="selectionEntryGroup"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="155.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="155.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="87b2-868a-ce21-4d83" name="Black Biker" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="639b-8ed2-3173-d0c6" name="Black Knight Bikers" hidden="false" targetId="4853-6b39-96ed-a9eb" type="profile"/>
-        <infoLink id="021a-52b1-05e7-7482" name="Dark Resolve" hidden="false" targetId="5dec-9937-47f8-7cf4" type="rule"/>
-        <infoLink id="eaa9-c30b-a2a6-bb2e" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
-        <infoLink id="53c2-8286-fb54-628f" name="Scout" hidden="false" targetId="7bc7-a892-49bc-ad88" type="rule"/>
-        <infoLink id="65a5-3f5f-113d-8df2" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
-      </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="e962-6901-8840-ad60" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="3496-fb93-ed03-abb4">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6522-64e6-a719-9649" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b97-444a-cd01-dc13" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="3496-fb93-ed03-abb4" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
-            <entryLink id="fd10-06b7-7d76-9c84" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="caf9-2779-d046-fda0" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="4553-2773-ca97-1c11" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a5a-9f12-56c9-adb8" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4853-48ed-fab3-001e" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="81ca-8223-37eb-73ae" name="Twin Plasma Carbine" hidden="false" collective="true" import="true" type="upgrade">
+    <selectionEntry id="81ca-8223-37eb-73ae" name="Twin Plasma Carbine" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="fe7a-95c9-0253-4144" name="Twin Plasma Carbines" hidden="false" targetId="542a-104b-9c73-e7bf" type="profile"/>
         <infoLink id="a83d-8003-ece9-02ac" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
@@ -15417,6 +15367,134 @@
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="9256-e441-3d5e-dd53" name="Dark Brothers - Upgrade List D (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0aa2-0f0a-d80b-44c9" name="Upgrade all models with:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="a738-25ea-9f19-1d09" name="Twin Plasma Carbines" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f587-824d-763f-9013" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="5d1b-a6ad-3ccd-f4ae" name="Replace one Twin Plasma Carbine:" hidden="false" collective="false" import="true" defaultSelectionEntryId="67b8-9d64-0a61-d29b">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f43c-a9ff-9105-80ec" type="min"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66ad-57fc-b28e-79bf" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="67b8-9d64-0a61-d29b" name="Twin Plasma Carbine" hidden="false" collective="false" import="true" targetId="81ca-8223-37eb-73ae" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3551-3262-6094-5552" type="min"/>
+                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5054-c7d8-0d90-c7b7" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="c11c-bd73-6dad-4ace" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="e089-6dd6-ec4e-12e6" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b62-c77e-8f25-89e0" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="66c1-45dd-c2ec-b0f6" name="Replace any CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="512c-dcdc-ab9a-7609">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6665-78ac-1f68-b723" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d69-945a-e91c-51b2" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="512c-dcdc-ab9a-7609" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+            <entryLink id="5095-4d88-50de-e4ce" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="8bfe-d582-b1fe-6dae" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="893d-ed69-931c-a39f" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa69-8807-1b01-4606" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02b7-7065-bf3c-3813" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="398d-1f27-899d-fb44" name="Dark Brothers - Upgrade List D (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="eee7-2a05-754f-7224" name="Upgrade all models with:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="0dca-616d-c3b1-e181" name="Twin Plasma Carbines" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b7c-5aee-75d7-e455" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="e162-a186-dbd8-bab9" name="Replace two Twin Plasma Carbines:" hidden="false" collective="false" import="true" defaultSelectionEntryId="c7df-4bff-3bbd-f350">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="614d-d109-1285-631f" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8901-4a94-eb4e-55ff" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="c7df-4bff-3bbd-f350" name="Twin Plasma Carbine" hidden="false" collective="false" import="true" targetId="81ca-8223-37eb-73ae" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d63-792b-e957-8188" type="min"/>
+                        <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa41-af62-33e8-6875" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="54b4-a19c-3774-8040" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="e089-6dd6-ec4e-12e6" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26d0-032f-89ec-2401" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="70.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7e0d-83cb-bb11-b507" name="Replace any CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="9481-60b9-092d-75ea">
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8135-2eac-57ea-00e0" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2641-961c-bd21-9270" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="9481-60b9-092d-75ea" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+            <entryLink id="af89-3972-1f92-eab0" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="1089-712b-cef3-a49f" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="70a0-86ce-9e3b-0718" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d71-c30d-b47c-8dd5" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17a9-f9d3-ba63-fd67" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -2152,7 +2152,7 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="281a-ee78-0632-079d" name="Spear-Rifle" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="281a-ee78-0632-079d" name="Spear-Rifle" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="be3d-d769-1f11-a7a5" name="Spear-Rifle" hidden="false" targetId="e8d9-43b8-0ede-5ac8" type="profile"/>
       </infoLinks>
@@ -2577,267 +2577,17 @@
         <infoLink id="d6ca-9c98-4684-86f3" name="Death Watcher" hidden="false" targetId="fcb3-51b8-b2d5-163c" type="profile"/>
         <infoLink id="0ce5-7ece-4758-a0a9" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
       </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="04f2-8168-0582-361d" name="Tactical Master" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f247-9565-7f1c-da2f" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="f734-805e-7c9f-78fa" name="Tactical Master" hidden="false" targetId="df74-e3da-9464-fc6f" type="rule"/>
-          </infoLinks>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="f2c7-e6b4-78c2-f175" name="Upgrades [max 1]" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f406-a495-da1c-d806" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="e4c7-929a-09a3-983e" name="Jetpack" hidden="false" collective="false" import="true" targetId="33d6-ea20-9d27-5f4e" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="9bc7-72f4-56d7-9bfd" name="Destroyer Armor" hidden="false" collective="false" import="true" targetId="8150-2743-e904-7a5c" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="ec98-065c-31ef-c036" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="57ef-830e-5fff-181c">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ccf-ed2f-3967-6a32" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab3a-2ce8-fc9e-dbc0" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="4a3b-fb2d-9587-70dc" name="Heavy Energy Hammer" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="ab95-9922-ff2e-ac35" name="Heavy Energy Hammer" hidden="false" collective="false" import="true" targetId="5cdf-6e92-c1ce-3a65" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1373-38f2-0971-7d86" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a83-08e2-7028-7b9d" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="57ef-830e-5fff-181c" name="Ranged &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="bed4-a3bb-7fba-050e" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="c82c-14d3-a5a9-f98c">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a82c-5666-b2ab-ea6b" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d0e-15a1-3df0-dfef" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="3542-199b-dee5-268b" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="5e31-5f03-239c-582b" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="6de5-8a5f-f6d5-bd4b" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="c82c-14d3-a5a9-f98c" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="0821-0d2c-96dd-9bf4" name="Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="5586-bb3e-5546-09d8">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01e7-f508-b7c9-e8a7" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="265c-2c33-1a70-00f0" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="700c-e68d-08d4-4016" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
-                      <selectionEntryGroups>
-                        <selectionEntryGroup id="cd6b-a86c-a423-972c" name="Assault Rifle Attachment" hidden="false" collective="false" import="true">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b307-b5b4-102b-0ce9" type="max"/>
-                          </constraints>
-                          <entryLinks>
-                            <entryLink id="10b9-1e26-ce01-7045" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
-                              <costs>
-                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="f1ca-2092-b8fb-3180" name="Gravity Rifle" hidden="false" collective="false" import="true" targetId="3e4a-da63-fdf2-c5fb" type="selectionEntry">
-                              <costs>
-                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="30d3-647a-a091-25d4" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
-                              <costs>
-                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-                              </costs>
-                            </entryLink>
-                            <entryLink id="a865-10e5-9547-6a48" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
-                              <costs>
-                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-                              </costs>
-                            </entryLink>
-                          </entryLinks>
-                        </selectionEntryGroup>
-                      </selectionEntryGroups>
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="67e4-7d7f-201a-6262" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="a475-3370-07fa-ec08" name="Stalker Rifle" hidden="false" collective="false" import="true" targetId="45c7-c680-df64-25c9" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="46e3-232e-58fb-d2e9" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="34f7-76db-c276-97aa" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="5586-bb3e-5546-09d8" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
-                    <entryLink id="160b-5e8d-4763-8bc2" name="Flame Pistol" hidden="false" collective="false" import="true" targetId="db8f-b317-2b7d-2ed3" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="1e3c-c27f-cedc-2d0f" name="Gravity Rifle" hidden="false" collective="false" import="true" targetId="3e4a-da63-fdf2-c5fb" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="4ca9-8015-e1ae-f02f" name="Gravity Pistol" hidden="false" collective="false" import="true" targetId="f790-2f7c-63a0-1603" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="eec0-8e70-c2be-603f" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="f962-f40d-a3f7-349f" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="2071-4cb6-f32c-5d11" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="5d09-9a11-435a-bda4" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="24a1-fd8d-91e7-9ed8" name="Death Shotgun" hidden="false" collective="false" import="true" targetId="62f5-cae0-bd32-ff9e" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="1f8f-fb1d-aced-2d43" name="Frag Blaster" hidden="false" collective="false" import="true" targetId="dcff-7eac-1a79-0535" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="2a9a-4260-09a6-7518" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="fbd8-ce6a-9bfa-dce3" name="Heavy Machinegun" hidden="false" collective="false" import="true" targetId="4481-49a4-e4f7-925b" type="selectionEntry">
-                      <entryLinks>
-                        <entryLink id="4005-3318-08cf-7ca7" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bd1-57f4-a252-432f" type="max"/>
-                          </constraints>
-                          <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-                          </costs>
-                        </entryLink>
-                      </entryLinks>
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="6254-63ce-a096-6f0c" name="Missile Launcher" hidden="false" collective="false" import="true" targetId="ff1b-714c-6353-221d" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0f9d-7138-08f8-570e" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="aa0d-ada2-0a2b-f1fb" name="Energy Claw" hidden="false" collective="false" import="true" targetId="71e9-a72c-6160-0673" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fa4-b3e6-489d-299a" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3fe-d258-e509-2c3c" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="2a2b-9966-4b04-26b0" name="Spear-Rifle" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="ab2e-1343-80c9-d4af" name="Spear (Watcher)" hidden="false" collective="false" import="true" targetId="2913-b7f2-2c10-a596" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d74-d12d-1679-750b" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a06-b7ac-2276-1737" type="min"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="5e55-9dc5-3fc5-d4e5" name="Spear-Rifle" hidden="false" collective="false" import="true" targetId="281a-ee78-0632-079d" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c643-34bd-a69f-f8a7" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8f5-8c41-9f6e-a29d" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="6e49-9820-14e4-2111" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a55-9ce0-b64f-a57c" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-          </costs>
-        </entryLink>
+        <entryLink id="5aa9-8702-2212-e525" name="Death Brothers - Upgrade List A" hidden="false" collective="false" import="true" targetId="6ea4-63bf-7092-9656" type="selectionEntryGroup"/>
+        <entryLink id="2eda-bf18-545b-d42d" name="Death Brothers - Upgrade List B (Heroes)" hidden="false" collective="false" import="true" targetId="2350-28b9-6b8f-9e58" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2913-b7f2-2c10-a596" name="Spear (Watcher)" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="2913-b7f2-2c10-a596" name="Spear (Watcher)" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="b40a-d8f6-0234-9ee2" name="Spear" hidden="false" targetId="3c92-28e7-f9b6-70d8" type="profile"/>
+        <infoLink id="b40a-d8f6-0234-9ee2" name="Spear (Watcher)" hidden="false" targetId="3c92-28e7-f9b6-70d8" type="profile"/>
         <infoLink id="1f45-0993-efff-a420" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
       </infoLinks>
       <costs>
@@ -15455,6 +15205,274 @@
               </costs>
             </selectionEntry>
           </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="6ea4-63bf-7092-9656" name="Watch Brothers - Upgrade List A" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="269f-a41b-6836-b7b0" name="Upgrade with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d953-75e1-1a78-53b3" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="d528-7fff-aad6-8526" name="Jetpack" hidden="false" collective="false" import="true" targetId="33d6-ea20-9d27-5f4e" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="7a6b-55a7-8d58-eab3" name="Destroyer Armor" hidden="false" collective="false" import="true" targetId="8150-2743-e904-7a5c" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7d14-49e4-6575-5dc6" name="Upgrade with:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="ce49-5870-37eb-4919" name="Watch Brothers - Tactical Master" hidden="false" collective="false" import="true" targetId="f2e2-ff33-227d-9876" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="2350-28b9-6b8f-9e58" name="Watch Brothers - Upgrade List B (Heroes)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="f483-a400-7eb7-e39d" name="Replace any Pistol &amp; CCW:" hidden="false" collective="true" import="true" defaultSelectionEntryId="8e4e-3877-0fa5-143c">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd9e-6b52-abb3-8a25" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="243b-e08e-f317-b93d" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8e4e-3877-0fa5-143c" name="Pistol &amp; CCW (A2)" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="221d-289e-465a-ed31" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="a95b-3eb5-b093-440c" name="Replace any Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="5560-3df6-ec48-d3e8">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed52-ee89-fdbd-844d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b82-f5ec-a9cd-586e" type="max"/>
+                  </constraints>
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="1c7a-d728-632f-ff98" name="Replace up to two Pistols:" hidden="false" collective="false" import="true">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aee1-a8ff-5800-22ef" type="max"/>
+                      </constraints>
+                      <entryLinks>
+                        <entryLink id="5489-81ee-2b5b-ad93" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="bd9e-1abb-3e13-5f73" name="Heavy Machinegun" hidden="false" collective="false" import="true" targetId="4481-49a4-e4f7-925b" type="selectionEntry">
+                          <selectionEntryGroups>
+                            <selectionEntryGroup id="d6c4-1726-20a5-9dcf" name="Any model may take one Heavy Machinegun attachment:" hidden="false" collective="false" import="true">
+                              <constraints>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b85c-dbe9-c2ac-a3c6" type="max"/>
+                              </constraints>
+                              <entryLinks>
+                                <entryLink id="a7fa-a612-cae8-8b9b" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
+                                  <costs>
+                                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+                                  </costs>
+                                </entryLink>
+                              </entryLinks>
+                            </selectionEntryGroup>
+                          </selectionEntryGroups>
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="a0ba-de51-c62f-d345" name="Missile Launcher" hidden="false" collective="false" import="true" targetId="ff1b-714c-6353-221d" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="7917-5bef-223f-2920" name="Frag Blaster" hidden="false" collective="false" import="true" targetId="dcff-7eac-1a79-0535" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
+                          </costs>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <entryLinks>
+                    <entryLink id="5560-3df6-ec48-d3e8" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
+                    <entryLink id="5369-259a-6eaa-467e" name="Gravity Pistol" hidden="false" collective="false" import="true" targetId="f790-2f7c-63a0-1603" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="0da6-a2f5-3ab8-d063" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="37d2-b90c-20c5-8192" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="c919-ecd0-f344-06da" name="Death Shotgun" hidden="false" collective="false" import="true" targetId="62f5-cae0-bd32-ff9e" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="34c7-ca6f-b610-4d1f" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="d4c6-53c4-5b1d-ebab" name="Gravity Rifle" hidden="false" collective="false" import="true" targetId="3e4a-da63-fdf2-c5fb" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="ba38-e840-808b-0025" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="a27b-fe8f-8557-9536" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="2071-4cb6-f32c-5d11" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="616b-d5ea-1e47-c753" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="133f-2206-ccc7-ecaf" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="62d2-fd97-6928-cd7b" name="Stalker Rifle" hidden="false" collective="false" import="true" targetId="45c7-c680-df64-25c9" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="1362-1646-9174-eb46" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
+                      <selectionEntryGroups>
+                        <selectionEntryGroup id="582e-ce63-ba1c-5921" name="Any model may take on Assault Rifle attachment:" hidden="false" collective="false" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d020-d66c-d665-54fb" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="d128-af6f-d7a6-bd22" name="Gravity Rifle" hidden="false" collective="false" import="true" targetId="3e4a-da63-fdf2-c5fb" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="0d20-60d4-64eb-65d2" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="22b1-0594-3411-f1d0" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="e647-5754-eaa5-1151" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+                              </costs>
+                            </entryLink>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                      </selectionEntryGroups>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="c3e2-06a1-b396-4afc" name="Replace any CCW" hidden="false" collective="false" import="true" defaultSelectionEntryId="c3c6-002c-6425-2d52">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98b2-0ff9-1fe0-c76d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d27-ba72-0f47-06bd" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="c3c6-002c-6425-2d52" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+                    <entryLink id="a8e8-9745-0d9c-600a" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="f1a3-0d4b-66f9-dbb7" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="c708-9c17-35e5-675b" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntry>
+            <selectionEntry id="08dd-3deb-7ea6-418e" name="2x Energy Claws" hidden="false" collective="true" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ea3-81e9-91b2-72cb" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="1ebc-cdb8-88e9-338a" name="Energy Claw" hidden="false" collective="true" import="true" targetId="0ed5-13cf-f02f-9759" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e143-bec6-e9cc-af64" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5927-bae3-337d-23c3" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="107e-e763-0cc8-f585" name="Upgrade List A Options" hidden="false" collective="false" import="true">
+              <selectionEntries>
+                <selectionEntry id="7a97-454b-7265-883d" name="Spear-Rifle &amp; Spear" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf1a-f008-8680-39cc" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="bc3b-1179-dcfe-5375" name="Spear-Rifle" hidden="false" collective="false" import="true" targetId="281a-ee78-0632-079d" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c31-fcdf-b416-56b8" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5baa-d9c0-fbae-4da3" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="d53b-51c1-64e9-d7fa" name="Spear (Watcher)" hidden="false" collective="false" import="true" targetId="2913-b7f2-2c10-a596" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b278-1951-edb3-84a2" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e535-a751-f1f8-bd57" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="f627-617d-aeac-2f7a" name="Heavy Energy Hammer" hidden="false" collective="false" import="true" targetId="5cdf-6e92-c1ce-3a65" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6edf-77b9-cf8e-be3d" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -3645,26 +3645,6 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="315.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="21ae-cfbf-b345-5314" name="Wolf" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="ce75-c507-f8b7-62ac" name="Cyborg Wolf" hidden="false" targetId="88b6-3cef-d05a-0798" type="profile"/>
-        <infoLink id="bb20-d437-1eb0-d79b" name="Strider" hidden="false" targetId="9dea-b566-200a-0605" type="rule"/>
-        <infoLink id="a87f-7241-c3e3-d379" name="Counter-Attack" hidden="false" targetId="5c24-d8ee-b4ed-4c8d" type="rule"/>
-        <infoLink id="7fdb-f4f0-b846-628d" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
-        <infoLink id="d8bb-c5c6-90e8-76aa" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
-      </infoLinks>
-      <entryLinks>
-        <entryLink id="427a-733d-0159-6bde" name="Claws" hidden="false" collective="false" import="true" targetId="a8f4-d9ee-4670-fd42" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad9f-78b1-ca37-3fb3" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7349-417b-43a7-3cfd" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="a8f4-d9ee-4670-fd42" name="Claws" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="d420-475f-30c4-5773" name="Claws" hidden="false" targetId="fa11-1250-0332-9b2c" type="profile"/>
@@ -3674,31 +3654,48 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="2fe2-f15a-5e23-4215" name="Wolves" hidden="false" collective="false" import="true" type="upgrade">
-      <selectionEntries>
-        <selectionEntry id="f761-c505-02fb-72d1" name="Cyborg Bodies" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="a92a-3bd1-1db7-2ac9" name="Wolf" hidden="false" targetId="88b6-3cef-d05a-0798" type="profile"/>
+        <infoLink id="437f-5c79-c3f5-c0ab" name="Counter" hidden="false" targetId="5c24-d8ee-b4ed-4c8d" type="rule"/>
+        <infoLink id="8ada-c3f0-600d-df99" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
+        <infoLink id="eeea-636f-0f9a-834e" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
+        <infoLink id="3140-773c-e874-6cc5" name="Strider" hidden="false" targetId="9dea-b566-200a-0605" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6b4b-a428-134c-a65e" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="99d3-b5ff-db21-03af">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5499-6199-c314-5989" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2b7-a697-0adf-d42e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2666-d499-8030-282f" type="max"/>
           </constraints>
-          <profiles>
-            <profile id="df74-2f72-2cc6-942d" name="Cyborg Bodies" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
-              <characteristics>
-                <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Defense +1</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <entryLinks>
-        <entryLink id="28e7-0c16-f710-1092" name="Cyborg Wolf" hidden="false" collective="false" import="true" targetId="21ae-cfbf-b345-5314" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="def7-34b4-074d-ba73" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="667a-7340-4806-70d2" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
+          <selectionEntries>
+            <selectionEntry id="99d3-b5ff-db21-03af" name="Single Unit [5 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="9799-d9b4-9dd8-deb3" name="Claws" hidden="false" collective="false" import="true" targetId="a8f4-d9ee-4670-fd42" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0403-dc96-412a-0a6a" type="min"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3297-765d-eeb6-225c" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="6386-e2a5-db24-5851" name="Wolf Brothers - Upgrade List G (single unit)" hidden="false" collective="false" import="true" targetId="ebeb-5197-d5be-559c" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="c567-e19c-7ea0-b37c" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="8be8-8b6e-5008-9b4d" name="Claws" hidden="false" collective="false" import="true" targetId="a8f4-d9ee-4670-fd42" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0a1-ca37-8c83-327e" type="min"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be95-8d5d-1d62-5ea3" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="eba0-e441-2c4f-707c" name="Wolf Brothers - Upgrade List G (combined unit)" hidden="false" collective="false" import="true" targetId="c748-9545-be84-9050" type="selectionEntryGroup"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="170.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="170.0"/>
       </costs>
@@ -5988,6 +5985,11 @@
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="1e94-b758-ffec-0f8d" name="Cyborg Bodies" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="a0ff-9024-7428-6097" name="Cyborg Bodies" hidden="false" targetId="244b-3059-7103-28f8" type="profile"/>
+      </infoLinks>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -16524,6 +16526,38 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>
+    <selectionEntryGroup id="ebeb-5197-d5be-559c" name="Wolf Brothers - Upgrade List G (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ac85-4a9d-e35c-d1b6" name="Upgrade all models with:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="e9c2-4f10-b6b9-9dec" name="Cyborg Bodies" hidden="false" collective="false" import="true" targetId="1e94-b758-ffec-0f8d" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d69e-3784-e92b-c17f" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="c748-9545-be84-9050" name="Wolf Brothers - Upgrade List G (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="b456-51ff-7976-bb4d" name="Upgrade all models with:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="1aca-0607-43ef-0802" name="Cyborg Bodies" hidden="false" collective="false" import="true" targetId="1e94-b758-ffec-0f8d" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3345-74ca-91ac-72b5" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
     <rule id="ff04-8ef9-82f1-a88b" name="Shield Wall" publicationId="dead-6af1-a069-5579" hidden="false">
@@ -18448,6 +18482,11 @@
     <profile id="e91c-d006-e62c-ad96" name="Interceptors" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
       <characteristics>
         <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Teleport</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="244b-3059-7103-28f8" name="Cyborg Bodies" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
+      <characteristics>
+        <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Defense +1</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -2009,54 +2009,6 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="bee1-b3db-687c-006a" name="Guardian Brother" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="d7ab-e3dd-ab1c-edf7" name="Guardian Brother" hidden="false" targetId="aa00-61d8-b1e1-247a" type="profile"/>
-        <infoLink id="9605-668e-7f04-0b7b" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
-        <infoLink id="0f23-6cee-7751-e9c0" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="9aea-d268-3165-c1e2" name="Flying" hidden="false" targetId="adc6-ddd5-223d-29b1" type="rule"/>
-        <infoLink id="e25a-4354-301c-1df0" name="Furious" hidden="false" targetId="ded5-4f1f-c61d-4659" type="rule"/>
-      </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="6b95-3240-8f34-9e7a" name="CCW" hidden="false" collective="false" import="true" defaultSelectionEntryId="f3bb-dde5-7b1c-0b70">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03de-b827-4e2f-bf90" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebe3-0f16-8e26-0eee" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="dc13-1cef-e646-40d9" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="324d-4623-7bfb-b4c9" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="f3bb-dde5-7b1c-0b70" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="557b-4892-4b11-e034" name="Pistol" hidden="false" collective="false" import="true" defaultSelectionEntryId="9d9f-e9fe-8c33-736b">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69ba-9c82-cd7c-4fd9" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb85-f69e-cc10-24b3" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="9ea5-27de-8543-0131" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry"/>
-            <entryLink id="c100-87c2-7f95-1559" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="2071-4cb6-f32c-5d11" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="9d9f-e9fe-8c33-736b" name="Assault Pistol" hidden="false" collective="false" import="true" targetId="2f45-0d02-fb60-4882" type="selectionEntry"/>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="2f45-0d02-fb60-4882" name="Assault Pistol" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="9b38-4f20-6877-4745" name="Assault Pistol" hidden="false" targetId="858c-f48d-a1a0-98c2" type="profile"/>
@@ -2066,22 +2018,36 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="4e9d-b1ae-41ee-e4cd" name="Guardian Brothers" hidden="false" collective="false" import="true" type="upgrade">
-      <entryLinks>
-        <entryLink id="58f4-eed3-3926-e8df" name="Guardian Brother" hidden="false" collective="false" import="true" targetId="bee1-b3db-687c-006a" type="selectionEntry">
+      <infoLinks>
+        <infoLink id="763e-dc7e-5ed7-0cd4" name="Guardian Brother" hidden="false" targetId="aa00-61d8-b1e1-247a" type="profile"/>
+        <infoLink id="9d5b-c8c8-5db1-da5e" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
+        <infoLink id="266a-83f5-1726-aa17" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
+        <infoLink id="7e62-1468-c311-3091" name="Flying" hidden="false" targetId="adc6-ddd5-223d-29b1" type="rule"/>
+        <infoLink id="5dc7-942f-f083-e4e8" name="Furious" hidden="false" targetId="ded5-4f1f-c61d-4659" type="rule"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="71cb-e69f-a08a-53d4" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="65ad-8387-cca2-1437">
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5880-d0e5-52d3-e013" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17bb-b89a-977f-1dcd" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8623-8aa6-e297-dffc" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a3b-8111-06c4-3621" type="max"/>
           </constraints>
-        </entryLink>
-        <entryLink id="7e63-02cd-8f0d-0d23" name="Battle Standard" hidden="false" collective="false" import="true" targetId="398c-3d34-79c6-a425" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ae9-623d-4efc-cd31" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-          </costs>
-        </entryLink>
-      </entryLinks>
+          <selectionEntries>
+            <selectionEntry id="65ad-8387-cca2-1437" name="Single Unit [5 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="b83d-b44b-bf66-0cef" name="Blood Brothers - Upgrade List C (single unit)" hidden="false" collective="false" import="true" targetId="ebd0-c4fc-2ee9-942c" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="5fc3-17d5-a325-4755" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="1591-cc5f-87d2-d992" name="Blood Brothers - Upgrade List C (combined unit)" hidden="false" collective="false" import="true" targetId="64f8-9429-2798-0b76" type="selectionEntryGroup"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="255.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="255.0"/>
       </costs>
@@ -15185,6 +15151,106 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="160.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="ebd0-c4fc-2ee9-942c" name="Blood Brothers - Upgrade List C (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="00e6-ac90-67f5-f88f" name="Replace any Assault Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4d97-3b7d-8d44-612e">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="921a-106b-3a2c-88e4" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cffd-c263-c6c3-4608" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="4d97-3b7d-8d44-612e" name="Assault Pistol" hidden="false" collective="false" import="true" targetId="2f45-0d02-fb60-4882" type="selectionEntry"/>
+            <entryLink id="7613-f220-c348-cf5f" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry"/>
+            <entryLink id="7743-4fcc-0d75-4c04" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="2071-4cb6-f32c-5d11" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="315d-ef38-836c-d16a" name="Replace any CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="e22f-7a82-4056-2f8c">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="846d-9588-a20d-5dcd" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3650-00f5-0f9f-89a9" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="e22f-7a82-4056-2f8c" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+            <entryLink id="8b32-f7df-87c9-11b8" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="c96a-3c58-a0f9-de3c" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="403b-940d-636c-395a" name="Upgrade one model with:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ad0-99c1-2c5c-0ff2" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="7bf2-a614-6f7b-933c" name="Battle Standard" hidden="false" collective="false" import="true" targetId="398c-3d34-79c6-a425" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="64f8-9429-2798-0b76" name="Blood Brothers - Upgrade List C (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="49d3-0d5a-3cd1-83dc" name="Replace any Assault Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="d0ef-f865-1f72-45c5">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="108b-7824-f000-fe81" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="177e-77ef-7a39-e539" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="d0ef-f865-1f72-45c5" name="Assault Pistol" hidden="false" collective="false" import="true" targetId="2f45-0d02-fb60-4882" type="selectionEntry"/>
+            <entryLink id="52f1-7147-457b-bd41" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry"/>
+            <entryLink id="4222-2442-c7d9-e962" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="2071-4cb6-f32c-5d11" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="aa8d-de6c-d6eb-981f" name="Replace any CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="f201-91e6-64dc-9656">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce8c-67ec-909b-8789" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="05e8-7f85-0b49-52d3" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="f201-91e6-64dc-9656" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+            <entryLink id="6cb5-6fc7-3817-85c3" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="314f-0e6d-8dd2-3d2e" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b73c-e634-66aa-4a26" name="Upgrade two models with:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97ed-26cc-8897-0529" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="1223-aab0-8a83-c881" name="Battle Standard" hidden="false" collective="false" import="true" targetId="398c-3d34-79c6-a425" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
               </costs>
             </entryLink>
           </entryLinks>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -3356,38 +3356,9 @@
         <infoLink id="3ad8-a25b-7ca6-80bf" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
         <infoLink id="269e-2c07-14ac-4e67" name="Counter-Attack" hidden="false" targetId="5c24-d8ee-b4ed-4c8d" type="rule"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="c120-19c9-8342-30e0" name="Upgrades" hidden="false" collective="false" import="true">
-          <entryLinks>
-            <entryLink id="7ef0-9d8e-0208-89b9" name="Destroyer Armor" hidden="false" collective="false" import="true" targetId="8150-2743-e904-7a5c" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ba3-4657-79ae-af03" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="0618-8b63-c8fb-950b" name="Cyborg Wolf" hidden="false" collective="false" import="true" targetId="a68e-80d5-aa9a-1138" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="55d6-d47e-ddfd-1a0f" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="2d24-2323-2874-2145" name="Great Wolf Mount" hidden="false" collective="false" import="true" targetId="5ab5-bbc9-2858-fd74" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2afc-7d08-7eb8-856c" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="07de-2a10-ced4-cc9b" name="Wolf Leader Weapons" hidden="false" collective="false" import="true" targetId="d882-5701-85b1-d209" type="selectionEntryGroup"/>
+        <entryLink id="07de-2a10-ced4-cc9b" name="Wolf Brothers - Upgrade List A (single unit)" hidden="false" collective="false" import="true" targetId="d882-5701-85b1-d209" type="selectionEntryGroup"/>
+        <entryLink id="080c-324d-20de-a54c" name="Wolf Brothers - Upgrade List B" hidden="false" collective="false" import="true" targetId="a172-2171-3466-4450" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
@@ -7062,105 +7033,135 @@
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="d882-5701-85b1-d209" name="Wolf Leader Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="ec16-cd41-634a-d123">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="721b-e749-e943-dfde" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa73-316b-03d9-4bbf" type="max"/>
-      </constraints>
-      <selectionEntries>
-        <selectionEntry id="ec16-cd41-634a-d123" name="Ranged &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
-          <selectionEntryGroups>
-            <selectionEntryGroup id="2206-5401-8d68-e915" name="Melee Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="73e8-580b-054d-47ab">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf10-10c3-f3ca-b216" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f99-acc5-2871-9018" type="max"/>
-              </constraints>
+    <selectionEntryGroup id="d882-5701-85b1-d209" name="Wolf Brothers - Upgrade List A (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d83a-cd23-e521-9e19" name="Replace one Pistol &amp; CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a2bd-793a-1999-7032">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ab4-35cd-57dc-6b0b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8719-139f-26d8-3f38" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="bd3b-430a-c452-0623" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="73e8-580b-054d-47ab" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
-                <entryLink id="82af-f87d-45c0-92f0" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="ec66-4395-c876-9250" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="fb6a-8449-d0dd-d80b" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                  </costs>
+                <entryLink id="6495-6455-ebb4-02c3" name="Energy Claw" hidden="false" collective="false" import="true" targetId="71e9-a72c-6160-0673" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="72c2-e3b8-da70-af87" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb60-1791-6fca-47bb" type="max"/>
+                  </constraints>
                 </entryLink>
               </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="4ad3-2b0c-68ec-11fc" name="Ranged Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="410b-eae2-711b-684e">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b2e-7b73-781d-e502" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cac9-ebfd-38fe-a63e" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="410b-eae2-711b-684e" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
-                <entryLink id="154d-8e71-d24c-c58f" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="10dc-9b08-2622-b02a" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
-                  <selectionEntryGroups>
-                    <selectionEntryGroup id="814c-89c6-d07e-c7f5" name="Assault Rifle Attachment" hidden="false" collective="false" import="true">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a2bd-793a-1999-7032" name="Pistol &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="161b-41d9-f454-2ec2" name="Replace one CCW:" hidden="false" collective="true" import="true" defaultSelectionEntryId="347f-adb9-e3dc-b01a">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f01-e5bb-1c31-5037" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30ec-f774-1533-f60d" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="347f-adb9-e3dc-b01a" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f99a-06a6-5a40-f2b0" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6838-d765-0d78-f925" type="max"/>
                       </constraints>
-                      <entryLinks>
-                        <entryLink id="698b-01f0-5109-bf07" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
-                          <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-                          </costs>
-                        </entryLink>
-                        <entryLink id="ddc8-a1ba-80d3-3115" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
-                          <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-                          </costs>
-                        </entryLink>
-                        <entryLink id="7ee7-6702-fc69-197b" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
-                          <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-                          </costs>
-                        </entryLink>
-                      </entryLinks>
-                    </selectionEntryGroup>
-                  </selectionEntryGroups>
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="558b-e450-8e04-f303" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="f12b-5533-2329-5b92" type="selectionEntry">
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                  </costs>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="6fb8-da3b-0df3-1851" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
-          <entryLinks>
-            <entryLink id="7c5f-af0b-73ce-686d" name="Energy Claw" hidden="false" collective="false" import="true" targetId="71e9-a72c-6160-0673" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab89-acbd-a1f1-fe9a" type="min"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1878-3cd1-b71d-bcd4" type="max"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+                    </entryLink>
+                    <entryLink id="66b7-746c-f0d0-dd0f" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f75-2402-c10a-a79f" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="c065-c867-e328-1f4f" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96c8-3de0-8e91-1992" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="d02c-df24-076b-4477" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb5b-6e5e-0f4d-b89a" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="8214-dcad-a8c2-c51f" name="Replace one Pistol:" hidden="false" collective="true" import="true" defaultSelectionEntryId="df46-40ce-52df-76b6">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9129-44e0-873d-ea82" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c8b-e5b8-a4b3-1082" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="df46-40ce-52df-76b6" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="818f-37aa-969c-b475" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="2c28-df5e-5c59-aabe" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0364-d5fb-93e7-5c8f" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="a270-7780-6feb-037a" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0bc-19aa-ca58-4b6c" type="max"/>
+                      </constraints>
+                      <selectionEntryGroups>
+                        <selectionEntryGroup id="4fda-27c9-8608-97c8" name="Take one Assault Rifle Attachment:" hidden="false" collective="true" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bef2-b1d5-b3ca-f73b" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="0734-b91f-f181-06b9" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="fe59-ebc5-751b-49f6" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="f0fb-3b2f-d6c7-93e4" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+                              </costs>
+                            </entryLink>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                      </selectionEntryGroups>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="fafe-1c98-c02d-4764" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8fa-6a0d-bce1-1058" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
     </selectionEntryGroup>
     <selectionEntryGroup id="1053-1e3d-6ca4-6012" name="Battle Brothers 1 - Upgrade List B" hidden="false" collective="false" import="true">
       <selectionEntryGroups>
@@ -16111,6 +16112,39 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="a172-2171-3466-4450" name="Wolf Brothers - Upgrade List B" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0e9a-5618-1d61-53d5" name="Upgrade with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48a9-c78d-2de6-ed74" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="fed7-eaf0-c684-87bf" name="Destroyer Armor" hidden="false" collective="false" import="true" targetId="8150-2743-e904-7a5c" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="a96b-cbcb-931f-12dc" name="Great Wolf Mount" hidden="false" collective="false" import="true" targetId="5ab5-bbc9-2858-fd74" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a8d2-fc9b-ae31-e9ee" name="Upgrade with up to two:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf22-e0f1-8fb0-fc5f" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="abb8-804f-09da-da13" name="Guard Wolf" hidden="false" collective="false" import="true" targetId="a68e-80d5-aa9a-1138" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
               </costs>
             </entryLink>
           </entryLinks>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -6957,25 +6957,6 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e864-29a4-df16-c891" name="Jetpack Brother (Plasma Carbines)" hidden="false" collective="false" import="true" type="upgrade">
-      <entryLinks>
-        <entryLink id="9d41-6f69-3f21-98eb" name="Plasma Carbine" hidden="false" collective="false" import="true" targetId="6adc-a2b8-8cec-3fa6" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="462a-1948-0882-3d97" type="max"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e010-e7f5-0b00-0811" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="048e-d8ca-230c-d6e1" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="168d-fc4b-a9af-d00f" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f03-3af9-07a8-f2fe" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31b9-3ad8-1252-77d1" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="6adc-a2b8-8cec-3fa6" name="Plasma Carbine" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="b7f1-6c22-ebf3-51cd" name="Plasma Carbines" hidden="false" targetId="eb1c-18c1-7411-5fe1" type="profile"/>
@@ -6993,95 +6974,38 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="555c-c32f-5943-66f6" name="Jetpack Brother (Assault Carbines)" hidden="false" collective="false" import="true" type="upgrade">
-      <entryLinks>
-        <entryLink id="3028-9119-9fd9-cded" name="Assault Carbine" hidden="false" collective="false" import="true" targetId="14bf-1db5-882f-d03d" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9229-cfb6-1742-242b" type="max"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a27d-4c8f-d480-8a96" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="d874-7eb2-4d63-5484" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="168d-fc4b-a9af-d00f" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="459a-9fb0-d5d5-94ef" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="377d-2107-0815-3109" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="31be-af60-1b60-f510" name="Jetpack Squad" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="31a1-f538-543e-a879" name="Jetpack Brother" hidden="false" targetId="344a-22b2-a43e-2e29" type="profile"/>
+        <infoLink id="31a1-f538-543e-a879" name="Prime Jetpack Brother" hidden="false" targetId="344a-22b2-a43e-2e29" type="profile"/>
         <infoLink id="b974-a348-8056-229d" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
         <infoLink id="a743-70cc-3ac6-32c6" name="Firstborn" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
         <infoLink id="cb1b-17db-1e88-ebe1" name="Flying" hidden="false" targetId="adc6-ddd5-223d-29b1" type="rule"/>
       </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="3933-ce3d-21e4-13b2" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="be9c-fcf4-f14e-8462">
+        <selectionEntryGroup id="4b05-4eac-3312-b510" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="d94b-e9d9-8ada-9cb4">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88b2-ee8a-08be-50d5" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a77-df37-40fc-d5d7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fc5-ca12-dca2-c65c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b6a2-d2ba-8eda-76b5" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="be9c-fcf4-f14e-8462" name="Plasma Carbines" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="d94b-e9d9-8ada-9cb4" name="Single Unit [3 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="7bd8-eba0-1bec-d704" name="Jetpack Brother (Plasma Carbines)" hidden="false" collective="false" import="true" targetId="e864-29a4-df16-c891" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3e7-74fe-0ce9-991d" type="max"/>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed25-636e-d999-2bcf" type="min"/>
-                  </constraints>
-                </entryLink>
+                <entryLink id="e415-db6e-442a-8578" name="Prime Brothers 1 - Upgrade List K (single unit)" hidden="false" collective="false" import="true" targetId="eac9-917e-02f5-35d0" type="selectionEntryGroup"/>
+                <entryLink id="a793-1310-fd56-c40a" name="** Detachment Upgrade (Units of [3], single unit) **" hidden="false" collective="false" import="true" targetId="a060-d513-9f57-6e27" type="selectionEntryGroup"/>
               </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
             </selectionEntry>
-            <selectionEntry id="7ec5-8885-8b67-b060" name="Assault Carbines" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="f9ba-6055-fb64-623f" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="897b-3d52-7652-6367" name="Jetpack Brother (Assault Carbines)" hidden="false" collective="false" import="true" targetId="555c-c32f-5943-66f6" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0329-683d-0f36-245f" type="max"/>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdc6-c218-964c-9415" type="min"/>
-                  </constraints>
-                </entryLink>
+                <entryLink id="91e6-9b47-c7bf-9932" name="Prime Brothers 1 - Upgrade List K (combined unit)" hidden="false" collective="false" import="true" targetId="c3be-3b74-0be6-b173" type="selectionEntryGroup"/>
+                <entryLink id="2d15-a041-c560-088e" name="** Detachment Upgrade (Units of [3], combined unit) **" hidden="false" collective="false" import="true" targetId="453e-ef26-c3dc-e2b5" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="185.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="79b1-b67e-3005-1fc8" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="61a5-50ab-14bb-4a20" name="Wolf Brothers - Counter-Attack" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="510.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="d82d-9c4c-b864-ca54" name="Dark Brothers - Dark Assault &amp; Dark Resolve" hidden="false" collective="false" import="true" targetId="cf31-8c37-3347-79a3" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="efd3-b5e2-0a98-e9ea" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="db0d-78dd-a1f0-19a3" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-      </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="185.0"/>
       </costs>
@@ -11900,6 +11824,23 @@
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
           </costs>
         </entryLink>
+        <entryLink id="fb57-e054-8981-0a93" name="Dark Brothers - Dark Assault" hidden="true" collective="false" import="true" targetId="cf31-8c37-3347-79a3" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="31be-af60-1b60-f510" type="instanceOf"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4d7d-3f02-6345-2f6c" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+          </costs>
+        </entryLink>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="453e-ef26-c3dc-e2b5" name="** Detachment Upgrade (Units of [3], combined unit) **" hidden="false" collective="false" import="true">
@@ -11922,6 +11863,23 @@
         <entryLink id="3937-b316-2d39-e8a5" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="280c-f63f-1cf1-2782" name="Dark Brothers - Dark Assault" hidden="true" collective="false" import="true" targetId="cf31-8c37-3347-79a3" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="31be-af60-1b60-f510" type="instanceOf"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4d7d-3f02-6345-2f6c" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
           </costs>
         </entryLink>
       </entryLinks>
@@ -14584,6 +14542,100 @@
           </constraints>
         </entryLink>
       </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="eac9-917e-02f5-35d0" name="Prime Brothers 1 - Upgrade List K (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5587-44ca-2af2-e47b" name="Replace all Plasma Carbines:" hidden="false" collective="false" import="true" defaultSelectionEntryId="f6d7-d427-a0de-0877">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3c6-7a5d-f17e-a686" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be5f-a73d-5ceb-304e" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f6d7-d427-a0de-0877" name="Plasma Carbines" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="8697-9e7b-0a6d-4d21" name="Plasma Carbine" hidden="false" collective="false" import="true" targetId="6adc-a2b8-8cec-3fa6" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="545f-1a9b-9087-06ce" type="min"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e0e-d054-a189-1abe" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="752d-d4b4-af7c-eca6" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fea6-f377-0930-eee3" type="min"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1894-636b-1ee3-ab88" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="aca5-a366-024b-b4dc" name="Assault Carbines" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="f884-092f-5661-a91a" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4641-5dac-999a-76f1" type="min"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="432b-8a8d-3580-7c5c" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="a43b-fcc4-ab7b-44da" name="Assault Carbine" hidden="false" collective="false" import="true" targetId="14bf-1db5-882f-d03d" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="623d-a2e6-d5f1-7ae4" type="min"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c5f-192d-1ded-8c48" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="c3be-3b74-0be6-b173" name="Prime Brothers 1 - Upgrade List K (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e4c6-280b-9f73-e5ce" name="Replace all Plasma Carbines:" hidden="false" collective="false" import="true" defaultSelectionEntryId="9f6e-c1ca-fb59-2951">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f42-6a6d-6dd9-a88d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84a2-0774-2b8a-099c" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="9f6e-c1ca-fb59-2951" name="Plasma Carbines" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="a240-6db6-b8f3-29bf" name="Plasma Carbine" hidden="false" collective="false" import="true" targetId="6adc-a2b8-8cec-3fa6" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f16-19f6-ba41-d809" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4746-acb2-c03a-3944" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="b2c4-9c93-f7cc-cfc1" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76fb-bfc6-c055-f092" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4629-1c39-14e3-273f" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="b860-c16c-ba4f-0bfe" name="Assault Carbines" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="236f-fb55-e478-48e1" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="feef-52ec-b2cc-d913" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99f4-7af0-661b-ec55" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="e0c7-5194-618e-b511" name="Assault Carbine" hidden="false" collective="false" import="true" targetId="14bf-1db5-882f-d03d" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be8c-d965-24ee-c226" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5160-7821-595e-344d" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -933,11 +933,25 @@
     </entryLink>
     <entryLink id="4260-efb1-e48e-399a" name="**Army Selection**" hidden="false" collective="false" import="true" targetId="817b-3644-0181-0296" type="selectionEntry"/>
     <entryLink id="cbce-109e-21af-bf73" name="Prime ATV" hidden="false" collective="false" import="true" targetId="b75e-8917-0c3a-cd0c" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="dc7a-12df-d69b-ed72" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="b84a-b94c-4967-2bc4" name="Vehicles: Light" hidden="false" targetId="3089-78fc-94cc-28a2" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="26ae-fc2a-de79-c248" name="Anti-Grav Tank" hidden="false" collective="false" import="true" targetId="c708-237a-9145-77d2" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="dc7a-12df-d69b-ed72" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
       <categoryLinks>
         <categoryLink id="d9bd-f830-cce0-1015" name="New CategoryLink" hidden="false" targetId="b820-6309-e900-c733" primary="true"/>
       </categoryLinks>
@@ -6510,6 +6524,9 @@
                   </modifiers>
                 </entryLink>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="eb6a-2ff4-33fb-56ff" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -6648,6 +6665,9 @@
                 <entryLink id="be0c-24c3-e2f4-ce51" name="Prime Brothers 1 - Upgrade List E (single unit)" hidden="false" collective="false" import="true" targetId="0bb9-e22c-0855-349c" type="selectionEntryGroup"/>
                 <entryLink id="0acf-b1f5-211e-4e9e" name="** Detachment Upgrade (Units of [5], single unit) **" hidden="false" collective="false" import="true" targetId="f024-6c76-c658-300a" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="243d-b6cb-d851-372d" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -6693,6 +6713,9 @@
                 <entryLink id="21f0-52cd-aeb4-5a2a" name="Prime Brothers 1 - Upgrade List E (single unit)" hidden="false" collective="false" import="true" targetId="0bb9-e22c-0855-349c" type="selectionEntryGroup"/>
                 <entryLink id="4809-ce04-2739-2d67" name="Prime Brothers 1 - Upgrade List H (single unit)" hidden="false" collective="false" import="true" targetId="47fe-347c-904f-3c77" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="acf0-68de-d166-d5c3" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -6741,6 +6764,9 @@
                   </constraints>
                 </entryLink>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="e42c-5077-49bd-3c72" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -6799,6 +6825,9 @@
                 <entryLink id="6204-f02b-1eea-a882" name="** Detachment Upgrade (Units of [3], single unit) **" hidden="false" collective="false" import="true" targetId="a060-d513-9f57-6e27" type="selectionEntryGroup"/>
                 <entryLink id="698a-6a13-727d-e98b" name="Prime Brothers 1 - Upgrade List J (single unit)" hidden="false" collective="false" import="true" targetId="936a-2e35-796b-f5fb" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="9131-5cf8-f5ac-cff9" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -6850,6 +6879,9 @@
                 <entryLink id="48d1-076c-5be6-fabe" name="Prime Brothers 1 - Upgrade List L (single unit)" hidden="false" collective="false" import="true" targetId="6281-9b77-c683-ecc6" type="selectionEntryGroup"/>
                 <entryLink id="b206-df28-e151-defa" name="** Detachment Upgrade (Units of [3] with Tough(3), single unit) **" hidden="false" collective="false" import="true" targetId="46f0-6405-967e-2938" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="5099-b698-a625-954a" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -6912,6 +6944,9 @@
                 <entryLink id="e415-db6e-442a-8578" name="Prime Brothers 1 - Upgrade List K (single unit)" hidden="false" collective="false" import="true" targetId="eac9-917e-02f5-35d0" type="selectionEntryGroup"/>
                 <entryLink id="a793-1310-fd56-c40a" name="** Detachment Upgrade (Units of [3], single unit) **" hidden="false" collective="false" import="true" targetId="a060-d513-9f57-6e27" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="f9ba-6055-fb64-623f" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -6968,6 +7003,9 @@
                 </entryLink>
                 <entryLink id="150a-c444-7fd6-92b4" name="** Detachment Upgrade (Units of [3], single unit) **" hidden="false" collective="false" import="true" targetId="a060-d513-9f57-6e27" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="e6a0-4fd5-289b-9002" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -7324,84 +7362,12 @@
         <infoLink id="e7ca-8c0a-cbf7-f679" name="Firstborn" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
         <infoLink id="c6f3-5d94-d92a-963b" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
         <infoLink id="8876-62fe-c275-3e3b" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
-        <infoLink id="25de-277c-4f7a-8fcb" name="" hidden="false" targetId="ebc0-d921-df04-3c1d" type="profile"/>
+        <infoLink id="25de-277c-4f7a-8fcb" name="Heavy Anti-Grav Destroyer Tank" hidden="false" targetId="ebc0-d921-df04-3c1d" type="profile"/>
         <infoLink id="73df-f059-bff2-177e" name="Transport(X)" hidden="false" targetId="3460-57e3-8a15-7977" type="rule"/>
         <infoLink id="fec3-fb38-f985-dfce" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
         <infoLink id="7267-f012-ea6a-bacf" name="Strider" hidden="false" targetId="9dea-b566-200a-0605" type="rule"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="32d2-7ad8-9380-8842" name="Weapon - Turret" hidden="false" collective="false" import="true" defaultSelectionEntryId="97aa-dcdf-a090-0f58">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79a8-36d7-fdb2-1aa4" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3ea-ae58-ddfa-4c8c" type="min"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="97aa-dcdf-a090-0f58" name="Heavy Plasma Cannon" hidden="false" collective="false" import="true" targetId="e710-08f1-e420-99f1" type="selectionEntry"/>
-            <entryLink id="d0f9-122f-f411-7181" name="Heavy Laser Cannon" hidden="false" collective="false" import="true" targetId="79f9-758b-24c4-e1b6" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="120.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="227d-a394-5796-8e2c" name="Upgrades" hidden="false" collective="false" import="true">
-          <selectionEntries>
-            <selectionEntry id="0900-3fe1-384c-03bc" name="2x Storm Rifles" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aeaf-2594-b944-dae9" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="a27e-353e-c490-5da8" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="f12b-5533-2329-5b92" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8156-dfe9-7956-e6c3" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25a2-3bb3-4d34-7fd6" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="987c-8d33-5e43-17b0" name="AA-Rocket Pod" hidden="false" collective="false" import="true" targetId="5ce3-bc25-e242-c85c" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27ca-5864-9341-d7a7" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="7753-9676-9c8b-f97a" name="Light Machinegun" hidden="false" collective="false" import="true" targetId="6bf9-8992-7b02-5764" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83a0-86a3-5a72-fd99" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="dce9-8544-798a-e0ef" name="Twin AA-Machinegun" hidden="false" collective="false" import="true" targetId="5666-6954-7608-c6cd" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b954-9255-7c9b-d930" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="2963-8a58-24f3-9779" name="Blood Brothers - Very Fast" hidden="false" collective="false" import="true" targetId="ec17-0396-1d9d-0ad9" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="6473-3b8a-25a5-9214" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="55.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="eb34-e468-46d4-9c4e" name="Twin Heavy Machinegun" hidden="false" collective="false" import="true" targetId="dae8-3106-6a96-228c" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2ff-e07c-1aab-7860" type="min"/>
@@ -7414,6 +7380,8 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7acb-1a63-db8f-8b52" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="0501-d5a7-9af6-3de6" name="** Detachment Upgrade (Units of [1] with Tough(18) &amp; Fast) **" hidden="false" collective="false" import="true" targetId="ad75-3b37-3d15-05f7" type="selectionEntryGroup"/>
+        <entryLink id="80ec-2d4b-1078-9845" name="Prime Brothers 2 - Upgrade List D" hidden="false" collective="false" import="true" targetId="0868-87db-27ff-c3f6" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="780.0"/>
@@ -7943,6 +7911,9 @@
                 <entryLink id="05ec-96b0-bcff-90c9" name="Prime Brothers 1 - Upgrade List E (single unit)" hidden="false" collective="false" import="true" targetId="0bb9-e22c-0855-349c" type="selectionEntryGroup"/>
                 <entryLink id="9a28-8079-acf5-e272" name="** Detachment Upgrade (Units of [5], single unit) **" hidden="false" collective="false" import="true" targetId="f024-6c76-c658-300a" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="406c-16fb-4b4b-585a" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -8000,6 +7971,9 @@
                 </entryLink>
                 <entryLink id="ec42-afcc-a695-934b" name="** Detachment Upgrade (Units of [3], single unit) **" hidden="false" collective="false" import="true" targetId="a060-d513-9f57-6e27" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="9d7b-250b-2a41-c14c" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -8057,6 +8031,9 @@
                 </entryLink>
                 <entryLink id="b347-341f-59aa-fa6e" name="** Detachment Upgrade (Units of [3], single unit) **" hidden="false" collective="false" import="true" targetId="a060-d513-9f57-6e27" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="fa51-815f-46e2-3c88" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -8126,6 +8103,9 @@
                   </constraints>
                 </entryLink>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="e59b-fea4-e038-ccb9" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -8256,6 +8236,9 @@
         <infoLink id="0c82-7bb7-000b-8ace" name="Grave Armor" hidden="false" targetId="03e2-9f50-3f86-e757" type="profile"/>
         <infoLink id="1a83-b04a-761d-a1c7" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="17ef-0557-9b2e-366c" name="Combat Bike (Prime)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -8306,6 +8289,9 @@
         <infoLink id="510b-1353-94c4-f7ee" name="Energy Fist (Elite)" hidden="false" targetId="931f-40b0-f32c-78ed" type="profile"/>
         <infoLink id="3fc3-09c5-45fa-17f6" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="62f2-1914-2276-5288" name="Energy Hammer (Elite)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -8313,18 +8299,27 @@
         <infoLink id="07ac-c6be-e4e9-9123" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
         <infoLink id="a3c6-069e-1aaa-2413" name="Deadly(X)" hidden="false" targetId="377b-3864-960e-57ac" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="8998-727e-c77b-8eea" name="Grapnels" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="18cb-04c4-93e0-d4d3" name="Grapnels" hidden="false" targetId="697c-3227-f602-1b4f" type="profile"/>
         <infoLink id="c08f-c5f1-504e-f2b4" name="Strider" hidden="false" targetId="9dea-b566-200a-0605" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="d73c-2d1f-8106-6fed" name="Orbital Deployment" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="5783-2a77-0692-37e6" name="Orbital Deployment" hidden="false" targetId="ad96-9919-18eb-26bc" type="profile"/>
         <infoLink id="506d-0a1f-f5a3-5230" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="b75e-8917-0c3a-cd0c" name="Prime ATV" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -8353,6 +8348,9 @@
       <infoLinks>
         <infoLink id="863d-e38f-3218-985d" name="Twin Auto-Rifles" hidden="false" targetId="4c65-274d-2ab1-dc68" type="profile"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="c708-237a-9145-77d2" name="Anti-Grav Tank" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -8367,6 +8365,9 @@
         <entryLink id="f44a-d141-cc30-dad1" name="Prime Brothers 2 - Upgrade List B" hidden="false" collective="false" import="true" targetId="799d-1323-0842-401d" type="selectionEntryGroup"/>
         <entryLink id="cf64-18f8-5b29-e4bf" name="** Detachment Upgrade (Units of [1] with Tough(12) &amp; Fast) **" hidden="false" collective="false" import="true" targetId="a235-3a7c-ad55-1c1b" type="selectionEntryGroup"/>
       </entryLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="490.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="d4aa-cfa3-aa0e-5f13" name="Twin Heavy Laser Cannon" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -8374,17 +8375,26 @@
         <infoLink id="26f9-7721-7fb2-f3cd" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
         <infoLink id="ce68-950f-0ff1-2329" name="Deadly(X)" hidden="false" targetId="377b-3864-960e-57ac" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="35f5-f6d4-f7a9-4a09" name="Twin Heavy Gatling Gun" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="c3f3-92c0-a7d5-5418" name="Twin Heavy Gatling Gun" hidden="false" targetId="cb17-3f52-a513-af8d" type="profile"/>
         <infoLink id="7be5-de7b-c97d-f387" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="2fa7-fdb5-c20c-e6a9" name="Tempest Rifle" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="8072-9fc3-d357-9cfc" name="Tempest Rifle" hidden="false" targetId="0af6-57af-191d-8d1f" type="profile"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="3bd4-96e7-5d0d-10c5" name="Twin Laser Talon" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
@@ -8392,6 +8402,9 @@
         <infoLink id="dbb4-b434-902d-669a" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
         <infoLink id="f800-8965-b9c4-aec2" name="Deadly(X)" hidden="false" targetId="377b-3864-960e-57ac" type="rule"/>
       </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -13713,6 +13726,9 @@
                           </constraints>
                         </entryLink>
                       </entryLinks>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+                      </costs>
                     </selectionEntry>
                   </selectionEntries>
                   <selectionEntryGroups>
@@ -13790,6 +13806,9 @@
                   </selectionEntryGroups>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="94f4-5b23-290f-f23f" name="Assault Rifles &amp; CCWs (A2)" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -13806,6 +13825,9 @@
                   </constraints>
                 </entryLink>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -13862,6 +13884,9 @@
                           </constraints>
                         </entryLink>
                       </entryLinks>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+                      </costs>
                     </selectionEntry>
                   </selectionEntries>
                   <selectionEntryGroups>
@@ -13939,6 +13964,9 @@
                   </selectionEntryGroups>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="1a16-f4f4-5520-2b26" name="Assault Rifles &amp; CCWs (A2)" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -13955,6 +13983,9 @@
                   </constraints>
                 </entryLink>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
@@ -13997,6 +14028,9 @@
                   </constraints>
                 </entryLink>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="da0f-d0e6-7334-66f7" name="Plasma Auto-Rifles" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -14053,6 +14087,9 @@
                   </constraints>
                 </entryLink>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="95b2-0c34-5033-8e38" name="Plasma Auto-Rifles" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -14167,6 +14204,9 @@
                   </constraints>
                 </entryLink>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="aca5-a366-024b-b4dc" name="2x Assault Carbines" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -14214,6 +14254,9 @@
                   </constraints>
                 </entryLink>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="b860-c16c-ba4f-0bfe" name="2x Assault Carbines" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -14261,6 +14304,9 @@
                   </constraints>
                 </entryLink>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="8699-a033-bb8b-eabe" name="2x Fist-Flamethrowers" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -14328,6 +14374,9 @@
                   </constraints>
                 </entryLink>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="31f3-3381-2d80-d2c0" name="2x Fist-Flamethrowers" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -14579,6 +14628,9 @@
                   </constraints>
                 </entryLink>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="aef4-9a4b-d6ff-4c71" name="2x HE-Launchers" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -14589,6 +14641,9 @@
                   </constraints>
                 </entryLink>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="0833-1825-95ad-1816" name="2x Tempest Rifles" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -14766,6 +14821,70 @@
               </costs>
             </selectionEntry>
           </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="0868-87db-27ff-c3f6" name="Prime Brothers 2 - Upgrade List D" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5154-a95f-22c8-46ee" name="Replace Heavy Plasma Cannon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="0968-5e1c-91d9-57f7">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f44-cd0c-9216-b6c9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f968-5695-8b9b-0ce2" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="0968-5e1c-91d9-57f7" name="Heavy Plasma Cannon" hidden="false" collective="false" import="true" targetId="e710-08f1-e420-99f1" type="selectionEntry"/>
+            <entryLink id="cb29-1eb3-5ab6-162c" name="Heavy Laser Cannon" hidden="false" collective="false" import="true" targetId="79f9-758b-24c4-e1b6" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="120.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="77b4-eb4d-c254-7447" name="Upgrade with any:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="539a-5ce0-d15a-dac1" name="2x Storm Rifles" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ea3-567c-501f-efeb" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="ed39-b9b8-9619-c4d0" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c18-a904-c2ba-5fa5" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d15-1109-a406-dc92" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="f18a-e793-8252-9ef9" name="AA-Rocket Pod" hidden="false" collective="false" import="true" targetId="5ce3-bc25-e242-c85c" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8923-a74e-1aa1-7078" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="52d7-e8c8-2102-f2fc" name="Machinegun" hidden="false" collective="false" import="true" targetId="6bf9-8992-7b02-5764" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ed7-91ed-938b-46cc" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="5629-b6bd-0146-83d8" name="Twin AA-Machinegun" hidden="false" collective="false" import="true" targetId="5666-6954-7608-c6cd" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36ba-d664-5692-aac5" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -2084,112 +2084,9 @@
         <infoLink id="4ddd-513b-b37e-4def" name="Fear" hidden="false" targetId="d21e-0b0f-ebec-46da" type="rule"/>
         <infoLink id="a93e-09c7-050c-b5f6" name="Furious" hidden="false" targetId="ded5-4f1f-c61d-4659" type="rule"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="4b82-434c-55ad-52fa" name="Left Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="d41e-5c6f-ad21-5849">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e514-7fcf-1b8d-1863" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8da-da57-ebf7-cbd1" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="d41e-5c6f-ad21-5849" name="Fist &amp; Under-Slung Weapon" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="145b-9f02-ef5f-a0cd" name="Under-Slung Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="c22a-db67-7136-b568">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0854-c4f4-7b83-eb86" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cc9-c861-1ce0-32a4" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="c22a-db67-7136-b568" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry"/>
-                    <entryLink id="8005-bcf4-2730-0dd2" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="3d3d-b3f5-235a-2429" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="deef-35cc-588e-415e" name="Fist" hidden="false" collective="false" import="true" defaultSelectionEntryId="02b1-322c-f53f-cda4">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c164-aadb-bcd9-b5e6" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4237-3cd0-147d-1d85" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="02b1-322c-f53f-cda4" name="Walker Fist" hidden="false" collective="false" import="true" targetId="e008-b179-c068-469a" type="selectionEntry"/>
-                    <entryLink id="11a8-4ee9-1bf9-a045" name="Blood Fist" hidden="false" collective="false" import="true" targetId="b2d1-3291-34b7-3063" type="selectionEntry"/>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="50a7-9a8c-7499-5813" name="Frag Blaster" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="effd-7824-1649-d279" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="401e-7131-26f5-c09e" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="5b6e-b359-8afd-f381" name="Frag Blaster" hidden="false" collective="false" import="true" targetId="dcff-7eac-1a79-0535" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6de-af13-d9bc-f439" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="146c-607e-3af6-8423" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="ab6b-f43c-9489-ba85" name="Right Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="87a9-9d8b-0619-118d">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="087a-997b-c884-b7a3" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="431d-b4b4-29a7-3207" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="87a9-9d8b-0619-118d" name="Fist &amp; Under-Slung Weapon" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="47e1-9448-f9f0-4e37" name="Under-Slung Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="bee8-331d-cd39-41f7">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4a9-faf4-1645-09fb" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc27-9775-ca48-9ce0" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="bee8-331d-cd39-41f7" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry"/>
-                    <entryLink id="3ead-297a-fe02-98df" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="9721-bf1f-869d-82ad" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="b020-4815-1be7-1420" name="Fist" hidden="false" collective="false" import="true" defaultSelectionEntryId="4b61-a2cf-0d2c-2222">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22b9-d0bd-20e3-4e82" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9984-a9a4-dc7a-069f" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="4b61-a2cf-0d2c-2222" name="Walker Fist" hidden="false" collective="false" import="true" targetId="e008-b179-c068-469a" type="selectionEntry"/>
-                    <entryLink id="f06d-1cae-94b8-0184" name="Blood Fist" hidden="false" collective="false" import="true" targetId="b2d1-3291-34b7-3063" type="selectionEntry"/>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="855d-1af8-a0a2-1553" name="Blood Brothers - Upgrade List E" hidden="false" collective="false" import="true" targetId="b062-c8dc-5fb4-9881" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="380.0"/>
       </costs>
@@ -15259,6 +15156,79 @@
               </costs>
             </entryLink>
           </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="b062-c8dc-5fb4-9881" name="Blood Brothers - Upgrade List E" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1207-89d6-dbef-6d48" name="Replace one Walker Fist &amp; Storm Rifle:" hidden="false" collective="false" import="true" defaultSelectionEntryId="e156-6807-934d-411d">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcf0-926b-d281-7fff" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d17a-e2e7-3d49-72a8" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="e156-6807-934d-411d" name="Walker Fist &amp; Storm Rifle" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="d52d-e13d-7b62-2a60" name="Replace any Storm Rifle:" hidden="false" collective="false" import="true" defaultSelectionEntryId="0f6f-dd76-d67e-ba6d">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e444-aeb0-2b98-6223" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e74c-18ce-0f31-2941" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="0f6f-dd76-d67e-ba6d" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry"/>
+                    <entryLink id="fa2b-4912-5520-69fa" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="10c9-2894-ddda-33b6" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="94dd-6945-3f4a-03cc" name="Replace any Walker Fist:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4eb1-b74a-b477-121c">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fba7-024c-dc88-9a50" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="085d-8299-32fe-4264" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="4eb1-b74a-b477-121c" name="Walker Fist (Attack Walker)" hidden="false" collective="false" import="true" targetId="e008-b179-c068-469a" type="selectionEntry"/>
+                    <entryLink id="b532-70a9-25fc-8736" name="Blood Fist" hidden="false" collective="false" import="true" targetId="b2d1-3291-34b7-3063" type="selectionEntry"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="315b-d701-a6c6-d42c" name="Frag Blaster" hidden="false" collective="false" import="true" targetId="dcff-7eac-1a79-0535" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ac0-cd81-8280-ef76" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7b4e-ad82-768d-ca95" name="Upgrade with:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="3589-caac-cb47-cdb4" name="Psychic(1)" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a851-87bf-5471-40a5" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="69d7-902d-b06e-022f" name="Psychic(X)" hidden="false" targetId="ba47-b43b-18f8-97c1" type="rule"/>
+              </infoLinks>
+              <entryLinks>
+                <entryLink id="5a88-b66a-9ccd-5d5d" name="Blood Brothers Psychic Spells" hidden="false" collective="false" import="true" targetId="e6bc-e6cc-cdb2-3924" type="selectionEntryGroup"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -1312,6 +1312,9 @@
                 <entryLink id="3bc2-c48c-1890-6905" name="Battle Brothers 2 - Upgrade List A (single unit)" hidden="false" collective="false" import="true" targetId="a326-cae3-0234-0572" type="selectionEntryGroup"/>
                 <entryLink id="5e46-816a-5412-a4b8" name="** Detachment Upgrade (Units of [5] with Tough(3), single unit)" hidden="false" collective="false" import="true" targetId="47b6-1c61-aef4-88db" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="4c69-e95b-9e23-f8ea" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -1376,6 +1379,9 @@
                 <entryLink id="29bc-4cb9-c86f-0fc3" name="Battle Brothers 2 - Upgrade List B (single unit)" hidden="false" collective="false" import="true" targetId="51cf-adc8-a9ca-7780" type="selectionEntryGroup"/>
                 <entryLink id="db5a-6df8-0dc3-20bf" name="** Detachment Upgrade (Units of [3] with Tough(6), single unit)" hidden="false" collective="false" import="true" targetId="13c1-f9c0-7048-d216" type="selectionEntryGroup"/>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="9ad3-885a-3e12-5b65" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -1772,32 +1778,6 @@
         <infoLink id="a6ea-b469-febc-4831" name="Talon Gunship" hidden="false" targetId="dc9b-dfdc-db0f-70a7" type="profile"/>
         <infoLink id="7db9-c1ba-235e-dc7e" name="Aircraft" hidden="false" targetId="187f-6a03-5b99-a4db" type="rule"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="a9d5-3fbf-f594-c64b" name="Main Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="33b0-7af0-7259-0037">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78fd-84e6-325b-b9cd" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6303-07ac-294f-98aa" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="e79c-fbaf-4852-d7b1" name="Hammer Missiles" hidden="false" collective="false" import="true" targetId="2b23-f91f-8f74-d7d9" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="-5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="33b0-7af0-7259-0037" name="Twin Heavy Machinegun" hidden="false" collective="false" import="true" targetId="dae8-3106-6a96-228c" type="selectionEntry"/>
-            <entryLink id="ccd0-1145-7359-d6dc" name="Twin Laser Cannon" hidden="false" collective="false" import="true" targetId="d271-2d81-e640-0040" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="f42a-a833-ec0b-2f5a" name="Typhoon Missiles" hidden="false" collective="false" import="true" targetId="8aef-9844-eaa7-e640" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="c967-7876-34b2-71ef" name="Twin Minigun" hidden="false" collective="false" import="true" targetId="a8f7-27d2-59eb-c865" type="selectionEntry">
           <constraints>
@@ -1805,6 +1785,8 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e18-5662-4a12-bfd7" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="56fb-dee4-72a7-34ce" name="Battle Brothers 3 - Upgrade List E" hidden="false" collective="false" import="true" targetId="e4c2-5710-b39a-8b93" type="selectionEntryGroup"/>
+        <entryLink id="091b-2b80-ebbb-9473" name="** Detachment Upgrade (Units of [1] with Tough(6) **" hidden="false" collective="false" import="true" targetId="35c2-8df3-f833-4949" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="260.0"/>
@@ -13060,6 +13042,9 @@
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="c5fc-df50-d9da-657d" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -13176,6 +13161,9 @@
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="9b9e-412a-caf9-092f" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -13902,6 +13890,9 @@
                   </constraints>
                 </entryLink>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="6c22-65b8-e8cd-281e" name="2x Flamethrower Cannons" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -13912,6 +13903,9 @@
                   </constraints>
                 </entryLink>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="e81d-17f8-8c54-06be" name="2x Twin Laser Cannons" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
@@ -14014,6 +14008,9 @@
                   </constraints>
                 </entryLink>
               </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
@@ -14117,6 +14114,34 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="115.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="e4c2-5710-b39a-8b93" name="Battle Brothers 3 - Upgrade List E" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="af5b-f28a-78e4-1a89" name="Replace Twin Heavy Machinegun:" hidden="false" collective="false" import="true" defaultSelectionEntryId="1693-5f20-4787-8440">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64cf-1a94-5c31-b6c5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fe8-7729-7179-8c44" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="784e-49e1-5dc4-975c" name="Hammer Missiles" hidden="false" collective="false" import="true" targetId="2b23-f91f-8f74-d7d9" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="-5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="1693-5f20-4787-8440" name="Twin Heavy Machinegun" hidden="false" collective="false" import="true" targetId="dae8-3106-6a96-228c" type="selectionEntry"/>
+            <entryLink id="50f6-7f10-0e88-c956" name="Twin Laser Cannon" hidden="false" collective="false" import="true" targetId="d271-2d81-e640-0040" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="80f1-52ea-bee1-cddd" name="Typhoon Missiles" hidden="false" collective="false" import="true" targetId="8aef-9844-eaa7-e640" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
               </costs>
             </entryLink>
           </entryLinks>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -6454,61 +6454,11 @@
         <infoLink id="a032-9b94-30e0-74b2" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
         <infoLink id="7326-a27f-b6f0-5e47" name="Psychic(X)" hidden="false" targetId="ba47-b43b-18f8-97c1" type="rule"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="9cac-4610-2bc9-aa6b" name="Psychic" hidden="false" collective="false" import="true" defaultSelectionEntryId="2113-4842-3c99-4c07">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b929-85e8-b999-05e6" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e09-31b9-15f9-7b50" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="7c1f-de04-ec76-aa70" name="Psychic(2)" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="54af-b2ba-4405-2d0e" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="7acb-ef36-b540-eedf" name="Psychic(X)" hidden="false" targetId="ba47-b43b-18f8-97c1" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="2113-4842-3c99-4c07" name="Psychic(1)" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07c6-fe0b-72f6-726b" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="d46e-9426-6782-06b6" name="Psychic(X)" hidden="false" targetId="ba47-b43b-18f8-97c1" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="982d-86ef-e847-7336" name="Prime Psychic Spell List" hidden="false" collective="false" import="true" targetId="b8a5-2300-ea05-b1e8" type="selectionEntryGroup"/>
-        <entryLink id="550b-3e2d-7351-6af6" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="3f0c-6b59-53ee-1f31" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="60f3-94e2-b1a0-f2e5" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="d3f7-3178-a536-21be" name="Wolf Brothers - Counter" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="caec-c8a0-495b-0b0b" name="Prime Brothers 1 - Upgrade List A" hidden="false" collective="false" import="true" targetId="d455-2126-cc2a-5f47" type="selectionEntryGroup"/>
+        <entryLink id="caec-c8a0-495b-0b0b" name="Prime Brothers 1 - Upgrade List B" hidden="false" collective="false" import="true" targetId="9b9b-2dc9-35a9-7953" type="selectionEntryGroup"/>
+        <entryLink id="2a8b-a8ba-ff47-70ed" name="Prime Brothers 1 - Upgrade List D" hidden="false" collective="false" import="true" targetId="6608-d448-c63b-f38d" type="selectionEntryGroup"/>
+        <entryLink id="8226-0131-0f39-62c4" name="Prime Brothers 1 - Upgrade List A" hidden="false" collective="false" import="true" targetId="d455-2126-cc2a-5f47" type="selectionEntryGroup"/>
+        <entryLink id="dd36-6ea8-17cd-e799" name="** Detachment Upgrade (Heroes) **" hidden="false" collective="false" import="true" targetId="64f3-fff6-95b2-f27b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="125.0"/>
@@ -10023,7 +9973,7 @@
             </selectionEntry>
             <selectionEntry id="fe38-4dac-c861-fbcd" name="Energy Sword, Energy Fist &amp; Fist-Pistol" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="14cf-6142-6ffd-89ea" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                <entryLink id="14cf-6142-6ffd-89ea" name="Energy Sword (A4,Rending)" hidden="false" collective="false" import="true" targetId="cd64-9c2b-796a-a23d" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc5c-0685-c588-4540" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ea2-b069-5dff-7178" type="max"/>
@@ -10035,7 +9985,7 @@
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23c6-0e85-c096-777c" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="52cd-04e5-9883-b837" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                <entryLink id="52cd-04e5-9883-b837" name="Energy Fist (Prime)" hidden="false" collective="false" import="true" targetId="14b5-9b15-044f-e126" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b38c-14fc-7f6e-dd9c" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f93a-9a80-e46a-48ba" type="max"/>
@@ -14158,6 +14108,113 @@
           </constraints>
         </entryLink>
       </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="6608-d448-c63b-f38d" name="Prime Brothers 1 - Upgrade List D" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c710-4250-4de7-964a" name="Upgrade Psychic(1):" hidden="false" collective="false" import="true" defaultSelectionEntryId="368d-8b85-be3b-6202">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="391d-fdf7-b53a-00ea" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b780-400f-de11-cf71" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="33d1-81e1-a532-2dd7" name="Psychic(2)" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e511-d00e-e499-e590" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="774e-6384-fe54-38f6" name="Psychic(X)" hidden="false" targetId="ba47-b43b-18f8-97c1" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="368d-8b85-be3b-6202" name="Psychic(1)" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a28-1477-f168-7cd0" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="47f1-a959-8445-04a4" name="Psychic(X)" hidden="false" targetId="ba47-b43b-18f8-97c1" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8d13-18fe-4244-2c37" name="Psychic Spell List" hidden="false" collective="false" import="true" defaultSelectionEntryId="7b9e-013e-ce7f-912d">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="659f-0791-8e54-eda9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfac-f7de-17c2-f45e" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="7b9e-013e-ce7f-912d" name="Prime Brother Psychic Spells" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd6c-2ec1-31a7-e7fe" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="a23f-d4d0-ae97-f379" name="Battle/Prime Brothers Psychic Spells" hidden="false" collective="false" import="true" targetId="45ad-36d0-7652-d8bb" type="selectionEntryGroup"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ef40-03a6-b352-e828" name="Blood Brother Psychic Spells" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fc5e-c95a-636b-865d" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="09bb-3203-8758-d232" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="4a82-d337-081f-f897" name="Blood Brothers Psychic Spells" hidden="false" collective="false" import="true" targetId="e6bc-e6cc-cdb2-3924" type="selectionEntryGroup"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e699-81ba-44b8-ebf8" name="Knight Brother Psychic Spells" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2f26-c83d-870c-62d5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da32-eb06-44d3-0ea3" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="a8f1-9d8f-4ca9-8d21" name="Knight Brothers Psychic Spells" hidden="false" collective="false" import="true" targetId="ef87-9afc-97d0-abdf" type="selectionEntryGroup"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1bb4-15fa-cf84-f324" name="Wolf Brother Psychic Spells" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5afe-d010-2cea-03e5" type="equalTo"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38d7-f7e4-47fe-e591" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="6c71-c07e-05cb-c0f2" name="Wolf Brothers Psychic Spells" hidden="false" collective="false" import="true" targetId="b6c7-182d-972d-6ca2" type="selectionEntryGroup"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -8454,112 +8454,47 @@
           </constraints>
           <selectionEntries>
             <selectionEntry id="22c5-91b6-064d-8281" name="Single Unit [3 models]" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntries>
-                <selectionEntry id="a5a0-fc95-7997-0e3b" name="Prime Eradication Brother" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="8d7c-a0dc-d156-cff0" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="168d-fc4b-a9af-d00f" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a477-fefb-4c79-09d6" type="min"/>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69be-f35e-8756-69b6" type="max"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9636-059b-d048-ea24" type="min"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f28c-8630-f2ed-a5f2" type="max"/>
                   </constraints>
-                  <entryLinks>
-                    <entryLink id="8b69-091b-8988-271c" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="6277-2494-2ff3-7e56" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfa7-6adf-d146-ba9f" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a95-cb42-0950-04bf" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="c554-1d3e-a691-e0c9" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="168d-fc4b-a9af-d00f" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="487b-abb3-8bee-7834" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6573-ff12-0a24-d13c" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="315b-275a-c02d-e607" name="Detachment Upgrade" hidden="false" collective="false" import="true">
-                  <entryLinks>
-                    <entryLink id="ab60-dc79-61f3-7a33" name="Wolf Brothers - Counter" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="4397-ece8-76a5-4eb0" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="4f11-afe2-35e3-051a" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
+                </entryLink>
+                <entryLink id="bddf-ec2c-4030-92c6" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="6277-2494-2ff3-7e56" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="134c-1028-68d5-b87e" type="min"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b518-b9f5-87a6-d60c" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="b347-341f-59aa-fa6e" name="** Detachment Upgrade (Units of [3], single unit) **" hidden="false" collective="false" import="true" targetId="a060-d513-9f57-6e27" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="fa51-815f-46e2-3c88" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="5cfd-8bb0-9d8a-d034" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="168d-fc4b-a9af-d00f" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f053-9e8d-2534-f83e" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c691-1b29-5da0-c334" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="da0e-9dc9-ee0f-953b" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="6277-2494-2ff3-7e56" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6bdf-fa14-b662-08ba" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f54-37f4-bab9-0be5" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="9c03-778b-85ee-8720" name="** Detachment Upgrade (Units of [3], combined unit) **" hidden="false" collective="false" import="true" targetId="453e-ef26-c3dc-e2b5" type="selectionEntryGroup"/>
+              </entryLinks>
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="180.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b0b9-2252-9244-50dd" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntries>
-                <selectionEntry id="3b3d-cb9c-3d04-fc16" name="Prime Eradication Brother" hidden="false" collective="false" import="true" type="upgrade">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6eec-10cb-ee40-bfd3" type="min"/>
-                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a64-b725-0cc1-4f07" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="7dfd-e032-1918-b4c7" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="6277-2494-2ff3-7e56" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0ed-0dff-9d16-59d0" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cea-e72b-1694-532c" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="20fe-29ce-6628-8f83" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="168d-fc4b-a9af-d00f" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a615-32e8-9302-2bf3" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6101-f1f8-2b04-7c85" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="bab7-0c81-5792-597c" name="Detachment Upgrade" hidden="false" collective="false" import="true">
-                  <entryLinks>
-                    <entryLink id="88a0-0f79-be31-0e7f" name="Wolf Brothers - Counter" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="e001-7b72-2716-f489" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="cffa-954f-9362-9a63" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="360.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="180.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6277-2494-2ff3-7e56" name="Fusion Rifle" hidden="false" collective="true" import="true" type="upgrade">

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -7121,72 +7121,11 @@
     </selectionEntry>
     <selectionEntry id="8190-7f9b-48c5-67b0" name="Prime Attack Walker" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="5a9a-b569-52a6-98fc" name="Firstborn" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
+        <infoLink id="5a9a-b569-52a6-98fc" name="Prime" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
         <infoLink id="30e3-79fd-b270-a642" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
         <infoLink id="484d-9e3d-792b-0311" name="Prime Attack Walker" hidden="false" targetId="3063-82ba-83de-6710" type="profile"/>
         <infoLink id="c096-9c11-1404-061d" name="Fear" hidden="false" targetId="d21e-0b0f-ebec-46da" type="rule"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="76a7-8b80-7832-5821" name="Right Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="c72a-b80d-06b3-407d">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fe0-5ed8-9bfc-2829" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d2b-adbb-0770-6cfb" type="min"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="c72a-b80d-06b3-407d" name="Heavy Gatling Gun" hidden="false" collective="false" import="true" targetId="53fd-83b6-c5ce-01f3" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c18-231a-ce30-5525" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="a291-6d5d-12fa-08b2" name="Heavy Plasma Cannon" hidden="false" collective="false" import="true" targetId="e710-08f1-e420-99f1" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="219d-a3c0-82f3-63cd" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="-20.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="1ff4-4c27-454a-88e8" name="Upgrade with one:" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a679-4789-a08f-eabe" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="be19-8207-a02a-b0ee" name="Gatling Gun" hidden="false" collective="false" import="true" targetId="2680-ae75-416d-93ea" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="83ac-c7bc-ee3b-f401" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="6e8b-39c3-1c91-caaa" name="Left Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="a141-47a1-ed0d-c87e">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bde9-97dd-2267-f791" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76e5-86ed-d267-9a65" type="min"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="a141-47a1-ed0d-c87e" name="Twin Storm Rifle" hidden="false" collective="false" import="true" targetId="c262-f674-c03e-dcae" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99c6-a361-107b-de41" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="30bf-ca63-3934-9f9c" name="Twin HE-Launcher" hidden="false" collective="false" import="true" targetId="fbc3-5a79-7946-6bd8" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d566-8d86-e972-8689" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="df83-8312-5e98-437c" name="Walker Fist" hidden="false" collective="false" import="true" targetId="e008-b179-c068-469a" type="selectionEntry">
           <constraints>
@@ -7194,25 +7133,14 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c518-7894-998b-d62d" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="9535-0f09-b5e0-8204" name="AA-Rocket Pod" hidden="false" collective="false" import="true" targetId="5ce3-bc25-e242-c85c" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6836-09f7-9bae-af85" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
         <entryLink id="e7cd-5d22-e244-6e80" name="Stomp (Walker)" hidden="false" collective="false" import="true" targetId="fd88-1524-b5ee-010c" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b806-0ae2-4e69-9410" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9452-c4e6-8ab2-6c7a" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="5cdc-913a-45ff-1641" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="45.0"/>
-          </costs>
-        </entryLink>
+        <entryLink id="82de-cb3f-0760-68e2" name="** Detachment Upgrade (Units of [1] with Tough(12)) **" hidden="false" collective="false" import="true" targetId="b007-c0d8-b1e0-23d9" type="selectionEntryGroup"/>
+        <entryLink id="dae2-ba68-fe55-83b9" name="Prime Brothers 2 - Upgrade List G" hidden="false" collective="false" import="true" targetId="2077-2f09-6465-e40d" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="500.0"/>
@@ -15024,6 +14952,67 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="2077-2f09-6465-e40d" name="Prime Brothers 2 - Upgrade List G" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="eaf8-bf0a-fbeb-758c" name="Replace Heavy Gatling Gun:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ca18-9b07-b74a-ca49">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="573d-7d1f-78cc-e439" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2c7-5f5e-d1a5-947e" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="ca18-9b07-b74a-ca49" name="Heavy Gatling Gun" hidden="false" collective="false" import="true" targetId="53fd-83b6-c5ce-01f3" type="selectionEntry"/>
+            <entryLink id="bb7a-c9dc-b44c-77a3" name="Heavy Plasma Cannon" hidden="false" collective="false" import="true" targetId="e710-08f1-e420-99f1" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="-20.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0631-0179-0022-b62d" name="Replace Twin Storm Rifle:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ab51-be94-4c48-aa40">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03a9-5857-e3af-d465" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d614-cecd-b146-8e5e" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="ab51-be94-4c48-aa40" name="Twin Storm Rifle" hidden="false" collective="false" import="true" targetId="c262-f674-c03e-dcae" type="selectionEntry"/>
+            <entryLink id="0de1-5170-8069-cdf2" name="Twin HE-Launcher" hidden="false" collective="false" import="true" targetId="fbc3-5a79-7946-6bd8" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="568c-1701-835d-f7f9" name="Upgrade with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9a8-88ae-d21e-2e01" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="61dd-1541-5afd-85a9" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="561d-1579-5ef8-d3dc" name="Gatling Gun" hidden="false" collective="false" import="true" targetId="2680-ae75-416d-93ea" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="737b-0ce8-3c04-aaaa" name="Upgrade with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbff-a817-ff0d-3186" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="d372-a761-0bf5-1616" name="AA-Rocket Pod" hidden="false" collective="false" import="true" targetId="5ce3-bc25-e242-c85c" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
               </costs>
             </entryLink>
           </entryLinks>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -2248,154 +2248,12 @@
         <infoLink id="7659-bd55-31e5-6ad5" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
         <infoLink id="ecfb-c871-3a0c-9550" name="Hero" hidden="false" targetId="5065-c3a4-a9cf-db27" type="rule"/>
         <infoLink id="3c7e-9321-83d9-d40e" name="Interrogator" hidden="false" targetId="fa74-8cc0-91e2-49eb" type="profile"/>
-        <infoLink id="6f8c-3a8f-a2ad-01d2" name="Dark Resolve" hidden="false" targetId="5dec-9937-47f8-7cf4" type="rule"/>
+        <infoLink id="6f8c-3a8f-a2ad-01d2" name="Grim" hidden="false" targetId="5dec-9937-47f8-7cf4" type="rule"/>
         <infoLink id="e80d-a7a8-dbbd-5c81" name="Fear" hidden="false" targetId="d21e-0b0f-ebec-46da" type="rule"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="a014-66c6-5c7c-ad7f" name="Upgrades" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94a6-e7dc-d2fe-7237" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="cf75-1b11-04c5-ccd0" name="Bike" hidden="false" collective="false" import="true" targetId="c47e-3660-de3d-86f7" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="7482-a9ad-0fa0-e41d" name="Jetpack" hidden="false" collective="false" import="true" targetId="33d6-ea20-9d27-5f4e" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="1bac-d454-6f1c-7e52" name="Destroyer Armor" hidden="false" collective="false" import="true" targetId="8150-2743-e904-7a5c" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="1be3-493d-9e1d-75c6" name="Leader Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="6948-6521-191d-71f9">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe00-ffeb-fd51-1da4" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2f6-84e1-0fa1-c2dd" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="6948-6521-191d-71f9" name="Assault Rifle &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="2237-076e-6194-2bbc" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="7906-9dd7-ab54-4aff">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d6e8-389d-c9af-8bf8" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96d9-dfc5-ce6f-d434" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="12e1-8e42-f249-8eaa" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="7f07-0afc-1c65-7fcf" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="7906-9dd7-ab54-4aff" name="CCW (A1)" hidden="false" collective="false" import="true" targetId="4761-1567-afe2-c2ed" type="selectionEntry"/>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks>
-                <entryLink id="3963-2bbf-4672-5c66" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58c1-fbd2-f2df-8763" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7033-c4fc-0d09-22c2" type="min"/>
-                  </constraints>
-                  <selectionEntryGroups>
-                    <selectionEntryGroup id="a35c-f625-7209-3340" name="Assault Rifle Attachment" hidden="false" collective="false" import="true">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="582c-4d73-fbbd-f1e3" type="max"/>
-                      </constraints>
-                      <entryLinks>
-                        <entryLink id="f790-5f25-208c-c4f2" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
-                          <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                          </costs>
-                        </entryLink>
-                        <entryLink id="d26c-d815-8d54-156c" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
-                          <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-                          </costs>
-                        </entryLink>
-                        <entryLink id="466e-57ca-4431-0677" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
-                          <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                          </costs>
-                        </entryLink>
-                      </entryLinks>
-                    </selectionEntryGroup>
-                  </selectionEntryGroups>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="1d6c-f9d2-041d-6584" name="Pistol &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="e398-71cd-3760-145a" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="5278-ec50-4939-a872">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee8e-baaa-974b-efd8" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a79-61d4-67ec-3fe5" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="f883-dd97-86fa-0e42" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="8864-195f-43c1-9640" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="5278-ec50-4939-a872" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="c45b-5e13-93f9-251f" name="Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="7981-bb4a-947b-42a6">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e68c-b261-8358-3286" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2aa-1ae1-5d97-4aa7" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="9eb9-5556-9c5c-adae" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="581c-d8fd-0f75-6156" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="7981-bb4a-947b-42a6" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
-                    <entryLink id="9ada-fe94-53fa-1e08" name="Flame Pistol" hidden="false" collective="false" import="true" targetId="db8f-b317-2b7d-2ed3" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="aec6-33e7-8d1a-6339" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="2071-4cb6-f32c-5d11" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="795d-c995-17bb-1553" name="Dark Brothers - Upgrade List A" hidden="false" collective="false" import="true" targetId="f950-3ba7-5f90-d23d" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="105.0"/>
       </costs>
@@ -14573,7 +14431,7 @@
     </selectionEntryGroup>
     <selectionEntryGroup id="48d2-d0d7-06cb-9b7a" name="Blood Brothers - Upgrade List A" hidden="false" collective="false" import="true">
       <selectionEntryGroups>
-        <selectionEntryGroup id="7883-eab2-5268-1e06" name="Replace Assault Rifles &amp; CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="6d37-1db2-b091-2368">
+        <selectionEntryGroup id="7883-eab2-5268-1e06" name="Replace Assault Rifle &amp; CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="6d37-1db2-b091-2368">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2eb-3de0-c9d5-a820" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e05-f5fd-4220-3a3f" type="max"/>
@@ -14643,13 +14501,6 @@
               </costs>
             </selectionEntry>
             <selectionEntry id="6d37-1db2-b091-2368" name="Assault Rifle &amp; CCW (A1)" hidden="false" collective="false" import="true" type="upgrade">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="330f-2245-e9af-36b6" type="greaterThan"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
               <selectionEntryGroups>
                 <selectionEntryGroup id="9311-c225-fdbb-0fd3" name="Replace one CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="fe56-f0bc-23ca-00d3">
                   <constraints>
@@ -15229,6 +15080,154 @@
               </costs>
             </selectionEntry>
           </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="f950-3ba7-5f90-d23d" name="Dark Brothers - Upgrade List A" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9f57-ec81-597c-773c" name="Replace Assault Rifle &amp; CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="8618-c87d-341b-3d29">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15c9-ec5d-e104-2764" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="358d-67f8-b5b7-8022" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="c0de-c04f-ce73-4124" name="Pistol &amp; CCW (A2)" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d67-2fac-72fe-6042" type="max"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="2628-4376-891c-7a62" name="Replace one CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="d6ce-c927-542c-09b1">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6d5-e73f-7241-fbe4" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0533-1e77-dee7-fb2e" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="d6ce-c927-542c-09b1" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+                    <entryLink id="7514-b18b-4486-9a8b" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="2568-7e10-8ce8-a4b8" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="386b-2a45-a8f6-e941" name="Replace one Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="703f-6453-e8f0-4b4a">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69be-1ad1-cb52-86d0" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca3c-51ec-469d-fb2b" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="703f-6453-e8f0-4b4a" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
+                    <entryLink id="c60e-4a02-3046-6d09" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="c15d-3d3b-0593-1f7a" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="9a84-409a-2749-2e7e" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="6207-8015-0347-1bc3" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="2071-4cb6-f32c-5d11" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8618-c87d-341b-3d29" name="Assault Rifle &amp; CCW (A1)" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="08ea-4257-c6da-94a0" name="Replace one CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="1b3c-322f-4719-df9b">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac1f-f3d5-6244-ad87" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c677-d2df-ec89-54be" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="1b3c-322f-4719-df9b" name="CCW (A1)" hidden="false" collective="false" import="true" targetId="4761-1567-afe2-c2ed" type="selectionEntry"/>
+                    <entryLink id="eaa8-ed56-621c-b9f3" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="466c-005f-840b-f77b" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="5747-9e1a-3187-f88f" name="Take one Assault Rifle attachment:" hidden="false" collective="false" import="true">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef04-5cc5-adfc-d88b" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="de14-095b-70e5-fd51" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="b69b-9c17-35a3-e5f8" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="59f3-b611-9f6e-1907" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="2cf2-0bf9-f776-ea10" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b07-2768-7e32-2b5c" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1eaa-e647-4ee0-07ef" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="20ec-4e4c-02d6-920e" name="Upgrade with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d52b-11ef-459a-0345" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="ef9e-0fa7-ef38-af37" name="Jetpack" hidden="false" collective="false" import="true" targetId="33d6-ea20-9d27-5f4e" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="50cd-d3d6-7e83-0ce9" name="Combat Bike" hidden="false" collective="false" import="true" targetId="c47e-3660-de3d-86f7" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="6a4a-2b23-a955-ee98" name="Destroyer Armor" hidden="false" collective="false" import="true" targetId="8150-2743-e904-7a5c" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -2266,128 +2266,23 @@
         <infoLink id="9255-39b6-64bb-2e5a" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
       </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="a6cd-873e-3999-efe4" name="Upgrade one model with:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="ecc1-714b-0028-4099" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="8e44-c222-4dda-ccfe">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b85c-d478-89c7-2b3f" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="1fa4-dac4-9325-d742" name="Cyclone Missiles" hidden="false" collective="false" import="true" targetId="de20-063e-ab3f-d5cb" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="7b11-8af9-c280-278c" name="Weapon Options" hidden="false" collective="false" import="true" defaultSelectionEntryId="0897-80ca-fd1a-5e1c">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e81-0e7a-01b1-d118" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66ae-344f-bde5-a2cc" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a223-5252-5e24-78a2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1738-21cc-7cdb-251a" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="0174-9033-9c97-7c74" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="8e44-c222-4dda-ccfe" name="Single Unit [5 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="41eb-7007-d878-02e7" name="Energy Claw" hidden="false" collective="false" import="true" targetId="71e9-a72c-6160-0673" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9c4-e6b7-94e8-f25c" type="min"/>
-                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3087-d913-0827-33c7" type="max"/>
-                  </constraints>
-                </entryLink>
+                <entryLink id="8a54-cea2-6a60-67f6" name="Dark Brothers - Upgrade List B (single unit)" hidden="false" collective="false" import="true" targetId="5b91-c09c-1a1c-198d" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="c0f4-fde5-041f-ad52" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="cf0a-9d35-0cab-fe2c" name="Dark Brothers - Upgrade List B (combined unit)" hidden="false" collective="false" import="true" targetId="61b4-9d72-1ff5-ae90" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0b34-2fd8-d45d-531b" name="Energy Hammer &amp; Combat Shield" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="7659-e48b-4025-803a" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eca1-6c20-24d9-1ab7" type="min"/>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="70be-3c5f-2ac2-9709" type="max"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="bf83-b011-1e13-f128" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="035c-d6e8-bb8f-2d49" type="min"/>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af6e-ccbf-b6d4-18b2" type="max"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0897-80ca-fd1a-5e1c" name="Storm Rifle &amp; Energy Fist" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="cffc-99c9-4ce3-3dae" name="Ranged Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="fe9e-9c31-6a55-44db">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3a2-f872-7874-cc55" type="min"/>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10c0-2ad3-37cb-bf8b" type="max"/>
-                  </constraints>
-                  <selectionEntryGroups>
-                    <selectionEntryGroup id="23af-c58e-eeb3-9e0a" name="Replace one Storm Rifle:" hidden="false" collective="false" import="true">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="468a-7759-975f-a915" type="max"/>
-                      </constraints>
-                      <entryLinks>
-                        <entryLink id="9488-1a3b-2432-8d60" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
-                          <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                          </costs>
-                        </entryLink>
-                        <entryLink id="75a1-9d47-10a4-23ed" name="Minigun" hidden="false" collective="false" import="true" targetId="7b99-9f38-072e-e027" type="selectionEntry">
-                          <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-                          </costs>
-                        </entryLink>
-                        <entryLink id="1e02-7fb1-9c66-196d" name="Plasma Cannon" hidden="false" collective="false" import="true" targetId="05e9-6fae-2a04-8820" type="selectionEntry">
-                          <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
-                          </costs>
-                        </entryLink>
-                      </entryLinks>
-                    </selectionEntryGroup>
-                  </selectionEntryGroups>
-                  <entryLinks>
-                    <entryLink id="fe9e-9c31-6a55-44db" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb50-83b2-6bde-18a1" type="max"/>
-                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ff1-36ec-b211-147c" type="min"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="be3c-f18e-8608-5747" name="Melee Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="79c1-c5dc-7010-d079">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cec-fdcb-a4bd-0abf" type="min"/>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4acd-742e-b6bd-1b94" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="79c1-c5dc-7010-d079" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d400-551f-fa8c-c049" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="ce6e-d188-718f-ecad" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a86d-46f2-5d0e-3ae4" type="max"/>
-                      </constraints>
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="-5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="30c4-27dd-15e6-4308" name="Chainsaw Fist" hidden="false" collective="false" import="true" targetId="ee7c-53ab-fcc5-afdb" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="123d-253c-4356-429e" type="max"/>
-                      </constraints>
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="575.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -15223,6 +15118,236 @@
               </costs>
             </entryLink>
             <entryLink id="6a4a-2b23-a955-ee98" name="Destroyer Armor" hidden="false" collective="false" import="true" targetId="8150-2743-e904-7a5c" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="5b91-c09c-1a1c-198d" name="Dark Brothers - Upgrade List B (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c876-a0d8-6b6d-0cfc" name="Replace all Storm Rifles &amp; Energy Fists:" hidden="false" collective="false" import="true" defaultSelectionEntryId="6640-9dc6-14aa-4f95">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1e0-f440-cbef-17d2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c48f-0368-2c2b-1d10" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="d0ce-acd3-4af8-74b4" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="101c-143e-e98e-4cb8" name="Energy Claw" hidden="false" collective="false" import="true" targetId="71e9-a72c-6160-0673" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e05d-cd3f-4b4b-65c3" type="min"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33a8-b25c-9ad4-685a" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="de8f-1381-de27-e592" name="Energy Hammers &amp; Combat Shields" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="2e0c-c221-5281-5482" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a860-8810-879e-0ee9" type="min"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ba5-e4e7-5483-f36d" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="0f8a-3660-be71-1d43" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6803-3775-6168-37a0" type="min"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb15-a144-9909-b1e3" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6640-9dc6-14aa-4f95" name="Storm Rifles &amp; Energy Fists" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="8ee1-2761-3285-c03e" name="Storm Rifles" hidden="false" collective="false" import="true" defaultSelectionEntryId="8560-d69a-7b49-1135">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce4d-b7d6-4049-8db5" type="min"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cc8-34f9-e34b-6f9d" type="max"/>
+                  </constraints>
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="c7ef-9873-840a-0f47" name="Replace one Storm Rifle:" hidden="false" collective="false" import="true">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b009-b1b2-c097-531a" type="max"/>
+                      </constraints>
+                      <entryLinks>
+                        <entryLink id="de3b-bc51-fb2d-2c01" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="19fd-922f-f6e5-946d" name="Minigun" hidden="false" collective="false" import="true" targetId="7b99-9f38-072e-e027" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="f0b6-8cd0-bf74-675a" name="Plasma Cannon" hidden="false" collective="false" import="true" targetId="05e9-6fae-2a04-8820" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
+                          </costs>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <entryLinks>
+                    <entryLink id="8560-d69a-7b49-1135" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="0a53-fe6f-4487-d7fb" name="Replace any Energy Fist:" hidden="false" collective="false" import="true" defaultSelectionEntryId="0bb5-acc9-7c15-084a">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7655-7b30-90d2-1264" type="min"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b399-1224-4d53-6b58" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="0bb5-acc9-7c15-084a" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry"/>
+                    <entryLink id="0647-23d9-3566-6484" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="-5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="7a4f-131a-2f5e-f724" name="Chainsaw Fist" hidden="false" collective="false" import="true" targetId="ee7c-53ab-fcc5-afdb" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="3ab8-1454-665b-bcbc" name="Upgrade one model with:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f5c9-38b8-930a-3b05" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="749c-ae65-3a10-102e" name="Cyclone Missiles" hidden="false" collective="false" import="true" targetId="de20-063e-ab3f-d5cb" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="61b4-9d72-1ff5-ae90" name="Dark Brothers - Upgrade List B (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="64b6-113c-43b3-2b61" name="Replace all Storm Rifles &amp; Energy Fists:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a973-c760-2332-a83c">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8554-1d64-b530-7c77" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="384d-44e4-0113-737e" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="fa07-f104-dbe9-722d" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="eb19-bbcd-f9c8-fbe6" name="Energy Claw" hidden="false" collective="false" import="true" targetId="71e9-a72c-6160-0673" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77f2-c796-c38a-c276" type="min"/>
+                    <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87a1-c063-e32b-e431" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3d2c-75c0-7690-ccfd" name="Energy Hammers &amp; Combat Shields" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="e4b3-1153-66be-8135" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f894-b11c-b9f8-33bb" type="min"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ca8-d973-4d60-8781" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="6d15-9b63-cecd-136e" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad46-1587-ee12-f539" type="min"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1855-d90c-edbc-ef6d" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a973-c760-2332-a83c" name="Storm Rifles &amp; Energy Fists" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="c619-d07a-bca3-c498" name="Storm Rifles" hidden="false" collective="false" import="true" defaultSelectionEntryId="4d50-c50f-99b7-3c43">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2805-0b0b-b55e-64f6" type="min"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fd8-780d-2e87-c24d" type="max"/>
+                  </constraints>
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="0569-4010-1f7d-9158" name="Replace two Storm Rifles:" hidden="false" collective="false" import="true">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f644-cab7-367b-5b7c" type="max"/>
+                      </constraints>
+                      <entryLinks>
+                        <entryLink id="dff4-fdf6-cb95-0ed0" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="38cc-93ed-763e-bd59" name="Minigun" hidden="false" collective="false" import="true" targetId="7b99-9f38-072e-e027" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                          </costs>
+                        </entryLink>
+                        <entryLink id="d0fc-7881-6c5c-6d36" name="Plasma Cannon" hidden="false" collective="false" import="true" targetId="05e9-6fae-2a04-8820" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
+                          </costs>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <entryLinks>
+                    <entryLink id="4d50-c50f-99b7-3c43" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry"/>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="4732-4d76-e3cc-280d" name="Replace any Energy Fist:" hidden="false" collective="false" import="true" defaultSelectionEntryId="163e-d0bb-6f7d-a268">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c098-ef97-608d-f2db" type="min"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0bf-72cc-3b0d-be98" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="163e-d0bb-6f7d-a268" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry"/>
+                    <entryLink id="9623-2189-8c83-3e86" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="-5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="d521-144e-e335-def6" name="Chainsaw Fist" hidden="false" collective="false" import="true" targetId="ee7c-53ab-fcc5-afdb" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="80e5-26cd-64e0-4851" name="Upgrade two models with:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb91-95ff-46cd-b4dd" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="0b7f-f9bf-0c72-ab8a" name="Cyclone Missiles" hidden="false" collective="false" import="true" targetId="de20-063e-ab3f-d5cb" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
               </costs>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -968,6 +968,18 @@
         <categoryLink id="8d10-24e1-7505-c91c" name="New CategoryLink" hidden="false" targetId="3089-78fc-94cc-28a2" primary="true"/>
       </categoryLinks>
     </entryLink>
+    <entryLink id="c967-8829-4bac-4b93" name="Support Turret" hidden="false" collective="false" import="true" targetId="1f0b-73f9-9cf0-c69d" type="selectionEntry">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="dc7a-12df-d69b-ed72" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink id="6b11-a711-8d66-ee95" name="New CategoryLink" hidden="false" targetId="3089-78fc-94cc-28a2" primary="true"/>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="40e7-3f33-f159-d98d" name="Captain" hidden="false" collective="false" import="true" type="upgrade">
@@ -8335,6 +8347,38 @@
         <infoLink id="0e0b-22e8-a7af-cd9b" name="Deadly(X)" hidden="false" targetId="377b-3864-960e-57ac" type="rule"/>
       </infoLinks>
     </selectionEntry>
+    <selectionEntry id="945e-15ad-b707-77b4" name="Twin Heavy Autocannon" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="a0f9-cf78-6d32-891b" name="Twin Heavy Autocannon" hidden="false" targetId="30a2-e84d-af91-24f9" type="profile"/>
+        <infoLink id="96fe-d446-5e60-e290" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="1f0b-73f9-9cf0-c69d" name="Support Turret" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="2d88-11ec-f5d3-262f" name="Support Turret" hidden="false" targetId="cbd7-905e-a982-aedb" type="profile"/>
+        <infoLink id="b8d5-c4a9-42ba-d804" name="Immobile" hidden="false" targetId="2c1d-c23a-cb5d-cb83" type="rule"/>
+        <infoLink id="5242-4fca-f1f5-f7f9" name="Prime" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
+        <infoLink id="b2d7-be93-a506-216b" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
+      </infoLinks>
+      <entryLinks>
+        <entryLink id="1ffe-f7cd-5ccd-836f" name="** Detachment Upgrade (Units of [1] with Tough(3)) **" hidden="false" collective="false" import="true" targetId="fcc5-ad77-d73a-2161" type="selectionEntryGroup"/>
+        <entryLink id="385f-e669-1e1b-0269" name="Prime Brothers 2 - Upgrade List H" hidden="false" collective="false" import="true" targetId="1310-a7b5-31f2-e3fc" type="selectionEntryGroup"/>
+        <entryLink id="b08f-d5de-5e3e-8466" name="Turret Crew" hidden="false" collective="false" import="true" targetId="85a4-c097-3957-7879" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a09e-6a21-f8a1-c165" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="138e-f391-f363-285f" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="165.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="85a4-c097-3957-7879" name="Turret Crew" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="1859-a1e6-c0c5-ca8f" name="Turret Crew" hidden="false" targetId="6840-c3ac-1e90-97a2" type="profile"/>
+      </infoLinks>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="763b-1230-bcad-b19d" name="Battle Brothers 1 - Upgrade List A (single unit)" hidden="false" collective="false" import="true" defaultSelectionEntryId="4323-8b88-efda-e548">
@@ -15019,6 +15063,20 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>
+    <selectionEntryGroup id="1310-a7b5-31f2-e3fc" name="Prime Brothers 2 - Upgrade List H" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c3e8-5fc2-537c-1f94" name="Replace Twin Heavy Autocannon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="72a9-71c3-1588-cfd6">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="392b-1e46-87e8-8108" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b52-ab02-273c-e38e" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="72a9-71c3-1588-cfd6" name="Twin Heavy Autocannon" hidden="false" collective="false" import="true" targetId="945e-15ad-b707-77b4" type="selectionEntry"/>
+            <entryLink id="52cd-a292-b6b5-2eb6" name="Twin Laser Talon" hidden="false" collective="false" import="true" targetId="3bd4-96e7-5d0d-10c5" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
     <rule id="ff04-8ef9-82f1-a88b" name="Shield Wall" publicationId="dead-6af1-a069-5579" hidden="false">
@@ -16912,6 +16970,26 @@
         <characteristic name="Range" typeId="79f4-5578-c041-f866">48&quot;</characteristic>
         <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A1</characteristic>
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(4), Deadly(6)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="cbd7-905e-a982-aedb" name="Support Turret" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
+      <characteristics>
+        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">3+</characteristic>
+        <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">2+</characteristic>
+        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Immobile, Prime, Tough(3)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="30a2-e84d-af91-24f9" name="Twin Heavy Autocannon" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="79f4-5578-c041-f866">48&quot;</characteristic>
+        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A6</characteristic>
+        <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(2)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="6840-c3ac-1e90-97a2" name="Turret Crew" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
+      <characteristics>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
+        <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -3399,47 +3399,39 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="130.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="e85d-abf8-6f4d-e52d" name="Wolf Brother" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="8098-4d3b-f6d0-a2ed" name="Wolf Brother" hidden="false" targetId="f954-0ab0-5bd2-5b2f" type="profile"/>
-        <infoLink id="76c9-964e-cae9-c2c2" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="26a5-fe11-7f4f-19df" name="Counter-Attack" hidden="false" targetId="5c24-d8ee-b4ed-4c8d" type="rule"/>
-      </infoLinks>
-      <entryLinks>
-        <entryLink id="0a4f-afda-9bbc-8797" name="Wolf Leader Weapons" hidden="false" collective="false" import="true" targetId="d882-5701-85b1-d209" type="selectionEntryGroup"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="42e0-c2cb-bb2a-321a" name="Wolf Brothers" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="4a40-66f2-bd84-b937" name="Wolf Brother" hidden="false" targetId="f954-0ab0-5bd2-5b2f" type="profile"/>
+        <infoLink id="d0dd-9b16-ed9f-7693" name="Counter" hidden="false" targetId="5c24-d8ee-b4ed-4c8d" type="rule"/>
+        <infoLink id="bce2-6e20-0c87-4eac" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
+      </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="2a13-8d28-2786-8643" name="Upgrade all:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="122f-bcbd-5073-ba56" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="34c8-d182-fb85-d470">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d976-dced-7387-e074" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63cd-92be-a2a4-643a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b097-98db-3e0c-d89f" type="max"/>
           </constraints>
-          <entryLinks>
-            <entryLink id="c687-3dd9-6cd2-7f89" name="Jetpack" hidden="false" collective="false" import="true" targetId="33d6-ea20-9d27-5f4e" type="selectionEntry">
+          <selectionEntries>
+            <selectionEntry id="34c8-d182-fb85-d470" name="Single Unit [5 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="d684-16ff-059b-8925" name="Wolf Brothers - Upgrade List A (single unit)" hidden="false" collective="false" import="true" targetId="d882-5701-85b1-d209" type="selectionEntryGroup"/>
+                <entryLink id="3ba9-6411-f5dd-214d" name="Wolf Brothers - Upgrade List C (single unit)" hidden="false" collective="false" import="true" targetId="af3b-9e7e-0448-ab7e" type="selectionEntryGroup"/>
+                <entryLink id="0644-6f80-1e48-0531" name="Wolf Brothers - Upgrade List D (single unit)" hidden="false" collective="false" import="true" targetId="4e1f-09a7-914a-8301" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="ad85-6096-609a-aa93" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="8b24-40cd-4afc-bda0" name="Wolf Brothers - Upgrade List A (combined unit)" hidden="false" collective="false" import="true" targetId="769e-f400-b20a-d6db" type="selectionEntryGroup"/>
+                <entryLink id="49aa-10ab-0839-aed1" name="Wolf Brothers - Upgrade List C (combined unit)" hidden="false" collective="false" import="true" targetId="4254-c06a-e4db-a35c" type="selectionEntryGroup"/>
+                <entryLink id="8e34-a3da-b15a-933d" name="Wolf Brothers - Upgrade List D (combined unit)" hidden="false" collective="false" import="true" targetId="7817-6914-254f-75fe" type="selectionEntryGroup"/>
+              </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="155.0"/>
               </costs>
-            </entryLink>
-            <entryLink id="9cbe-63e2-a4e2-aacb" name="Bike" hidden="false" collective="false" import="true" targetId="c47e-3660-de3d-86f7" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="95.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
+            </selectionEntry>
+          </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="f76d-cb04-7bf4-1e31" name="Wolf Brother" hidden="false" collective="false" import="true" targetId="e85d-abf8-6f4d-e52d" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3179-b7f5-3ae1-75ee" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4133-1a08-11ef-41dc" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="155.0"/>
       </costs>
@@ -16260,6 +16252,72 @@
           </constraints>
         </entryLink>
       </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="4e1f-09a7-914a-8301" name="Wolf Brothers - Upgrade List D (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="13f0-f615-3652-b6dd" name="Upgrade all models with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51cf-9c9c-affa-dcfc" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="f6dd-f211-414a-ce86" name="Jetpack" hidden="false" collective="false" import="true" targetId="33d6-ea20-9d27-5f4e" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="9e47-109c-cff5-8fa2" name="Combat Bike" hidden="false" collective="false" import="true" targetId="c47e-3660-de3d-86f7" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="95.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="fd53-f9cb-9165-f886" name="Upgrade one model with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0979-05a2-ede5-e302" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="8c9a-faf4-9d89-b583" name="Battle Standard" hidden="false" collective="false" import="true" targetId="398c-3d34-79c6-a425" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="7817-6914-254f-75fe" name="Wolf Brothers - Upgrade List D (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e73b-99d3-1b62-4058" name="Upgrade all models with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d906-7ade-548d-d3ff" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="8ed0-678d-322f-e69a" name="Jetpack" hidden="false" collective="false" import="true" targetId="33d6-ea20-9d27-5f4e" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="160.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="aab0-5584-5c53-759e" name="Combat Bike" hidden="false" collective="false" import="true" targetId="c47e-3660-de3d-86f7" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="190.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7c9a-b093-eeb8-90d6" name="Upgrade two models with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9a7-21e9-6e0e-248e" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="6474-9d9d-2cc6-6d6d" name="Battle Standard" hidden="false" collective="false" import="true" targetId="398c-3d34-79c6-a425" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -8315,9 +8315,10 @@
     </selectionEntry>
     <selectionEntry id="141f-1f3a-1608-a977" name="Prime Bikers" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="c7d2-ad12-ff4a-94be" name="Prime Guard Brother" hidden="false" targetId="8fc7-b5cb-a682-74ea" type="profile"/>
+        <infoLink id="c7d2-ad12-ff4a-94be" name="Prime Biker" hidden="false" targetId="6db8-9a67-2b76-7419" type="profile"/>
         <infoLink id="f4e9-86d8-0b33-d953" name="Firstborn" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
-        <infoLink id="cab6-cad0-04d9-dead" name="Shield Wall" hidden="false" targetId="ff04-8ef9-82f1-a88b" type="rule"/>
+        <infoLink id="cab6-cad0-04d9-dead" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
+        <infoLink id="23e7-d6d7-56c1-83d6" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
       </infoLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="ece8-14af-3a69-7446" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="95f8-65b6-0f4a-a52a">
@@ -8327,136 +8328,49 @@
           </constraints>
           <selectionEntries>
             <selectionEntry id="95f8-65b6-0f4a-a52a" name="Single Unit [3 models]" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntries>
-                <selectionEntry id="2ef7-0292-a737-cf79" name="Prime Biker" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="ec70-3392-4982-373f" name="** Detachment Upgrade (Units of [3], single unit) **" hidden="false" collective="false" import="true" targetId="a060-d513-9f57-6e27" type="selectionEntryGroup"/>
+                <entryLink id="a2dd-bd49-ca71-6fdc" name="Prime Brothers 1 - Upgrade List M (single unit)" hidden="false" collective="false" import="true" targetId="9d49-5f57-5db3-d3d3" type="selectionEntryGroup"/>
+                <entryLink id="6759-3fcd-fa73-1bdc" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a872-21c0-2c24-1ee6" type="min"/>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c7f-0164-1b4c-9b80" type="max"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de6e-e85a-a89b-04b4" type="min"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f22-7155-ed14-6d31" type="max"/>
                   </constraints>
-                  <entryLinks>
-                    <entryLink id="2b8f-78f2-4f52-631b" name="Pistol" hidden="false" collective="false" import="true" targetId="0f74-a615-8329-0c1a" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4c6-aff1-f90a-8bad" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cbb-dade-4d7f-8892" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="695d-852d-168f-6e23" name="CCW (A3)" hidden="false" collective="false" import="true" targetId="f2c6-3cc8-1ad8-6e26" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd54-bfbf-9ee5-ce6c" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f59-4ce6-c42b-d9bb" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="e317-b985-d4c5-e396" name="Detachment Upgrade" hidden="false" collective="false" import="true">
-                  <entryLinks>
-                    <entryLink id="65ec-5536-a7e2-7166" name="Wolf Brothers - Counter" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="9191-7501-a152-e967" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="7926-8150-5de4-ac9e" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="9242-aa67-fa65-e1c0" name="Upgrade all models with:" hidden="false" collective="false" import="true">
-                  <entryLinks>
-                    <entryLink id="0894-08d1-41b7-6d3e" name="Twin Rifle" hidden="false" collective="false" import="true" targetId="706a-f3fe-b249-493c" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a89b-0086-73ce-c513" type="max"/>
-                      </constraints>
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="60.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
+                </entryLink>
+                <entryLink id="0010-059b-6294-0046" name="CCW (A3)" hidden="false" collective="false" import="true" targetId="f2c6-3cc8-1ad8-6e26" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e503-1f75-49da-7385" type="min"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1e0-b6ed-a328-792e" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="e59b-fea4-e038-ccb9" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="a578-233d-391d-5bf0" name="** Detachment Upgrade (Units of [3], combined unit) **" hidden="false" collective="false" import="true" targetId="453e-ef26-c3dc-e2b5" type="selectionEntryGroup"/>
+                <entryLink id="eb01-50aa-be4a-9757" name="Prime Brothers 1 - Upgrade List M (combined unit)" hidden="false" collective="false" import="true" targetId="99ab-5b2a-58dd-96dc" type="selectionEntryGroup"/>
+                <entryLink id="615d-3467-45eb-adab" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d972-2815-2480-4c6d" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7bf7-735b-7f10-7448" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="1d05-aa4f-d22c-d8bf" name="CCW (A3)" hidden="false" collective="false" import="true" targetId="f2c6-3cc8-1ad8-6e26" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ab6-0e07-cadb-0858" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cfb8-2a50-af8a-7a66" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="145.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="25c3-3ddb-d8f9-b50d" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntries>
-                <selectionEntry id="2f3f-3127-0fd6-cfa2" name="Prime Biker" hidden="false" collective="false" import="true" type="upgrade">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f01-06b2-b3b5-cba9" type="min"/>
-                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a96-e7a4-cb07-75dc" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="14ae-6a3d-b907-61d8" name="Pistol" hidden="false" collective="false" import="true" targetId="0f74-a615-8329-0c1a" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9c0-577e-1f40-fc34" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4dc7-c477-3acf-af61" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="958c-9167-5450-1cd0" name="CCW (A3)" hidden="false" collective="false" import="true" targetId="f2c6-3cc8-1ad8-6e26" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a30-d362-53eb-0116" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01fc-71a3-870c-79bf" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="5a06-3ca4-1967-67de" name="Detachment Upgrade" hidden="false" collective="false" import="true">
-                  <entryLinks>
-                    <entryLink id="9143-16bf-c903-3fb2" name="Wolf Brothers - Counter" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="d378-fadb-73a4-fded" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="7f4d-7c0a-cff7-3593" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="4d8b-e827-bfb9-dd96" name="Upgrade all models with:" hidden="false" collective="false" import="true">
-                  <entryLinks>
-                    <entryLink id="c894-5988-a987-f629" name="Twin Rifle" hidden="false" collective="false" import="true" targetId="706a-f3fe-b249-493c" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="253e-41d3-bb85-1af2" type="max"/>
-                      </constraints>
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="120.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="290.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="145.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="706a-f3fe-b249-493c" name="Twin Rifle" hidden="false" collective="false" import="true" type="upgrade">
@@ -14722,6 +14636,54 @@
           </costs>
         </entryLink>
       </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="9d49-5f57-5db3-d3d3" name="Prime Brothers 1 - Upgrade List M (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8c55-44e6-5f91-dcd8" name="Upgrade all models with:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="265d-eece-beb5-b421" name="Twin Rifles" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2624-873a-47ec-8b1c" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="4950-6285-10bb-f0ad" name="Twin Rifle" hidden="false" collective="false" import="true" targetId="706a-f3fe-b249-493c" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a63a-ea22-0f8a-02dd" type="min"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80b8-c4f4-e664-61de" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="60.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="99ab-5b2a-58dd-96dc" name="Prime Brothers 1 - Upgrade List M (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="95b1-caa7-635e-183a" name="Upgrade all models with:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="4892-1346-7017-f63c" name="Twin Rifles" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d78-7384-569e-1ca7" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="c38d-54f7-34ca-a04b" name="Twin Rifle" hidden="false" collective="false" import="true" targetId="706a-f3fe-b249-493c" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abbd-b056-6c0a-c03a" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="133b-d96d-34b4-aace" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="120.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -7054,67 +7054,6 @@
         <infoLink id="1fb6-e4e7-edfe-2c89" name="Fear" hidden="false" targetId="d21e-0b0f-ebec-46da" type="rule"/>
         <infoLink id="de44-07cb-d6a9-6830" name="Scout" hidden="false" targetId="7bc7-a892-49bc-ad88" type="rule"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="de6d-774e-f32c-ec1d" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="136a-6b0a-7929-2e64">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5222-0126-d18b-fd02" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b52-5da1-c4d3-bc14" type="min"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="7f1c-45dc-d3b9-93e6" name="Twin-Iron Cannon" hidden="false" collective="false" import="true" targetId="1501-f46a-a1c1-66bf" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd8d-d9e2-48ec-989e" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="60.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="136a-6b0a-7929-2e64" name="Incendiary Cannon" hidden="false" collective="false" import="true" targetId="4f36-d525-8467-7d02" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01a6-22cf-85e0-97cc" type="max"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="6fb9-b873-4bcf-b78f" name="Upgrades" hidden="false" collective="false" import="true">
-          <selectionEntries>
-            <selectionEntry id="e44d-50b6-175b-46be" name="2x Machineguns" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d4e-fe41-c16b-97e0" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="a325-fb58-fafa-1161" name="Light Machinegun" hidden="false" collective="false" import="true" targetId="6bf9-8992-7b02-5764" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebf8-e412-d5ed-c66c" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7be6-4deb-93bc-d295" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="9006-7a22-6dcf-4d80" name="Heavy MG Pistol" hidden="false" collective="false" import="true" targetId="2436-0d7a-57c6-bb7d" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="482e-6880-dd9d-cc45" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="d0d4-2106-b9ed-3eec" name="HE-Launcher" hidden="false" collective="false" import="true" targetId="3599-2d43-1180-9d59" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fffe-dd01-7f01-8e84" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="39af-a2fc-d533-eae0" name="Walker Fist" hidden="false" collective="false" import="true" targetId="9353-6eec-8ab4-0ba9" type="selectionEntry">
           <constraints>
@@ -7128,11 +7067,8 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65d5-528a-81c6-06ba" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="c202-a087-d18c-8aa7" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
-          </costs>
-        </entryLink>
+        <entryLink id="dbe6-f947-2b0d-e91a" name="** Detachment Upgrade (Units of [1] with Tough(6) **" hidden="false" collective="false" import="true" targetId="35c2-8df3-f833-4949" type="selectionEntryGroup"/>
+        <entryLink id="0268-826f-04ae-833a" name="Prime Brothers 2 - Upgrade List F" hidden="false" collective="false" import="true" targetId="aa2b-2aa2-fce1-6a84" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="260.0"/>
@@ -15032,6 +14968,62 @@
             <entryLink id="a74e-012e-9f93-d254" name="Fury Missiles" hidden="false" collective="false" import="true" targetId="b462-6a11-cedb-7b97" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="aa2b-2aa2-fce1-6a84" name="Prime Brothers 2 - Upgrade List F" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9f7f-33bf-72a1-87e4" name="Replace Incendiary Cannon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4c1c-4736-cc51-a053">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1452-e636-65f8-b9c1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="295f-092b-7172-691c" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="4c1c-4736-cc51-a053" name="Incendiary Cannon" hidden="false" collective="false" import="true" targetId="4f36-d525-8467-7d02" type="selectionEntry"/>
+            <entryLink id="c56e-755a-df79-7221" name="Twin Iron-Cannon" hidden="false" collective="false" import="true" targetId="1501-f46a-a1c1-66bf" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="60.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6a86-9322-b322-92f0" name="Upgrade with any:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="3472-fffb-4134-9143" name="2x Machineguns" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b408-e96a-347c-9910" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="9cf0-8778-94bc-9b17" name="Machinegun" hidden="false" collective="false" import="true" targetId="6bf9-8992-7b02-5764" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f36-1b3a-8b5e-83e6" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a11e-5eb3-3fe4-3a7b" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="9d5b-ecb8-5e9c-4f3a" name="HE-Launcher" hidden="false" collective="false" import="true" targetId="3599-2d43-1180-9d59" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ebb-ff9d-9a01-9e05" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="a759-a984-0b90-3a23" name="Heavy MG Pistol" hidden="false" collective="false" import="true" targetId="2436-0d7a-57c6-bb7d" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89ef-1bef-1c4c-2ef9" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
               </costs>
             </entryLink>
           </entryLinks>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -7300,188 +7300,23 @@
         <infoLink id="edc5-1366-79f2-1357" name="Firstborn" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
         <infoLink id="3ad1-2c6f-0af8-0ea5" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
         <infoLink id="2616-3a93-1d41-d0de" name="Impact(X)" hidden="false" targetId="0c08-1729-0be7-c286" type="rule"/>
-        <infoLink id="c280-bd61-79b8-bd91" name="Anti-Grav Tank" hidden="false" targetId="178e-604a-1e45-0b70" type="profile"/>
+        <infoLink id="c280-bd61-79b8-bd91" name="Heavy Anti-Grav Transport Tank" hidden="false" targetId="178e-604a-1e45-0b70" type="profile"/>
         <infoLink id="08ab-11f6-41a9-1265" name="Transport(X)" hidden="false" targetId="3460-57e3-8a15-7977" type="rule"/>
         <infoLink id="7335-4f60-6a00-b6ec" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
         <infoLink id="90bc-6bfc-483f-45fd" name="Strider" hidden="false" targetId="9dea-b566-200a-0605" type="rule"/>
       </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="9b09-62ba-8f9a-12d7" name="2x AT-Launchers" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7ee-7938-6a17-a847" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="42f9-20c8-721c-0b5a" name="AT-Launcher" hidden="false" collective="false" import="true" targetId="0e41-7739-d286-fce8" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b49b-f20f-81e2-8e72" type="max"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23fd-df0c-c415-9bb0" type="min"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="9f3e-bffb-66b0-1b68" name="Weapon - Pintle Mount" hidden="false" collective="false" import="true" defaultSelectionEntryId="429d-25bc-c18b-9e15">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="325c-261d-57ed-d567" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="429d-25bc-c18b-9e15" name="Light Machinegun" hidden="false" collective="false" import="true" targetId="6bf9-8992-7b02-5764" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6851-b0a7-3e1b-e507" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="920b-dfd2-fd55-6c3a" name="Gatling Gun" hidden="false" collective="false" import="true" targetId="2680-ae75-416d-93ea" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b40-79a3-1a3a-5173" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="f1d7-6956-dade-69dc" name="Weapon - Turret Mount" hidden="false" collective="false" import="true" defaultSelectionEntryId="890d-81b3-e8c8-4e36">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="818b-3130-e852-ce95" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6217-d0a6-b480-4a08" type="min"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="53ce-b858-09d6-e92d" name="Heavy Gatling Gun" hidden="false" collective="false" import="true" targetId="53fd-83b6-c5ce-01f3" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7066-cb17-55ac-2bb7" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="60.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="890d-81b3-e8c8-4e36" name="Laser Talon" hidden="false" collective="false" import="true" targetId="a799-464d-ce26-f29b" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="912f-b056-a455-f0a3" type="max"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="3084-e817-2875-1aca" name="Weapon - Hull Mount" hidden="false" collective="false" import="true" defaultSelectionEntryId="02a7-b5e3-010e-685d">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3848-8f97-85a8-ebd1" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3351-e7b4-3e77-8efd" type="min"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="02a7-b5e3-010e-685d" name="Twin Heavy Machinegun" hidden="false" collective="false" import="true" targetId="dae8-3106-6a96-228c" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f075-3bf7-4a14-0dad" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="34d3-ebef-4474-d33f" name="Twin Laser Cannon" hidden="false" collective="false" import="true" targetId="d271-2d81-e640-0040" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf45-efec-64f4-51b4" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="1004-0d26-a98a-4bd4" name="Weapon - Rear Mount [max 1]" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d152-99c6-e3fc-3ae6" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="c133-48f0-2192-0b6c" name="HE-Launcher" hidden="false" collective="false" import="true" targetId="3599-2d43-1180-9d59" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a556-eded-54c3-b7ed" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="8979-a137-c454-1d52" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="f12b-5533-2329-5b92" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de2d-ee41-87c0-685d" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="d202-7b30-aed8-aadd" name="AA-Rocket Pod" hidden="false" collective="false" import="true" targetId="5ce3-bc25-e242-c85c" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2e5-291e-507b-9b8c" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="299d-4d10-0699-0c7e" name="AA-Machinegun" hidden="false" collective="false" import="true" targetId="9f24-5cb6-52ad-b7ec" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22e0-8c78-8acb-3b37" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="8cfb-fb52-c56f-d488" name="Weapon - Side Mounts [max 1]" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae52-e8d2-e38a-41ed" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="58e0-d103-0277-70f3" name="2x Storm Rifles" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="d5f5-228f-9dcb-8854" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="f12b-5533-2329-5b92" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dad5-a678-25aa-e23a" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8531-c47d-70cc-8278" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b0ba-a76a-4dd1-d9c9" name="2x HE-Launchers" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="8f13-58b6-48aa-6a37" name="HE-Launcher" hidden="false" collective="false" import="true" targetId="3599-2d43-1180-9d59" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="89fa-8669-b58a-fc64" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="089d-b215-e4c7-d389" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="99fd-0ad2-ca51-0032" name="Light Machinegun" hidden="false" collective="false" import="true" targetId="6bf9-8992-7b02-5764" type="selectionEntry">
+        <entryLink id="99fd-0ad2-ca51-0032" name="Machinegun" hidden="false" collective="false" import="true" targetId="6bf9-8992-7b02-5764" type="selectionEntry">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6112-2f61-959b-06cf" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a14-8c2b-e05e-346a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6112-2f61-959b-06cf" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9a14-8c2b-e05e-346a" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="ca16-7905-a32d-7481" name="Blood Brothers - Very Fast" hidden="false" collective="false" import="true" targetId="ec17-0396-1d9d-0ad9" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="fc5d-e7a0-a7e2-7e7a" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="55.0"/>
-          </costs>
-        </entryLink>
+        <entryLink id="104d-1eb5-a032-aad1" name="** Detachment Upgrade (Units of [1] with Tough(18) &amp; Fast) **" hidden="false" collective="false" import="true" targetId="ad75-3b37-3d15-05f7" type="selectionEntryGroup"/>
+        <entryLink id="6bd7-54d1-aacb-5dec" name="Prime Brothers 2 - Upgrade List C" hidden="false" collective="false" import="true" targetId="0ccd-be8e-626c-a86c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="520.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="695.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="49e2-29e2-9ef6-6348" name="Heavy Anti-Grav Destroyer Tank" hidden="false" collective="false" import="true" type="upgrade">
@@ -7581,7 +7416,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="605.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="780.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5666-6954-7608-c6cd" name="Twin AA-Machinegun" hidden="false" collective="false" import="true" type="upgrade">
@@ -14805,6 +14640,135 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>
+    <selectionEntryGroup id="0ccd-be8e-626c-a86c" name="Prime Brothers 2 - Upgrade List C" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="47f2-60a9-b303-4bb9" name="Replace Laser Talon:" hidden="false" collective="false" import="true" defaultSelectionEntryId="6da1-be01-fff8-395b">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b27-e81e-7674-abd5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b01-e05d-ed44-0199" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="6da1-be01-fff8-395b" name="Laser Talon" hidden="false" collective="false" import="true" targetId="a799-464d-ce26-f29b" type="selectionEntry"/>
+            <entryLink id="9463-4965-a671-42f6" name="Heavy Gatling Gun" hidden="false" collective="false" import="true" targetId="53fd-83b6-c5ce-01f3" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="60.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a755-75dc-4837-0d7d" name="Replace Twin Heavy Machinegun:" hidden="false" collective="false" import="true" defaultSelectionEntryId="9ae3-79a5-ad4b-b1af">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44e6-a9df-6a79-6174" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ad8-996d-aca3-a9a8" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="9ae3-79a5-ad4b-b1af" name="Twin Heavy Machinegun" hidden="false" collective="false" import="true" targetId="dae8-3106-6a96-228c" type="selectionEntry"/>
+            <entryLink id="823a-da3d-9cef-bb54" name="Twin Laser Cannon" hidden="false" collective="false" import="true" targetId="d271-2d81-e640-0040" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f761-6251-ccc7-a676" name="Upgrade with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="29d0-0964-9c3f-730f" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="1ad7-de58-9989-27c0" name="Machinegun" hidden="false" collective="false" import="true" targetId="6bf9-8992-7b02-5764" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="c38d-ac35-2f77-3a56" name="Gatling Gun" hidden="false" collective="false" import="true" targetId="2680-ae75-416d-93ea" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6869-aaab-aeba-67ce" name="Upgrade with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5cb6-35e1-20ff-7852" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="4697-4987-033a-8e39" name="HE-Launcher" hidden="false" collective="false" import="true" targetId="3599-2d43-1180-9d59" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="2c52-254b-8866-3ed4" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="04d3-405e-48d6-0de3" name="AA-Rocket Pod" hidden="false" collective="false" import="true" targetId="5ce3-bc25-e242-c85c" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="c49e-25ac-92bc-ca28" name="AA-Machinegun" hidden="false" collective="false" import="true" targetId="9f24-5cb6-52ad-b7ec" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8570-4df9-e05e-6006" name="Upgrade with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e53-d7bc-1e8f-b7a3" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8bd1-9153-63c5-2be0" name="2x Storm Rifles" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="98a1-1879-dce4-b7f4" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f6e6-7cbf-09a7-97a9" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="751b-71d2-ce9d-4ba6" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="603b-7c54-6fe3-9cdb" name="2x HE-Launchers" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="cafb-e0b8-a410-c95a" name="HE-Launcher" hidden="false" collective="false" import="true" targetId="3599-2d43-1180-9d59" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9042-69be-ad18-bf04" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="097c-436f-badb-86a6" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f897-42e9-e33a-718a" name="Upgrade with:" hidden="false" collective="false" import="true">
+          <selectionEntries>
+            <selectionEntry id="252f-9218-3432-7da0" name="2x AT-Launchers" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ed59-1c23-ef93-ce3e" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="188f-7aca-e41a-3282" name="AT-Launcher" hidden="false" collective="false" import="true" targetId="0e41-7739-d286-fce8" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6e9-f1ad-3ed8-fb90" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f42d-19bf-a876-edeb" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
     <rule id="ff04-8ef9-82f1-a88b" name="Shield Wall" publicationId="dead-6af1-a069-5579" hidden="false">
@@ -16071,11 +16035,11 @@
         <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fear, Prime, Tough(12)</characteristic>
       </characteristics>
     </profile>
-    <profile id="178e-604a-1e45-0b70" name="Anti-Grav Transport Tank" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
+    <profile id="178e-604a-1e45-0b70" name="Heavy Anti-Grav Transport Tank" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
       <characteristics>
         <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">3+</characteristic>
         <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">2+</characteristic>
-        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32"> Fast, Prime, Impact(6), Strider, Tough(12), Transport(11)</characteristic>
+        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32"> Fast, Impact(6), Prime, Strider, Tough(18), Transport(11)</characteristic>
       </characteristics>
     </profile>
     <profile id="6566-7dec-c93b-88f3" name="Auto-Rifle" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
@@ -16369,11 +16333,11 @@
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(2), Blast(3)</characteristic>
       </characteristics>
     </profile>
-    <profile id="ebc0-d921-df04-3c1d" name="Anti-Grav Destroyer Tank" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
+    <profile id="ebc0-d921-df04-3c1d" name="Heavy Anti-Grav Destroyer Tank" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
       <characteristics>
         <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">3+</characteristic>
         <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">2+</characteristic>
-        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32"> Fast, Prime, Impact(6), Strider, Tough(12), Transport(11)</characteristic>
+        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32"> Fast, Impact(6), Prime, Strider, Tough(18), Transport(6)</characteristic>
       </characteristics>
     </profile>
     <profile id="19dc-21da-bf1d-1f2f" name="Heavy Laser Cannon" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -3364,143 +3364,35 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="83a0-a8e2-dd6c-7d19" name="Wolf Rookie" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="45ee-f218-5d02-7ac0" name="Wolf Rookie" hidden="false" targetId="2e3f-34bf-883b-a620" type="profile"/>
-        <infoLink id="e157-6aad-42f1-bb7b" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="7471-c1a3-df65-86b2" name="Counter-Attack" hidden="false" targetId="5c24-d8ee-b4ed-4c8d" type="rule"/>
-      </infoLinks>
-      <entryLinks>
-        <entryLink id="4f57-2e49-e540-5ed7" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="168d-fc4b-a9af-d00f" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56c0-bc25-3802-5644" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="840f-9184-6e6e-18da" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="23c4-1eda-dd00-d2bc" name="Pistol" hidden="false" collective="false" import="true" targetId="0f74-a615-8329-0c1a" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4403-a46b-7965-2184" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef6a-16d9-76e7-ef60" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="c8ba-be2b-d974-9351" name="Wolf Rookie (Leader)" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="4ce1-8feb-c809-357d" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="00a4-2dbf-202a-2af2" name="Counter-Attack" hidden="false" targetId="5c24-d8ee-b4ed-4c8d" type="rule"/>
-        <infoLink id="fa06-cf9a-6807-371e" name="Wolf Rookie" hidden="false" targetId="2e3f-34bf-883b-a620" type="profile"/>
-      </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="1ca9-12ba-e704-4c4a" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="e497-532d-5467-65ec">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2509-edd2-382e-59ca" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68d0-7912-c5a8-dfd8" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="ba71-c214-292e-8eeb" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="b63e-b553-adf0-cee7" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="e497-532d-5467-65ec" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="1e86-bbe7-bf2b-476a" name="Pistol" hidden="false" collective="false" import="true" defaultSelectionEntryId="8bbf-0c07-e40d-8eed">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb2f-89bb-1a8a-046c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3073-f1c2-610c-f1c1" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="9acd-adbe-4ec5-15af" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="8bbf-0c07-e40d-8eed" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="7428-add4-e71a-f13a" name="Wolf Rookie (Special Weapon)" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="2aad-d14e-f8b3-b214" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="6a12-1575-3d9c-e583" name="Wolf Rookie" hidden="false" targetId="2e3f-34bf-883b-a620" type="profile"/>
-        <infoLink id="1696-b3e4-482c-b3a9" name="Counter-Attack" hidden="false" targetId="5c24-d8ee-b4ed-4c8d" type="rule"/>
-      </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="45ce-71a3-e49d-d148" name="Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="a641-3fa4-c5fd-3622">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fa1-c24c-a481-6a50" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d883-064a-2be9-e493" type="min"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="a641-3fa4-c5fd-3622" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="9bc8-d629-4c44-abe4" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="abab-c670-9a47-bd37" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="97f2-47f6-f130-96ea" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3f5-03cf-eedb-0726" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b6a-eca2-c9ef-297b" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="a2a0-98a3-5eaa-430a" name="Wolf Rookies" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="e9eb-642e-12bc-27d8" name="Wolf Rookie" hidden="false" targetId="2e3f-34bf-883b-a620" type="profile"/>
+        <infoLink id="68c0-e94b-e850-f2b1" name="Counter" hidden="false" targetId="5c24-d8ee-b4ed-4c8d" type="rule"/>
+        <infoLink id="0a4e-0999-2d8f-b616" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
+      </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="37ea-c0a4-f8f2-c160" name="Rookies" hidden="false" collective="false" import="true" defaultSelectionEntryId="b066-d5f7-18a2-6069">
+        <selectionEntryGroup id="4432-8e8c-655a-be9a" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="9d3d-063c-971f-3d5f">
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f23d-f24d-1619-0405" type="max"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e662-9c5f-42f6-4a03" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0245-35da-e41a-5c0f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e01-bf0c-c9e6-503a" type="max"/>
           </constraints>
-          <entryLinks>
-            <entryLink id="b066-d5f7-18a2-6069" name="Wolf Rookie" hidden="false" collective="false" import="true" targetId="83a0-a8e2-dd6c-7d19" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3350-c1e6-f9e3-6bc1" type="max"/>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="495f-6586-0d1d-fbc8" type="min"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="28e3-f875-de9f-98de" name="Wolf Brother (Special Weapon)" hidden="false" collective="false" import="true" targetId="7428-add4-e71a-f13a" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="588c-7a7a-6eaf-d0e0" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="45f2-f0e2-a98c-1403" name="Wolf Rookie (Leader)" hidden="false" collective="false" import="true" targetId="c8ba-be2b-d974-9351" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6f5-51a7-e197-addd" type="max"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
+          <selectionEntries>
+            <selectionEntry id="9d3d-063c-971f-3d5f" name="Single Unit [5 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="c9dc-c6d7-3b2d-dee1" name="Wolf Brothers - Upgrade List A (single unit)" hidden="false" collective="false" import="true" targetId="d882-5701-85b1-d209" type="selectionEntryGroup"/>
+                <entryLink id="6804-e546-91e4-67ab" name="Wolf Brothers - Upgrade List C (single unit)" hidden="false" collective="false" import="true" targetId="af3b-9e7e-0448-ab7e" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="69f7-5cb6-de6e-ecc8" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="24e6-f493-68f8-0c25" name="Wolf Brothers - Upgrade List A (combined unit)" hidden="false" collective="false" import="true" targetId="769e-f400-b20a-d6db" type="selectionEntryGroup"/>
+                <entryLink id="5a6c-5a72-83cc-16c5" name="Wolf Brothers - Upgrade List C (combined unit)" hidden="false" collective="false" import="true" targetId="4254-c06a-e4db-a35c" type="selectionEntryGroup"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="130.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
@@ -7056,7 +6948,7 @@
             </selectionEntry>
             <selectionEntry id="a2bd-793a-1999-7032" name="Pistol &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
               <selectionEntryGroups>
-                <selectionEntryGroup id="161b-41d9-f454-2ec2" name="Replace one CCW:" hidden="false" collective="true" import="true" defaultSelectionEntryId="347f-adb9-e3dc-b01a">
+                <selectionEntryGroup id="161b-41d9-f454-2ec2" name="Replace one CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="347f-adb9-e3dc-b01a">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f01-e5bb-1c31-5037" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30ec-f774-1533-f60d" type="max"/>
@@ -7093,7 +6985,7 @@
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="8214-dcad-a8c2-c51f" name="Replace one Pistol:" hidden="false" collective="true" import="true" defaultSelectionEntryId="df46-40ce-52df-76b6">
+                <selectionEntryGroup id="8214-dcad-a8c2-c51f" name="Replace one Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="df46-40ce-52df-76b6">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9129-44e0-873d-ea82" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c8b-e5b8-a4b3-1082" type="max"/>
@@ -7117,7 +7009,7 @@
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0bc-19aa-ca58-4b6c" type="max"/>
                       </constraints>
                       <selectionEntryGroups>
-                        <selectionEntryGroup id="4fda-27c9-8608-97c8" name="Take one Assault Rifle Attachment:" hidden="false" collective="true" import="true">
+                        <selectionEntryGroup id="4fda-27c9-8608-97c8" name="Take one Assault Rifle Attachment:" hidden="false" collective="false" import="true">
                           <constraints>
                             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bef2-b1d5-b3ca-f73b" type="max"/>
                           </constraints>
@@ -16150,6 +16042,224 @@
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="769e-f400-b20a-d6db" name="Wolf Brothers - Upgrade List A (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="bc72-506d-7e4e-aed5" name="Replace two Pistols &amp; CCWs:" hidden="false" collective="false" import="true" defaultSelectionEntryId="26e9-4104-d1f0-e4c1">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad6b-c415-2607-745b" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7588-3766-bcd7-1e10" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="ec66-32cb-9b88-07ed" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="4aca-b997-b202-a512" name="Energy Claw" hidden="false" collective="false" import="true" targetId="71e9-a72c-6160-0673" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5d6-5e0d-6dd6-9452" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27e0-3f8d-fb11-a3b3" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="26e9-4104-d1f0-e4c1" name="Pistol &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="b3b0-0f94-2420-19bf" name="Replace one CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="be13-822a-804c-2ac6">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b68-3cb0-7b58-51d6" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66ce-7f8a-826f-767f" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="be13-822a-804c-2ac6" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+                    <entryLink id="376f-37b7-1729-1f93" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="4739-5f29-8ad1-1857" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="d6d9-1953-d05f-9ce3" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="bd7c-df76-7c93-4f48" name="Replace one Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="df52-9dfc-b74b-c294">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c74-a95e-eef2-2e18" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c50b-3197-15cb-7caa" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="df52-9dfc-b74b-c294" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
+                    <entryLink id="f706-f096-24c8-5a85" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="d5da-ef2b-6511-6b08" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
+                      <selectionEntryGroups>
+                        <selectionEntryGroup id="6e89-eeaf-de44-4d1f" name="Take one Assault Rifle Attachment:" hidden="false" collective="false" import="true">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cc32-a388-a4c8-49bb" type="max"/>
+                          </constraints>
+                          <entryLinks>
+                            <entryLink id="2065-7c0c-2c14-3a78" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="28e0-d862-27fc-db78" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                              </costs>
+                            </entryLink>
+                            <entryLink id="4198-7f0e-7aa5-cfc6" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
+                              <costs>
+                                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+                              </costs>
+                            </entryLink>
+                          </entryLinks>
+                        </selectionEntryGroup>
+                      </selectionEntryGroups>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="c336-05a4-0aea-1ca5" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="af3b-9e7e-0448-ab7e" name="Wolf Brothers - Upgrade List C (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ef45-c594-d06c-9c46" name="Pistols" hidden="false" collective="false" import="true" defaultSelectionEntryId="a324-5a94-adbb-afdc">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7772-d23a-7d4e-c92a" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1b7-464d-0f83-ecf9" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="a637-f0c8-dd4d-c0d2" name="Replace one Pistol:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1c4-4d4d-6ef2-d63d" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="25b7-3706-4c83-cbbb" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="2f0d-18ff-67aa-49c0" name="Replace one Pistol:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="676c-20d6-9c6e-677e" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="55bc-1a66-2dd4-308f" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="a9f2-0f63-d69d-c109" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="510b-e496-40c0-1338" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="a324-5a94-adbb-afdc" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="9d9b-5067-1bdc-a5a6" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f4e-6be5-49a0-c542" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a660-b25c-7fbe-b205" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="4254-c06a-e4db-a35c" name="Wolf Brothers - Upgrade List C (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9a46-5c49-2a52-384c" name="Pistols" hidden="false" collective="false" import="true" defaultSelectionEntryId="26a3-bbd8-4aaf-a158">
+          <constraints>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c6d-ea6a-52f3-64c8" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c730-2501-17cb-ed91" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="1336-c812-d3de-ed2b" name="Replace two Pistols:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a960-86ec-363c-526a" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="4390-814b-1c10-62fb" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="e22c-16c0-d1a4-d57b" name="Replace two Pistols:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c62-4394-469b-4e1a" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="aca6-14b1-36fc-e235" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="c80c-7d26-e429-a968" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="443b-4903-36ef-691c" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="26a3-bbd8-4aaf-a158" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="6f8d-de10-b97b-f259" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d64-a97d-161e-30cc" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a807-531c-e3a7-f669" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -3749,105 +3749,36 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="215.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4962-a702-8350-9aff" name="Purgation Brother" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="3a9d-ea63-7afe-bd69" name="Purgation Brothers" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="69cf-d6a0-44ea-d153" name="Purgation Brother" hidden="false" targetId="f461-b4cd-60e6-d787" type="profile"/>
-        <infoLink id="f634-c61f-7c80-2636" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="e8ea-97f9-b48b-9650" name="Aegis" hidden="false" targetId="ed8b-a6ad-6d94-9c14" type="rule"/>
-        <infoLink id="b2f8-058e-2894-86cf" name="Relentless" hidden="false" targetId="973a-bce3-c43c-b039" type="rule"/>
+        <infoLink id="0756-edb9-6ed0-9929" name="Purgation Brother" hidden="false" targetId="f461-b4cd-60e6-d787" type="profile"/>
+        <infoLink id="bf68-9c5b-95bd-6bb5" name="Aegis" hidden="false" targetId="ed8b-a6ad-6d94-9c14" type="rule"/>
+        <infoLink id="6577-ca4c-24db-b109" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
+        <infoLink id="f3f6-6690-fe18-aa46" name="Relentless" hidden="false" targetId="973a-bce3-c43c-b039" type="rule"/>
       </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="b81c-10b0-6ceb-efa6" name="Psychic(1)" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a72-e803-c643-1914" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="0658-0fb8-9f82-1117" name="Psychic(1)" hidden="false" targetId="2432-e2b3-c2c4-9482" type="profile"/>
-            <infoLink id="5f43-62cf-ad0b-9e91" name="Psychic(X)" hidden="false" targetId="ba47-b43b-18f8-97c1" type="rule"/>
-          </infoLinks>
-          <entryLinks>
-            <entryLink id="be75-4f9a-9ade-9ceb" name="Knight Brothers Psychic Spells" hidden="false" collective="false" import="true" targetId="ef87-9afc-97d0-abdf" type="selectionEntryGroup"/>
-          </entryLinks>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="6bd2-ff6a-70b7-5c82" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="ec0e-aa40-ab5d-ac61">
+        <selectionEntryGroup id="4610-568a-c7dd-759f" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="b73e-8af5-86fc-1c34">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8416-8ff6-3bb7-cfd8" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8441-3855-31be-4694" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d267-2b8f-ad23-1a0e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4527-4a2b-49e7-eb95" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="6559-4aa3-22ce-eb81" name="2x Energy Falchions" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="b73e-8af5-86fc-1c34" name="Single Unit [5 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="53f4-1d00-8995-9179" name="Energy Falchions" hidden="false" collective="false" import="true" targetId="50ff-a6f0-26a7-44be" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2044-431c-9a98-41a0" type="min"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac89-4a7c-1b2d-a2e6" type="max"/>
-                  </constraints>
-                </entryLink>
+                <entryLink id="f374-9a61-aaac-1764" name="Knight Brothers - Upgrade List C (single unit)" hidden="false" collective="false" import="true" targetId="745a-57a6-863e-226e" type="selectionEntryGroup"/>
+                <entryLink id="f2ff-f460-b87f-c98f" name="Knight Brothers - Upgrade List E (single unit)" hidden="false" collective="false" import="true" targetId="c413-23dc-124c-d1e5" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="ecea-56a5-0649-cb7f" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="d850-1193-ba3e-ebe0" name="Knight Brothers - Upgrade List C (combined unit)" hidden="false" collective="false" import="true" targetId="0b1d-81b5-7380-570e" type="selectionEntryGroup"/>
+                <entryLink id="6e9c-0495-fc29-de2d" name="Knight Brothers - Upgrade List E (combined unit)" hidden="false" collective="false" import="true" targetId="bad9-bddd-3169-c1c5" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="225.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
-          <entryLinks>
-            <entryLink id="ec0e-aa40-ab5d-ac61" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry"/>
-            <entryLink id="f3d1-78aa-3945-1997" name="Energy Staff" hidden="false" collective="false" import="true" targetId="5812-eb85-ab7d-c183" type="selectionEntry"/>
-            <entryLink id="6253-1052-0eda-0598" name="Energy Halberd" hidden="false" collective="false" import="true" targetId="7b55-7b95-caec-2fe5" type="selectionEntry"/>
-            <entryLink id="258b-51f3-ed6d-a81a" name="Daemon Hammer" hidden="false" collective="false" import="true" targetId="10b6-089c-2053-fa2d" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="bfbe-f95d-e1ff-f2d4" name="Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="d0aa-30e6-5878-5066">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cf1-49ca-6bc6-4588" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76ad-8a4f-8871-6865" type="min"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="1160-ac75-a8e7-c768" name="Psychic Silencer" hidden="false" collective="false" import="true" targetId="ad33-44fc-7c8b-a775" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="f9dd-6f84-32d4-99ed" name="Psychic Cannon" hidden="false" collective="false" import="true" targetId="c6a1-a06c-031f-3a28" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="d0aa-30e6-5878-5066" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry"/>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="3a9d-ea63-7afe-bd69" name="Purgation Brothers" hidden="false" collective="false" import="true" type="upgrade">
-      <selectionEntryGroups>
-        <selectionEntryGroup id="4ccc-f7a8-8587-a319" name="Brothers" hidden="false" collective="false" import="true" defaultSelectionEntryId="5437-da0b-cf07-e1c7">
-          <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="670b-c309-6161-0754" type="min"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67c5-54fe-2c80-71cb" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="5437-da0b-cf07-e1c7" name="Purgation Brother" hidden="false" collective="false" import="true" targetId="4962-a702-8350-9aff" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c3c-4787-ef8e-498a" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="b35b-faa3-9c64-b57e" name="Purgation Brother (Special Weapon)" hidden="false" collective="false" import="true" targetId="b831-cf8d-de12-ab04" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5295-e3f4-a862-120d" type="max"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
@@ -6588,90 +6519,6 @@
           </constraints>
         </entryLink>
       </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="b831-cf8d-de12-ab04" name="Purgation Brother (Special Weapon)" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="c8ca-eba3-1465-1f93" name="Purgation Brother" hidden="false" targetId="f461-b4cd-60e6-d787" type="profile"/>
-        <infoLink id="7e01-d767-6f19-5706" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="c222-9ff9-cdb9-345f" name="Aegis" hidden="false" targetId="ed8b-a6ad-6d94-9c14" type="rule"/>
-        <infoLink id="d3a7-2f70-c3cf-f325" name="Relentless" hidden="false" targetId="973a-bce3-c43c-b039" type="rule"/>
-      </infoLinks>
-      <selectionEntries>
-        <selectionEntry id="026a-1308-f181-eb89" name="Psychic(1)" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c29-72d4-2f2d-a23b" type="max"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="cffe-3260-dd56-319b" name="Psychic(1)" hidden="false" targetId="2432-e2b3-c2c4-9482" type="profile"/>
-            <infoLink id="ea26-9542-dbc4-4e0e" name="Psychic(X)" hidden="false" targetId="ba47-b43b-18f8-97c1" type="rule"/>
-          </infoLinks>
-          <entryLinks>
-            <entryLink id="742e-9638-5859-27d1" name="Knight Brothers Psychic Spells" hidden="false" collective="false" import="true" targetId="ef87-9afc-97d0-abdf" type="selectionEntryGroup"/>
-          </entryLinks>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="5c82-fd0b-fd25-fdf2" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="dc30-ac60-3608-1355">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dac5-2576-c6cf-2069" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5768-fa1f-8dd9-6f02" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="e3ea-681d-b7a2-a7bd" name="2x Energy Falchions" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="5996-2c72-94fc-6660" name="Energy Falchions" hidden="false" collective="false" import="true" targetId="50ff-a6f0-26a7-44be" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cfd-62cb-3c72-e7b2" type="min"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="011c-5ebe-9398-1228" type="max"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="dc30-ac60-3608-1355" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry"/>
-            <entryLink id="4df5-54b9-c752-f215" name="Energy Staff" hidden="false" collective="false" import="true" targetId="5812-eb85-ab7d-c183" type="selectionEntry"/>
-            <entryLink id="a9ef-cd00-6044-b0ab" name="Energy Halberd" hidden="false" collective="false" import="true" targetId="7b55-7b95-caec-2fe5" type="selectionEntry"/>
-            <entryLink id="5426-0e22-6515-2cfa" name="Daemon Hammer" hidden="false" collective="false" import="true" targetId="10b6-089c-2053-fa2d" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="7a51-dbf9-71e7-8715" name="Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="490a-e868-0fb3-f3c4">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a50-0a54-cbbc-ec8e" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="782f-c04e-15c6-b0cf" type="min"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="54d5-2a2a-f3ef-5536" name="Psychic Silencer" hidden="false" collective="false" import="true" targetId="ad33-44fc-7c8b-a775" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="0a9b-6de6-dc55-ce62" name="Psychic Cannon" hidden="false" collective="false" import="true" targetId="c6a1-a06c-031f-3a28" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="490a-e868-0fb3-f3c4" name="Incinerator" hidden="false" collective="false" import="true" targetId="10a4-0331-6a0c-0de6" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
@@ -15597,9 +15444,9 @@
     </selectionEntryGroup>
     <selectionEntryGroup id="c413-23dc-124c-d1e5" name="Knight Brothers - Upgrade List E (single unit)" hidden="false" collective="false" import="true">
       <selectionEntryGroups>
-        <selectionEntryGroup id="39fa-12dc-861e-9075" name="Upgrade two models with:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="39fa-12dc-861e-9075" name="Upgrade one model with:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3617-2219-531e-9db9" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3617-2219-531e-9db9" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="e9de-c747-44e0-d0ff" name="Psychic(1)" hidden="false" collective="false" import="true" type="upgrade">
@@ -15620,9 +15467,9 @@
     </selectionEntryGroup>
     <selectionEntryGroup id="bad9-bddd-3169-c1c5" name="Knight Brothers - Upgrade List E (combined unit)" hidden="false" collective="false" import="true">
       <selectionEntryGroups>
-        <selectionEntryGroup id="0533-7157-714c-e82a" name="Upgrade one model with:" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="0533-7157-714c-e82a" name="Upgrade two models with:" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="096f-1a71-5a89-95a6" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="096f-1a71-5a89-95a6" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="0570-dd18-7786-45d8" name="Psychic(1)" hidden="false" collective="false" import="true" type="upgrade">
@@ -15640,6 +15487,78 @@
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="745a-57a6-863e-226e" name="Knight Brothers - Upgrade List C (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a660-93c4-d6e9-9afc" name="Replace any Storm Rifle:" hidden="false" collective="false" import="true" defaultSelectionEntryId="2549-d1ad-5eb8-bdaa">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a02-1a8d-c281-e5b0" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb9e-49a6-a2cd-fcbc" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="2549-d1ad-5eb8-bdaa" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry"/>
+            <entryLink id="2ad4-66d8-f708-1eee" name="Incinerator" hidden="false" collective="false" import="true" targetId="10a4-0331-6a0c-0de6" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="2155-47c7-a4df-b234" name="Psychic Silencer" hidden="false" collective="false" import="true" targetId="ad33-44fc-7c8b-a775" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="ad40-7c96-2c63-b0aa" name="Psychic Cannon" hidden="false" collective="false" import="true" targetId="c6a1-a06c-031f-3a28" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="acfe-a6b6-80d0-cc5d" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41c3-130b-c31b-b652" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6665-90d2-8d4f-eb90" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="0b1d-81b5-7380-570e" name="Knight Brothers - Upgrade List C (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1765-27cc-7b8b-8a91" name="Replace any Storm Rifle:" hidden="false" collective="false" import="true" defaultSelectionEntryId="f071-ef15-fd9e-bbc7">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ea2-7627-df50-5098" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3b1-7d34-d5a7-ac11" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="f071-ef15-fd9e-bbc7" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry"/>
+            <entryLink id="33d0-762d-c160-95f5" name="Incinerator" hidden="false" collective="false" import="true" targetId="10a4-0331-6a0c-0de6" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="686c-92b9-034f-ef7b" name="Psychic Silencer" hidden="false" collective="false" import="true" targetId="ad33-44fc-7c8b-a775" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="9a51-20fc-53da-198c" name="Psychic Cannon" hidden="false" collective="false" import="true" targetId="c6a1-a06c-031f-3a28" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="e16f-50f1-fa8a-9adb" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fad8-d87e-3c2e-e63b" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c28b-32ae-739c-a310" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -6405,6 +6405,7 @@
         <entryLink id="cef1-9b6e-4470-a028" name="Prime Brothers 1 - Upgrade List A" hidden="false" collective="false" import="true" targetId="d455-2126-cc2a-5f47" type="selectionEntryGroup"/>
         <entryLink id="3237-2fcb-ad20-5c8d" name="Prime Brothers 1 - Upgrade List B" hidden="false" collective="false" import="true" targetId="9b9b-2dc9-35a9-7953" type="selectionEntryGroup"/>
         <entryLink id="2ded-e6b3-6eea-707d" name="Prime Brothers 1 - Upgrade List C" hidden="false" collective="false" import="true" targetId="fe39-67bd-4fc1-28da" type="selectionEntryGroup"/>
+        <entryLink id="6019-6f21-aeae-d60d" name="** Detachment Upgrade (Heroes) **" hidden="false" collective="false" import="true" targetId="64f3-fff6-95b2-f27b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="105.0"/>
@@ -8683,38 +8684,9 @@
         <infoLink id="f921-bc34-ac22-5530" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
       </infoLinks>
       <entryLinks>
-        <entryLink id="aeca-c04e-257a-d660" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8403-c632-bbcf-0156" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c452-580f-a75e-4938" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="7c2a-57a9-2328-a3e7" name="Relic Sword" hidden="false" collective="false" import="true" targetId="f60f-d2ee-5f2f-d1bf" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2202-720b-756f-e52a" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0067-47a8-8503-ceee" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="166a-df24-bcbd-2e54" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="e1f6-9b25-7e37-4ea0" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="d531-7922-f34e-9e60" name="Watch Brothers - Tactical Master" hidden="false" collective="false" import="true" targetId="f2e2-ff33-227d-9876" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="1294-4b2e-9e96-3849" name="Wolf Brothers - Counter" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
+        <entryLink id="159f-c9e2-3aa7-7693" name="** Detachment Upgrade (Heroes) **" hidden="false" collective="false" import="true" targetId="64f3-fff6-95b2-f27b" type="selectionEntryGroup"/>
+        <entryLink id="6e1c-d413-5955-923d" name="Prime Brothers 1 - Upgrade List A (Judge)" hidden="false" collective="false" import="true" targetId="abf6-f1d6-acfa-94ac" type="selectionEntryGroup"/>
+        <entryLink id="8201-85ad-b04e-c570" name="Prime Brothers 1 - Upgrade List B" hidden="false" collective="false" import="true" targetId="9b9b-2dc9-35a9-7953" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="115.0"/>
@@ -9939,7 +9911,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e470-4cb1-fd2e-82a1" type="max"/>
               </constraints>
               <selectionEntryGroups>
-                <selectionEntryGroup id="020f-6088-abd5-6498" name="Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="50ab-b3d5-a4fb-cf2e">
+                <selectionEntryGroup id="020f-6088-abd5-6498" name="Replace one Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="50ab-b3d5-a4fb-cf2e">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4304-3824-3f5a-da1a" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bf5-f14d-a26f-35a6" type="max"/>
@@ -9978,7 +9950,7 @@
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
-                <selectionEntryGroup id="6c73-7574-0668-9129" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="8de5-d071-5b28-023e">
+                <selectionEntryGroup id="6c73-7574-0668-9129" name="Replace one CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="8de5-d071-5b28-023e">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8f9-7c91-78bb-55d4" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3da4-bb4b-1401-5858" type="max"/>
@@ -10012,7 +9984,7 @@
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f913-c147-a133-5a81" type="max"/>
               </constraints>
               <selectionEntryGroups>
-                <selectionEntryGroup id="34d6-341f-4015-742e" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="da06-60ef-d80c-f99c">
+                <selectionEntryGroup id="34d6-341f-4015-742e" name="Replace one CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="da06-60ef-d80c-f99c">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9a0-78b1-62d8-86d6" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fdb7-bb7c-bd38-9ccd" type="max"/>
@@ -10353,7 +10325,12 @@
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8150-2743-e904-7a5c" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d40-9fa2-76fb-f0c1" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8150-2743-e904-7a5c" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -10361,11 +10338,16 @@
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
           </costs>
         </entryLink>
-        <entryLink id="4ea3-66eb-25ce-7c88" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
+        <entryLink id="4ea3-66eb-25ce-7c88" name="Dark Brothers - Grim" hidden="true" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="hidden" value="true">
+            <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8150-2743-e904-7a5c" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8150-2743-e904-7a5c" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d40-9fa2-76fb-f0c1" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -14103,6 +14085,79 @@
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="abf6-f1d6-acfa-94ac" name="Prime Brothers 1 - Upgrade List A (Judge)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1d40-0223-e5a2-acb0" name="Upgrade one model with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f9d-d401-8128-0030" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="c55a-64ef-e2f3-f864" name="Camo Cloak" hidden="false" collective="false" import="true" targetId="95b9-f24a-635e-8f6f" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="8304-4351-d294-091b" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="d60d-b928-a583-5029" name="Grave Armor" hidden="false" collective="false" import="true" targetId="3d40-9fa2-76fb-f0c1" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="85.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4cd7-c15b-931d-7559" name="Replace one Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ccb4-3e7c-c077-fdf8">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c43-09ea-714e-1a6e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0abe-5bff-a430-dba8" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="ccb4-3e7c-c077-fdf8" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
+            <entryLink id="7488-887f-8100-2936" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="19df-4327-fc62-27a5" name="Heavy Carbine" hidden="false" collective="false" import="true" targetId="25db-4cd3-f542-cba6" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="9494-0372-273a-e242" name="Rifle (A2)" hidden="false" collective="false" import="true" targetId="893b-7055-5ccb-3592" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="481c-5a03-6cd2-4fb1" name="Precision Rifle" hidden="false" collective="false" import="true" targetId="141f-9981-66b1-32bd" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="f805-15d0-afd5-fbae" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="ae48-93dc-2ad8-33b1" name="Shred Pistol" hidden="false" collective="false" import="true" targetId="5f1b-580c-f736-839d" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="1c7f-d7ee-2216-dc63" name="Relic Sword" hidden="false" collective="false" import="true" targetId="f60f-d2ee-5f2f-d1bf" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91de-8c9c-ffce-e7c0" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a549-9a5e-88ef-5693" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -3270,16 +3270,6 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0509-2edd-0085-bf8f" name="Energy Hammer (Werewolf)" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="b538-4a9a-1505-d849" name="Energy Hammer" hidden="false" targetId="fa95-64ea-ab7b-300b" type="profile"/>
-        <infoLink id="dc4c-3789-20b8-5f21" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
-        <infoLink id="d76c-6f54-5d4a-0f23" name="Deadly(X)" hidden="false" targetId="377b-3864-960e-57ac" type="rule"/>
-      </infoLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="6703-fb60-7cf8-b651" name="Heavy Energy Axe" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="8155-55af-0d4b-bc5d" name="Energy Axe" hidden="false" targetId="39ad-81c8-533d-3a8f" type="profile"/>
@@ -3290,9 +3280,9 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d3f4-f6ac-a077-6da1" name="Energy Claw (A3,AP2)" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="d3f4-f6ac-a077-6da1" name="Energy Claw (A3,AP1)" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="438c-e4ed-785f-d7b6" name="Energy Claw" hidden="false" targetId="c4bc-31c1-61aa-840c" type="profile"/>
+        <infoLink id="438c-e4ed-785f-d7b6" name="Energy Claw (A3,AP1)" hidden="false" targetId="c4bc-31c1-61aa-840c" type="profile"/>
         <infoLink id="f5cc-11e4-e906-5ab5" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
         <infoLink id="1d36-4a55-1656-d7a7" name="Rending" hidden="false" targetId="9726-accd-9015-f6f6" type="rule"/>
       </infoLinks>
@@ -3310,7 +3300,7 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6bdb-e95c-d214-ad71" name="Backpack Grenade Launcher" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="6bdb-e95c-d214-ad71" name="Backpack GL" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="a1e1-be53-83f4-39bf" name="Backpack Grenade Launcher" page="" hidden="false" targetId="45c5-5e26-982a-eb5c" type="profile"/>
         <infoLink id="ff33-99f4-f6d3-20e6" name="Blast(X)" hidden="false" targetId="187f-6414-7037-a542" type="rule"/>
@@ -3436,125 +3426,32 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="155.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="84f8-7cbd-c4dc-19b2" name="Werewolf" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="e2b1-5d46-a0d8-5442" name="Werewolf" hidden="false" targetId="71ba-2efc-f155-eea8" type="profile"/>
-        <infoLink id="bfe3-c2e3-a561-d6bc" name="Regeneration" hidden="false" targetId="dea8-a8f9-1865-4424" type="rule"/>
-        <infoLink id="8ed4-e055-c398-b7b3" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="946d-1300-be33-fa0b" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
-        <infoLink id="7aa7-3744-2815-4799" name="Counter-Attack" hidden="false" targetId="5c24-d8ee-b4ed-4c8d" type="rule"/>
-      </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="d907-acbd-74cb-f5c8" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="8609-c0d8-2c28-0c92">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99a9-2800-275d-bdd6" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f42-ecf0-b765-678b" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="5a36-5937-1610-10e3" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="3fcf-50ea-bdcc-137a" name="Energy Claw" hidden="false" collective="false" import="true" targetId="d3f4-f6ac-a077-6da1" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11c9-8598-e717-b096" type="max"/>
-                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b51e-c75d-5f97-50b6" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="8609-c0d8-2c28-0c92" name="CCW (A3)" hidden="false" collective="true" import="true" targetId="c448-f0ed-6a78-0488" type="selectionEntry"/>
-            <entryLink id="7d95-e147-b196-b647" name="Energy Axe" hidden="false" collective="true" import="true" targetId="6703-fb60-7cf8-b651" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="5f09-4277-7315-eddd" name="Backpack Grenade Launcher" hidden="false" collective="false" import="true" targetId="6bdb-e95c-d214-ad71" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5202-062d-0258-53bc" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="ebef-ac57-09a3-5134" name="Werewolf (Energy Hammers &amp; Shields)" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="7512-67be-d28e-61b5" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="b54e-9232-d907-9f8a" name="Counter-Attack" hidden="false" targetId="5c24-d8ee-b4ed-4c8d" type="rule"/>
-        <infoLink id="5bb2-f3bb-0217-108e" name="Werewolf" hidden="false" targetId="71ba-2efc-f155-eea8" type="profile"/>
-        <infoLink id="35a1-1f3e-946e-9a37" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
-        <infoLink id="51c9-4ece-d023-0098" name="Regeneration" hidden="false" targetId="dea8-a8f9-1865-4424" type="rule"/>
-      </infoLinks>
-      <entryLinks>
-        <entryLink id="5ecc-fc4a-7b9a-f533" name="Backpack Grenade Launcher" hidden="false" collective="false" import="true" targetId="6bdb-e95c-d214-ad71" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cb3-0fb4-3b31-c3b1" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="f16e-897a-d43a-0ec0" name="Combat Shield" hidden="false" collective="true" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d203-6121-d0e9-6c2d" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6833-3cb4-e68d-be1c" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="cb48-716f-c0e6-f8c6" name="Energy Hammer" hidden="false" collective="true" import="true" targetId="0509-2edd-0085-bf8f" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e073-75d1-e843-c9b5" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22f1-c9e9-7097-0457" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="3ff5-cf59-75e8-f7e0" name="Werewolves" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="4af5-4add-49c9-5f11" name="Werewolf" hidden="false" targetId="71ba-2efc-f155-eea8" type="profile"/>
+        <infoLink id="e26d-5b65-3e83-358c" name="Counter" hidden="false" targetId="5c24-d8ee-b4ed-4c8d" type="rule"/>
+        <infoLink id="2fa1-076f-925f-242e" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
+        <infoLink id="23c1-8593-ee36-2b7c" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
+        <infoLink id="c526-8071-4dfc-5f86" name="Regeneration" hidden="false" targetId="dea8-a8f9-1865-4424" type="rule"/>
+      </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="f23d-efa2-7144-d287" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="729f-2f01-3a02-cb9c">
+        <selectionEntryGroup id="a1be-d6b3-4faf-18b6" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="1bad-e44d-8cd7-1e58">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="770c-3168-2d22-45de" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b08a-fe36-987d-c23d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24e9-8350-cd90-e882" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e59-da36-f52a-3492" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="729f-2f01-3a02-cb9c" name="Ranged &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="1bad-e44d-8cd7-1e58" name="Single Unit [5 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="550e-6747-5fdb-4ba5" name="Wolf Destroyer" hidden="false" collective="false" import="true" targetId="84f8-7cbd-c4dc-19b2" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2aa-92c4-f1f7-faae" type="max"/>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7c7-d15d-9ba9-5702" type="min"/>
-                  </constraints>
-                </entryLink>
+                <entryLink id="0d65-b230-6a9a-6897" name="Wolf Brothers - Upgrade List E (single unit)" hidden="false" collective="false" import="true" targetId="7477-ff5c-6f4e-4a94" type="selectionEntryGroup"/>
               </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
             </selectionEntry>
-            <selectionEntry id="2c2d-e542-b304-6e67" name="Energy Hammers &amp; Shields" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="5af2-d371-87fa-31c1" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="e48a-09ed-3843-74a3" name="Wolf Destroyer (Energy Hammers &amp; Shields)" hidden="false" collective="false" import="true" targetId="ebef-ac57-09a3-5134" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="179d-0466-a22f-b200" type="max"/>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7192-dfb6-1649-61b6" type="min"/>
-                  </constraints>
-                </entryLink>
+                <entryLink id="c3ee-af6d-0e77-ecbc" name="Wolf Brothers - Upgrade List E (combined unit)" hidden="false" collective="false" import="true" targetId="be1e-2ab4-c6ce-ade2" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="65.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="225.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -16319,6 +16216,158 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>
+    <selectionEntryGroup id="7477-ff5c-6f4e-4a94" name="Wolf Brothers - Upgrade List E (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="f41b-cc01-a1c7-9378" name="Replace all CCWs:" hidden="false" collective="false" import="true" defaultSelectionEntryId="de4f-7375-33fe-14f3">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e62-4755-47c4-098b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45be-22ea-6e46-425f" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="de4f-7375-33fe-14f3" name="CCWs" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="67a5-2fa9-4076-fc07" name="Replace any CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="88a6-f342-30dd-cf17">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0835-77f5-dc6c-d281" type="max"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e41-7cc8-f1fb-07fb" type="min"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="2b87-b4e9-06ad-ee15" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
+                      <entryLinks>
+                        <entryLink id="cc48-35a6-def3-24b6" name="Energy Claw (A3,AP1)" hidden="false" collective="false" import="true" targetId="d3f4-f6ac-a077-6da1" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d7d-a65c-625b-35fc" type="min"/>
+                            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e092-8c00-9201-a31a" type="max"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="88a6-f342-30dd-cf17" name="CCW (A3,AP1)" hidden="false" collective="false" import="true" targetId="c448-f0ed-6a78-0488" type="selectionEntry"/>
+                    <entryLink id="64d1-6cbb-2598-32b3" name="Heavy Energy Axe" hidden="false" collective="false" import="true" targetId="6703-fb60-7cf8-b651" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="965f-9709-0be9-b6b1" name="Energy Hammers &amp; Shields" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="663b-1fb5-56b3-c7b7" name="Energy Hammer (Elite)" hidden="false" collective="false" import="true" targetId="62f2-1914-2276-5288" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3755-e319-cf0d-8693" type="max"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9033-14db-499a-45b4" type="min"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="8dcb-24db-69ea-0514" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32e6-24ab-7121-781a" type="max"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac9c-a1e5-1f9d-8d7d" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="65.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e198-9215-bb1d-61ea" name="Upgrade any model with:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12ea-3ad1-9fdc-0a26" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="98e4-517d-52d8-1ff3" name="Backpack GrL" hidden="false" collective="false" import="true" targetId="6bdb-e95c-d214-ad71" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="be1e-2ab4-c6ce-ade2" name="Wolf Brothers - Upgrade List E (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7a11-56f7-58db-5e5f" name="Replace all CCWs:" hidden="false" collective="false" import="true" defaultSelectionEntryId="365a-ef37-2afe-04d9">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78ae-9eab-3bfe-0804" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7be6-6fcd-e57e-50d3" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="365a-ef37-2afe-04d9" name="CCWs" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="7ada-8de1-3154-cd11" name="Replace any CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="b8f2-0fef-f9f3-da0a">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d34-d7fe-1e0a-9e05" type="max"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e826-84f3-8221-f28b" type="min"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="30c7-0548-fa34-60f4" name="2x Energy Claws" hidden="false" collective="false" import="true" type="upgrade">
+                      <entryLinks>
+                        <entryLink id="bb09-a468-9c08-6f61" name="Energy Claw (A3,AP1)" hidden="false" collective="false" import="true" targetId="d3f4-f6ac-a077-6da1" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c401-1ffc-9319-9232" type="min"/>
+                            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ceff-7bcd-219b-bc86" type="max"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="b8f2-0fef-f9f3-da0a" name="CCW (A3,AP1)" hidden="false" collective="false" import="true" targetId="c448-f0ed-6a78-0488" type="selectionEntry"/>
+                    <entryLink id="9432-e595-31ca-5a2a" name="Heavy Energy Axe" hidden="false" collective="false" import="true" targetId="6703-fb60-7cf8-b651" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1395-8d9c-9410-ca1d" name="Energy Hammers &amp; Shields" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="b965-a8cc-bee0-6c9b" name="Energy Hammer (Elite)" hidden="false" collective="false" import="true" targetId="62f2-1914-2276-5288" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b32-65a8-b50b-16db" type="max"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4117-9fab-8dfa-1939" type="min"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="b413-01c8-f14e-1301" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45aa-5664-8aab-aa3d" type="max"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="918d-e3dc-9dbd-d691" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="130.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8abe-827b-1ecc-cf69" name="Upgrade any model with:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ea1-c168-f990-7de1" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="dc21-888a-8a98-48d6" name="Backpack Grenade Launcher" hidden="false" collective="false" import="true" targetId="6bdb-e95c-d214-ad71" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
     <rule id="ff04-8ef9-82f1-a88b" name="Shield Wall" publicationId="dead-6af1-a069-5579" hidden="false">
@@ -17374,19 +17423,13 @@
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(2), Rending</characteristic>
       </characteristics>
     </profile>
-    <profile id="fa95-64ea-ab7b-300b" name="Energy Hammer (Werewolf)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
+    <profile id="c4bc-31c1-61aa-840c" name="Energy Claw (A3,AP1)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
         <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
-        <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(1), Deadly(3)</characteristic>
+        <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(1), Rending</characteristic>
       </characteristics>
     </profile>
-    <profile id="c4bc-31c1-61aa-840c" name="Energy Claw (A3,AP2)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
-      <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
-        <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(2), Rending</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="45c5-5e26-982a-eb5c" name="Backpack Grenade Launcher" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
+    <profile id="45c5-5e26-982a-eb5c" name="Backpack GL" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
       <characteristics>
         <characteristic name="Range" typeId="79f4-5578-c041-f866">12&quot;</characteristic>
         <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A1</characteristic>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -6722,207 +6722,39 @@
     </selectionEntry>
     <selectionEntry id="4766-2820-8ae3-0dff" name="Raider Squad" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="1e35-6097-b1a6-a991" name="Raider Brother" hidden="false" targetId="c1bd-a6ee-8e69-16fa" type="profile"/>
+        <infoLink id="1e35-6097-b1a6-a991" name="Prime Raider Brother" hidden="false" targetId="c1bd-a6ee-8e69-16fa" type="profile"/>
         <infoLink id="c4be-95a6-c48c-c57f" name="Firstborn" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
         <infoLink id="a634-d51a-9fab-c219" name="Furious" hidden="false" targetId="ded5-4f1f-c61d-4659" type="rule"/>
       </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="3e87-0d02-e0b3-59d9" name="Weapon Option" hidden="false" collective="false" import="true" defaultSelectionEntryId="fe2d-8d59-f88d-93d8">
+        <selectionEntryGroup id="8a29-b0a8-c0f8-6577" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="ab4c-6815-ddf9-5a64">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a0b-1cf9-eecc-d987" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a33b-bce1-f769-3a3b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9801-57ec-fe70-578a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0161-4ea2-b113-8651" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="e2af-e763-5065-be7f" name="Rifles &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="ab4c-6815-ddf9-5a64" name="Single Unit [5 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="182d-a803-480a-4288" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb86-98a9-26bf-e12e" type="min"/>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7139-b7e4-1017-df12" type="max"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="b81a-286c-afcf-82cd" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e87-6285-8f03-1da7" type="min"/>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa6b-1d75-52a0-bd33" type="max"/>
-                  </constraints>
-                </entryLink>
+                <entryLink id="5c03-c5c7-01a3-8431" name="** Detachment Upgrade (Units of [5], single unit) **" hidden="false" collective="false" import="true" targetId="f024-6c76-c658-300a" type="selectionEntryGroup"/>
+                <entryLink id="21f0-52cd-aeb4-5a2a" name="Prime Brothers 1 - Upgrade List E (single unit)" hidden="false" collective="false" import="true" targetId="0bb9-e22c-0855-349c" type="selectionEntryGroup"/>
+                <entryLink id="4809-ce04-2739-2d67" name="Prime Brothers 1 - Upgrade List H (single unit)" hidden="false" collective="false" import="true" targetId="47fe-347c-904f-3c77" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="acf0-68de-d166-d5c3" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="4811-01bc-5fe1-2869" name="** Detachment Upgrade (Units of [5], combined unit) **" hidden="false" collective="false" import="true" targetId="3ed3-d384-8a43-eb07" type="selectionEntryGroup"/>
+                <entryLink id="c800-55c6-0183-4e9c" name="Prime Brothers 1 - Upgrade List E (combined unit)" hidden="false" collective="false" import="true" targetId="1ad2-e3d2-1485-cc14" type="selectionEntryGroup"/>
+                <entryLink id="d7da-e672-0c6c-4287" name="Prime Brothers 1 - Upgrade List H (combined unit)" hidden="false" collective="false" import="true" targetId="0b42-a9c6-01ed-0499" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="fe2d-8d59-f88d-93d8" name="Pistols &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="7404-0961-2d3c-b764" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="050d-a45a-edce-f59a">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b078-eb87-56b5-120c" type="max"/>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b50d-b21c-6bb5-c7e1" type="min"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="050d-a45a-edce-f59a" name="Heavy Pistol &amp; CCW" hidden="false" collective="true" import="true" type="upgrade">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c366-b142-9b73-21dd" type="max"/>
-                      </constraints>
-                      <entryLinks>
-                        <entryLink id="8d00-4916-80af-c6b5" name="Heavy Pistol" hidden="false" collective="true" import="true" targetId="aab5-8151-d4fb-2308" type="selectionEntry">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb17-396e-6b57-6124" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="daf8-12a5-bf65-f9d2" type="max"/>
-                          </constraints>
-                        </entryLink>
-                        <entryLink id="aed4-8e2f-e477-935b" name="CCW (A3)" hidden="false" collective="false" import="true" targetId="f2c6-3cc8-1ad8-6e26" type="selectionEntry">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81a6-e5f4-da2c-6ed4" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a506-632a-284f-856c" type="max"/>
-                          </constraints>
-                        </entryLink>
-                      </entryLinks>
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups>
-                    <selectionEntryGroup id="4f4e-19c0-e60d-9356" name="Weapon Upgrade [max 1]" hidden="false" collective="false" import="true">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="110d-aa44-1a58-4460" type="max"/>
-                      </constraints>
-                      <selectionEntries>
-                        <selectionEntry id="5e38-81e1-3470-6a09" name="Heavy Pistol &amp; Energy Sword" hidden="false" collective="false" import="true" type="upgrade">
-                          <entryLinks>
-                            <entryLink id="790b-cc5f-d76b-0dfa" name="Heavy Pistol" hidden="false" collective="false" import="true" targetId="aab5-8151-d4fb-2308" type="selectionEntry">
-                              <constraints>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5508-b1d0-0b94-e687" type="min"/>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77ae-7675-0e88-6596" type="max"/>
-                              </constraints>
-                            </entryLink>
-                            <entryLink id="e520-3a29-3334-c963" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
-                              <constraints>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30e1-daf9-67d2-4236" type="min"/>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7075-7f6d-35c6-2c4b" type="max"/>
-                              </constraints>
-                            </entryLink>
-                          </entryLinks>
-                          <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                          </costs>
-                        </selectionEntry>
-                        <selectionEntry id="1f54-85e4-27e6-52b9" name="Heavy Pistol &amp; Energy Fist" hidden="false" collective="false" import="true" type="upgrade">
-                          <entryLinks>
-                            <entryLink id="c37f-aa4a-0c1f-3a8c" name="Heavy Pistol" hidden="false" collective="false" import="true" targetId="aab5-8151-d4fb-2308" type="selectionEntry">
-                              <constraints>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="082d-a7cb-26dc-259a" type="min"/>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb34-1c1b-265c-2652" type="max"/>
-                              </constraints>
-                            </entryLink>
-                            <entryLink id="8179-0adc-0395-99c8" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
-                              <constraints>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0236-c481-6a65-4769" type="min"/>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf0d-baba-352c-5e64" type="max"/>
-                              </constraints>
-                            </entryLink>
-                          </entryLinks>
-                          <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                          </costs>
-                        </selectionEntry>
-                        <selectionEntry id="8b97-af2a-cd77-7461" name="Heavy Pistol &amp; Energy Hammer" hidden="false" collective="false" import="true" type="upgrade">
-                          <entryLinks>
-                            <entryLink id="48fd-c66f-3da5-6f7b" name="Heavy Pistol" hidden="false" collective="false" import="true" targetId="aab5-8151-d4fb-2308" type="selectionEntry">
-                              <constraints>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14eb-233b-a36b-1350" type="min"/>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5dd-6a0f-ca2f-6e0f" type="max"/>
-                              </constraints>
-                            </entryLink>
-                            <entryLink id="4482-b7f1-9bbb-13a4" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
-                              <constraints>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c266-5bb5-fe9c-69fa" type="min"/>
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec00-d461-a985-feb4" type="max"/>
-                              </constraints>
-                            </entryLink>
-                          </entryLinks>
-                          <costs>
-                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                          </costs>
-                        </selectionEntry>
-                      </selectionEntries>
-                      <entryLinks>
-                        <entryLink id="1c9d-3f81-a443-b770" name="Heavy Chainsaw Sword (Raider)" hidden="false" collective="false" import="true" targetId="12b8-2a78-c0f1-9101" type="selectionEntry"/>
-                      </entryLinks>
-                    </selectionEntryGroup>
-                  </selectionEntryGroups>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="205.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="ff78-40d6-84ac-8f45" name="Upgrade all:" hidden="false" collective="false" import="true">
-          <selectionEntries>
-            <selectionEntry id="8e83-f01b-4535-f501" name="Grapnels" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e49-724e-62b0-edb6" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="159d-c419-1bd7-23df" name="Strider" hidden="false" targetId="9dea-b566-200a-0605" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b7c6-d3c4-fc5f-6af6" name="Orbital Deployment" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b571-f2e1-c7d7-97b2" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="4ce4-8a98-59af-23a0" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="942c-4c02-cf7d-cd3c" name="Upgrade one model with:" hidden="false" collective="false" import="true">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b51-118e-31b4-ebcf" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="cac6-65e3-2d4e-2ea8" name="Medical Training" hidden="false" collective="false" import="true" targetId="8352-cbe6-9410-a422" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="45.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="d400-f664-6bc8-ff9c" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="d352-23d6-8a63-b07f" name="Wolf Brothers - Counter-Attack" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="10b7-7ef4-504c-615b" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="00ce-0855-81fe-9328" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-      </entryLinks>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="210.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="205.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="06ab-90de-30e2-fc37" name="Infiltration Brother" hidden="false" collective="false" import="true" type="upgrade">
@@ -8101,9 +7933,9 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="cd64-9c2b-796a-a23d" name="Energy Sword (A4,Rending)" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="cd64-9c2b-796a-a23d" name="Energy Sword (Prime)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="00ef-f624-a250-ca41" name="Energy Sword (A4,Rending)" hidden="false" targetId="bddc-3c21-5d50-b20a" type="profile"/>
+        <infoLink id="00ef-f624-a250-ca41" name="Energy Sword (Prime)" hidden="false" targetId="bddc-3c21-5d50-b20a" type="profile"/>
         <infoLink id="fc80-de4f-94d1-da05" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
         <infoLink id="48f0-f89a-425a-959c" name="Rending" hidden="false" targetId="9726-accd-9015-f6f6" type="rule"/>
       </infoLinks>
@@ -8138,7 +7970,7 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="aab5-8151-d4fb-2308" name="Heavy Pistol" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="aab5-8151-d4fb-2308" name="Heavy Pistol" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="a114-5021-1f82-2059" name="Heavy Pistol" hidden="false" targetId="995d-8895-1efa-5be8" type="profile"/>
         <infoLink id="c673-ea18-4923-da8c" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
@@ -8147,9 +7979,9 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="12b8-2a78-c0f1-9101" name="Heavy Chainsaw Sword (Raider)" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="12b8-2a78-c0f1-9101" name="Heavy Chainsaw Sword (Elite)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="ae75-df98-69cc-da5f" name="Heavy Chainsaw Sword (A9)" hidden="false" targetId="8738-edea-82e1-348a" type="profile"/>
+        <infoLink id="ae75-df98-69cc-da5f" name="Heavy Chainsaw Sword (Elite)" hidden="false" targetId="8738-edea-82e1-348a" type="profile"/>
         <infoLink id="751f-78da-38ee-f73c" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
       </infoLinks>
       <costs>
@@ -8609,9 +8441,9 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="185.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="262a-3a6e-424e-b887" name="Energy Sword (Guards)" hidden="false" collective="true" import="true" type="upgrade">
+    <selectionEntry id="262a-3a6e-424e-b887" name="Energy Sword (Elite)" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="8d5a-5404-3f6e-a075" name="Energy Sword (Guards)" hidden="false" targetId="5961-c5a1-481e-8371" type="profile"/>
+        <infoLink id="8d5a-5404-3f6e-a075" name="Energy Sword (A3,Rending)" hidden="false" targetId="5961-c5a1-481e-8371" type="profile"/>
         <infoLink id="1583-21f6-b314-31b7" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
         <infoLink id="ee8e-db6c-7f70-1bbf" name="Rending" hidden="false" targetId="9726-accd-9015-f6f6" type="rule"/>
       </infoLinks>
@@ -9164,6 +8996,31 @@
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
+    </selectionEntry>
+    <selectionEntry id="b7bb-dc0c-3e11-80db" name="Energy Fist (Elite)" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="510b-1353-94c4-f7ee" name="Energy Fist (Elite)" hidden="false" targetId="931f-40b0-f32c-78ed" type="profile"/>
+        <infoLink id="3fc3-09c5-45fa-17f6" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="62f2-1914-2276-5288" name="Energy Hammer (Elite)" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="628c-f0ae-d1fc-1bcc" name="Energy Hammer (Elite)" hidden="false" targetId="6e04-c238-4902-8d85" type="profile"/>
+        <infoLink id="07ac-c6be-e4e9-9123" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
+        <infoLink id="a3c6-069e-1aaa-2413" name="Deadly(X)" hidden="false" targetId="377b-3864-960e-57ac" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="8998-727e-c77b-8eea" name="Grapnels" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="18cb-04c4-93e0-d4d3" name="Grapnels" hidden="false" targetId="697c-3227-f602-1b4f" type="profile"/>
+        <infoLink id="c08f-c5f1-504e-f2b4" name="Strider" hidden="false" targetId="9dea-b566-200a-0605" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry id="d73c-2d1f-8106-6fed" name="Orbital Deployment" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="5783-2a77-0692-37e6" name="Orbital Deployment" hidden="false" targetId="ad96-9919-18eb-26bc" type="profile"/>
+        <infoLink id="506d-0a1f-f5a3-5230" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
+      </infoLinks>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -10672,11 +10529,16 @@
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
           </costs>
         </entryLink>
-        <entryLink id="ce3e-10f8-8498-e9e3" name="Dark Brothers - Dark Assault" hidden="false" collective="false" import="true" targetId="cf31-8c37-3347-79a3" type="selectionEntry">
+        <entryLink id="ce3e-10f8-8498-e9e3" name="Dark Brothers - Dark Assault" hidden="true" collective="false" import="true" targetId="cf31-8c37-3347-79a3" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="hidden" value="true">
+            <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33d6-ea20-9d27-5f4e" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d73c-2d1f-8106-6fed" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33d6-ea20-9d27-5f4e" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -10718,11 +10580,16 @@
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
           </costs>
         </entryLink>
-        <entryLink id="66e0-5ea7-bc71-71a2" name="Dark Brothers - Dark Assault" hidden="false" collective="false" import="true" targetId="cf31-8c37-3347-79a3" type="selectionEntry">
+        <entryLink id="66e0-5ea7-bc71-71a2" name="Dark Brothers - Dark Assault" hidden="true" collective="false" import="true" targetId="cf31-8c37-3347-79a3" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="hidden" value="true">
+            <modifier type="set" field="hidden" value="false">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33d6-ea20-9d27-5f4e" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="33d6-ea20-9d27-5f4e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="hidden" value="false">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d73c-2d1f-8106-6fed" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -14476,6 +14343,304 @@
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
+    <selectionEntryGroup id="47fe-347c-904f-3c77" name="Prime Brothers 1 - Upgrade List H (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="212a-3afc-1b2d-f2f0" name="Replace all Heavy Pistols &amp; CCWs:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a473-2edf-b011-0cb6">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f08-0751-4f54-fe53" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ea0-18ae-95f9-7636" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="a473-2edf-b011-0cb6" name="Heavy Pistols &amp; CCWs (A3)" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="8413-a667-fd85-c889" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="c1e7-31fb-6e15-03aa">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="736c-1946-4082-c3da" type="min"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56e9-57ec-3ccb-5a42" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="c1e7-31fb-6e15-03aa" name="Heavy Pistol &amp; CCW (A3)" hidden="false" collective="false" import="true" type="upgrade">
+                      <entryLinks>
+                        <entryLink id="d8f9-7748-56b9-8f68" name="Heavy Pistol" hidden="false" collective="false" import="true" targetId="aab5-8151-d4fb-2308" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c053-9125-9220-1603" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd51-bf17-22b8-2faa" type="max"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink id="375a-4276-5339-2f39" name="CCW (A3)" hidden="false" collective="false" import="true" targetId="f2c6-3cc8-1ad8-6e26" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="396f-817d-b54d-753d" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="903a-f3c1-7fac-e58a" type="max"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="f923-5313-3d36-49e5" name="Replace one Heavy Pistol &amp; CCW:" hidden="false" collective="false" import="true">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9e8-dc14-bbf2-2e54" type="max"/>
+                      </constraints>
+                      <selectionEntries>
+                        <selectionEntry id="e58e-5bd7-f072-14fc" name="Heavy Pistol &amp; Energy Sword" hidden="false" collective="false" import="true" type="upgrade">
+                          <entryLinks>
+                            <entryLink id="bfcd-cbd6-ee01-e175" name="Heavy Pistol" hidden="false" collective="false" import="true" targetId="aab5-8151-d4fb-2308" type="selectionEntry">
+                              <constraints>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a347-75e3-a893-0325" type="min"/>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="554c-1e20-58e8-3d35" type="max"/>
+                              </constraints>
+                            </entryLink>
+                            <entryLink id="5c04-ccb2-97f3-4daf" name="Energy Sword (Elite)" hidden="false" collective="false" import="true" targetId="262a-3a6e-424e-b887" type="selectionEntry">
+                              <constraints>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d88-42e4-8a7d-164c" type="min"/>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6049-633a-53c3-0cda" type="max"/>
+                              </constraints>
+                            </entryLink>
+                          </entryLinks>
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                          </costs>
+                        </selectionEntry>
+                        <selectionEntry id="a4d7-b697-f965-6dd7" name="Heavy Pistol &amp; Energy Fist" hidden="false" collective="false" import="true" type="upgrade">
+                          <entryLinks>
+                            <entryLink id="cf0a-c3b5-772d-c517" name="Heavy Pistol" hidden="false" collective="false" import="true" targetId="aab5-8151-d4fb-2308" type="selectionEntry">
+                              <constraints>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b9c6-6023-8609-3e76" type="min"/>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ad3-fe3c-77bd-b28a" type="max"/>
+                              </constraints>
+                            </entryLink>
+                            <entryLink id="ae95-bb59-2f29-d678" name="Energy Fist (Elite)" hidden="false" collective="false" import="true" targetId="b7bb-dc0c-3e11-80db" type="selectionEntry">
+                              <constraints>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c37-4095-2141-983d" type="min"/>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8e0-f0f4-1192-caa0" type="max"/>
+                              </constraints>
+                            </entryLink>
+                          </entryLinks>
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                          </costs>
+                        </selectionEntry>
+                        <selectionEntry id="7126-521f-f411-d7ab" name="Heavy Pistol &amp; Energy Hammer" hidden="false" collective="false" import="true" type="upgrade">
+                          <entryLinks>
+                            <entryLink id="34e5-d340-49c1-18c8" name="Heavy Pistol" hidden="false" collective="false" import="true" targetId="aab5-8151-d4fb-2308" type="selectionEntry">
+                              <constraints>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b1e-bb00-e62a-9a62" type="min"/>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da2f-1e1b-3283-4ba7" type="max"/>
+                              </constraints>
+                            </entryLink>
+                            <entryLink id="f07c-4233-7f3c-d2b2" name="Energy Hammer (Elite)" hidden="false" collective="false" import="true" targetId="62f2-1914-2276-5288" type="selectionEntry">
+                              <constraints>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c312-e80b-af9b-af6d" type="min"/>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ee9-4450-d37a-d531" type="max"/>
+                              </constraints>
+                            </entryLink>
+                          </entryLinks>
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                          </costs>
+                        </selectionEntry>
+                      </selectionEntries>
+                      <entryLinks>
+                        <entryLink id="f924-7da1-32f1-0376" name="Heavy Chainsaw Sword (Elite)" hidden="false" collective="false" import="true" targetId="12b8-2a78-c0f1-9101" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+                          </costs>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntry>
+            <selectionEntry id="94f4-5b23-290f-f23f" name="Assault Rifles &amp; CCWs (A2)" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="52bc-2dfd-8f64-3c4e" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="b1f7-fded-6b90-629b" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f02-e1ff-5228-287b" type="min"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc18-38cf-f49f-673b" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="0fa5-11f8-bc02-689a" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="168d-fc4b-a9af-d00f" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="533d-7659-543f-2588" type="min"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2253-be3d-4b9c-dc0c" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2859-b92b-213a-45d8" name="Upgrade all models with any:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="a743-6355-eb68-59b4" name="Grapnels" hidden="false" collective="false" import="true" targetId="8998-727e-c77b-8eea" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e49-5086-b466-e928" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="efcf-b608-49b5-2806" name="Orbital Deployment" hidden="false" collective="false" import="true" targetId="d73c-2d1f-8106-6fed" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4ae-b006-93f8-16f7" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="0b42-a9c6-01ed-0499" name="Prime Brothers 1 - Upgrade List H (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ccda-d12e-44e4-8a1f" name="Replace all Heavy Pistols &amp; CCWs:" hidden="false" collective="false" import="true" defaultSelectionEntryId="5fdc-f3d0-32f0-9dbe">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0910-64b7-1fe4-f65d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c29c-3eee-9127-b37e" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="5fdc-f3d0-32f0-9dbe" name="Heavy Pistols &amp; CCWs (A3)" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="abfd-223d-d555-e220" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="3f9e-3b8f-9a02-25bd">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d71-96b9-74ff-0075" type="min"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9853-ef07-074f-af5e" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="3f9e-3b8f-9a02-25bd" name="Heavy Pistol &amp; CCW (A3)" hidden="false" collective="false" import="true" type="upgrade">
+                      <entryLinks>
+                        <entryLink id="e78f-84f0-e8c1-90e0" name="Heavy Pistol" hidden="false" collective="false" import="true" targetId="aab5-8151-d4fb-2308" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce97-6ccb-58c1-9ede" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ceb-17b3-2f8c-f26c" type="max"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink id="85b4-9f36-68ad-d5df" name="CCW (A3)" hidden="false" collective="false" import="true" targetId="f2c6-3cc8-1ad8-6e26" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3bbf-dc60-3c7b-6ffa" type="min"/>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f40-094b-d2f3-42d9" type="max"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="9e7b-9172-be9a-9e1a" name="Replace two Heavy Pistols &amp; CCWs:" hidden="false" collective="false" import="true">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6087-30ba-5713-7da5" type="max"/>
+                      </constraints>
+                      <selectionEntries>
+                        <selectionEntry id="83f8-ef16-67a4-b800" name="Heavy Pistol &amp; Energy Sword" hidden="false" collective="false" import="true" type="upgrade">
+                          <entryLinks>
+                            <entryLink id="5364-85f0-8db2-5eda" name="Heavy Pistol" hidden="false" collective="false" import="true" targetId="aab5-8151-d4fb-2308" type="selectionEntry">
+                              <constraints>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="238b-ac25-2448-5be9" type="min"/>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2e9-b8d7-667f-0861" type="max"/>
+                              </constraints>
+                            </entryLink>
+                            <entryLink id="f490-0b9c-2159-3798" name="Energy Sword (Elite)" hidden="false" collective="false" import="true" targetId="262a-3a6e-424e-b887" type="selectionEntry">
+                              <constraints>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30eb-ed2b-984e-bb08" type="min"/>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa64-d59e-4510-2812" type="max"/>
+                              </constraints>
+                            </entryLink>
+                          </entryLinks>
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                          </costs>
+                        </selectionEntry>
+                        <selectionEntry id="628e-9818-9cd0-d3e1" name="Heavy Pistol &amp; Energy Fist" hidden="false" collective="false" import="true" type="upgrade">
+                          <entryLinks>
+                            <entryLink id="51f2-3646-aa01-d8f7" name="Heavy Pistol" hidden="false" collective="false" import="true" targetId="aab5-8151-d4fb-2308" type="selectionEntry">
+                              <constraints>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="921d-9c07-db86-2952" type="min"/>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="725b-3bdc-1760-6106" type="max"/>
+                              </constraints>
+                            </entryLink>
+                            <entryLink id="6cc1-2ac7-b9ce-4529" name="Energy Fist (Elite)" hidden="false" collective="false" import="true" targetId="b7bb-dc0c-3e11-80db" type="selectionEntry">
+                              <constraints>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e50-952a-68c2-b2ad" type="min"/>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2e4-1176-6035-a614" type="max"/>
+                              </constraints>
+                            </entryLink>
+                          </entryLinks>
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                          </costs>
+                        </selectionEntry>
+                        <selectionEntry id="c828-c004-5578-f8c3" name="Heavy Pistol &amp; Energy Hammer" hidden="false" collective="false" import="true" type="upgrade">
+                          <entryLinks>
+                            <entryLink id="da62-54da-2762-484a" name="Heavy Pistol" hidden="false" collective="false" import="true" targetId="aab5-8151-d4fb-2308" type="selectionEntry">
+                              <constraints>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76d7-0f4e-0e1a-20be" type="min"/>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61c4-7013-c952-3256" type="max"/>
+                              </constraints>
+                            </entryLink>
+                            <entryLink id="8e3a-cf04-b4fd-e500" name="Energy Hammer (Elite)" hidden="false" collective="false" import="true" targetId="62f2-1914-2276-5288" type="selectionEntry">
+                              <constraints>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec28-1ace-a5ad-a843" type="min"/>
+                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="596c-540e-cc99-a31d" type="max"/>
+                              </constraints>
+                            </entryLink>
+                          </entryLinks>
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                          </costs>
+                        </selectionEntry>
+                      </selectionEntries>
+                      <entryLinks>
+                        <entryLink id="bda1-375e-a266-f49a" name="Heavy Chainsaw Sword (Elite)" hidden="false" collective="false" import="true" targetId="12b8-2a78-c0f1-9101" type="selectionEntry">
+                          <costs>
+                            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+                          </costs>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntry>
+            <selectionEntry id="1a16-f4f4-5520-2b26" name="Assault Rifles &amp; CCWs (A2)" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="1822-6c79-740b-6bfd" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="b1f7-fded-6b90-629b" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbe9-bfad-78c3-7e6a" type="min"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e946-f963-6356-6d40" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="3fb7-4022-5473-2523" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="168d-fc4b-a9af-d00f" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b184-86d1-f7f6-a559" type="min"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fddc-d223-a112-5c14" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1dad-11da-4a9c-cb7f" name="Upgrade all models with any:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="e3eb-c8dc-bf60-dc0d" name="Grapnels" hidden="false" collective="false" import="true" targetId="8998-727e-c77b-8eea" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53b0-91a3-22c9-5f52" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="3dcd-2d1b-ef20-66c4" name="Orbital Deployment" hidden="false" collective="false" import="true" targetId="d73c-2d1f-8106-6fed" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="440f-a3bb-6edf-afee" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
     <rule id="ff04-8ef9-82f1-a88b" name="Shield Wall" publicationId="dead-6af1-a069-5579" hidden="false">
@@ -15976,7 +16141,7 @@
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d"/>
       </characteristics>
     </profile>
-    <profile id="bddc-3c21-5d50-b20a" name="Energy Sword (A4,Rending)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
+    <profile id="bddc-3c21-5d50-b20a" name="Energy Sword (Prime)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
         <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A4</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(1), Rending</characteristic>
@@ -16001,7 +16166,7 @@
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(1)</characteristic>
       </characteristics>
     </profile>
-    <profile id="8738-edea-82e1-348a" name="Heavy Chainsaw Sword (Raider)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
+    <profile id="8738-edea-82e1-348a" name="Heavy Chainsaw Sword (Elite)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
         <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A9</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(1)</characteristic>
@@ -16176,7 +16341,7 @@
         <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Prime, Shield Wall</characteristic>
       </characteristics>
     </profile>
-    <profile id="5961-c5a1-481e-8371" name="Energy Sword (Guards)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
+    <profile id="5961-c5a1-481e-8371" name="Energy Sword (Elite)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
         <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3	</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(1), Rending</characteristic>
@@ -16256,6 +16421,28 @@
     <profile id="67dc-309b-3fb7-ac62" name="Precision Shots" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
       <characteristics>
         <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">The hero and his unit get AP(+1) when shooting.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="931f-40b0-f32c-78ed" name="Energy Fist (Elite)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
+      <characteristics>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
+        <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(3)	</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="6e04-c238-4902-8d85" name="Energy Hammer (Elite)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
+      <characteristics>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
+        <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(1), Deadly(3)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="697c-3227-f602-1b4f" name="Grapnels" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
+      <characteristics>
+        <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Strider	</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="ad96-9919-18eb-26bc" name="Orbital Deployment" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
+      <characteristics>
+        <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Ambush</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -1693,167 +1693,6 @@
         <infoLink id="864e-356b-a86b-cfa5" name="Attack Walker" hidden="false" targetId="b3aa-2f94-720e-ef3a" type="profile"/>
         <infoLink id="4627-4e99-a0bf-c4fc" name="Fear" hidden="false" targetId="d21e-0b0f-ebec-46da" type="rule"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="db6c-86ca-20df-e64d" name="Left Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="8d34-331c-5d68-2577">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f93-3970-6b3d-758b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a229-d7e0-c4d7-60ff" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="6796-eb2c-f9a9-bb6c" name="Walker Fist &amp; Under-Slung Weapon" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="1ab7-43da-a267-4fe4" name="Under-Slung Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="6a44-fa20-10eb-16b2">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1885-78fd-5c87-03df" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee07-a546-292d-c8f9" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="6a44-fa20-10eb-16b2" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry"/>
-                    <entryLink id="f362-e4fc-740b-9ecf" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="f0a9-29db-a603-d3b6" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks>
-                <entryLink id="3df3-dc54-2d3b-6272" name="Walker Fist" hidden="false" collective="false" import="true" targetId="e008-b179-c068-469a" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9333-4ca7-b41d-ff91" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6164-1735-1ca3-6123" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="8d34-331c-5d68-2577" name="Assault Rifle Array" hidden="false" collective="false" import="true" targetId="faa1-761d-0d50-2135" type="selectionEntry"/>
-            <entryLink id="13b4-621b-400b-2cbb" name="Heavy Fusion Rifle" hidden="false" collective="false" import="true" targetId="a5f5-d44a-03b0-9a99" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="0ae5-3c6c-8a81-fb39" name="Heavy Minigun" hidden="false" collective="false" import="true" targetId="9db1-0539-dc9f-f147" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="2c15-b300-c055-0bd4" name="Plasma Cannon" hidden="false" collective="false" import="true" targetId="05e9-6fae-2a04-8820" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="bf7c-12f9-b5bb-1d0f" name="Twin Autocannon" hidden="false" collective="false" import="true" targetId="3640-bb26-8a54-047c" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="72bb-f3bf-d321-2010" name="Twin Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="76d2-5dc6-d28b-c278" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="7bd0-22b1-3454-c320" name="Twin Heavy Machinegun" hidden="false" collective="false" import="true" targetId="dae8-3106-6a96-228c" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="bbcc-a2d7-bcf9-1c68" name="Twin Laser Cannon" hidden="false" collective="false" import="true" targetId="d271-2d81-e640-0040" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="70.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="8cae-a2f9-6e57-50ca" name="Upgrades" hidden="false" collective="false" import="true">
-          <selectionEntries>
-            <selectionEntry id="b2b3-7725-03f0-2f2e" name="Veteran Walker" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e47-25f3-67f6-0ad4" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="17f8-40f9-baca-07e8" name="Veteran Walker" hidden="false" targetId="cf50-737f-31f8-9542" type="rule"/>
-              </infoLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="115.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="4b30-754d-b50d-10ba" name="Hunter Missile" hidden="false" collective="false" import="true" targetId="c756-9c2d-beca-986c" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e854-ac5c-890b-7c31" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="bd7d-4ff0-9948-9f55" name="Right Arm" hidden="false" collective="false" import="true" defaultSelectionEntryId="be17-a92c-e3d7-a8d8">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb78-930f-487c-97c8" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ef7-fdf8-1fb7-76ca" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="be17-a92c-e3d7-a8d8" name="Walker Fist &amp; Under-Slung Weapon" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="afab-322e-dc5d-6cfa" name="Under-Slung Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="75ea-2db6-4f5e-bd6b">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82ab-5b13-88f3-4c9c" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0cfa-29ce-e759-20cf" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="75ea-2db6-4f5e-bd6b" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry"/>
-                    <entryLink id="e0fa-aaab-c7eb-2479" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="d137-7de4-638d-01cb" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks>
-                <entryLink id="9f55-74f7-c5e4-dad1" name="Walker Fist" hidden="false" collective="false" import="true" targetId="e008-b179-c068-469a" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="145d-2e85-eab6-6079" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffa8-e6b6-8935-3bed" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="33fe-d839-f7e3-4469" name="Missile Launcher" hidden="false" collective="false" import="true" targetId="ff1b-714c-6353-221d" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="861f-df6a-ea75-e20a" name="Twin Autocannon" hidden="false" collective="false" import="true" targetId="3640-bb26-8a54-047c" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="40e6-c423-732b-3f17" name="Stomp (Walker)" hidden="false" collective="false" import="true" targetId="fd88-1524-b5ee-010c" type="selectionEntry">
           <constraints>
@@ -1861,11 +1700,9 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e6a-8f97-d7aa-33a0" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="3a97-8869-4862-1fb0" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
-          </costs>
-        </entryLink>
+        <entryLink id="781d-0e90-f97a-e16e" name="Battle Brothers 3 - Upgrade List B" hidden="false" collective="false" import="true" targetId="6d58-cfaf-3917-e973" type="selectionEntryGroup"/>
+        <entryLink id="9552-4f32-50b4-9f3c" name="Battle Brothers 3 - Upgrade List H" hidden="false" collective="false" import="true" targetId="5a30-0a3d-60c3-4465" type="selectionEntryGroup"/>
+        <entryLink id="5dd3-a619-418f-f88a" name="** Detachment Upgrade (Units of [1] with Tough(12)) **" hidden="false" collective="false" import="true" targetId="b007-c0d8-b1e0-23d9" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="370.0"/>
@@ -9873,6 +9710,14 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="d839-b6ad-8a75-cb04" name="Veteran Walker" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="cefa-2924-86b2-5057" name="Veteran Walker" hidden="false" targetId="a83a-15ac-32a0-f793" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="763b-1230-bcad-b19d" name="Battle Brothers 1 - Upgrade List A (single unit)" hidden="false" collective="false" import="true" defaultSelectionEntryId="4323-8b88-efda-e548">
@@ -14107,6 +13952,177 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>
+    <selectionEntryGroup id="b007-c0d8-b1e0-23d9" name="** Detachment Upgrade (Units of [1] with Tough(12)) **" hidden="false" collective="false" import="true">
+      <entryLinks>
+        <entryLink id="0d9d-b679-9a13-8284" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="81aa-dac4-4a87-751c" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="35.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="1908-5cc9-d520-39af" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="946c-8041-db70-118a" name="Wolf Brothers - Counter" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+          </costs>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="5a30-0a3d-60c3-4465" name="Battle Brothers 3 - Upgrade List H" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9006-adc7-0d8a-b01b" name="Replace Walker Fist &amp; Storm Rifle:" hidden="false" collective="false" import="true" defaultSelectionEntryId="622a-6c7f-6017-a708">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="abb4-3dd0-c612-b252" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a717-8522-d327-124f" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="622a-6c7f-6017-a708" name="Walker Fist &amp; Storm Rifle" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="faf9-fe52-503a-6251" name="Replace any Storm Rifle:" hidden="false" collective="false" import="true" defaultSelectionEntryId="f1fe-008d-27c0-b0fe">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1c6-7388-3144-17a7" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9517-4ee5-ca01-a5ff" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="f1fe-008d-27c0-b0fe" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry"/>
+                    <entryLink id="8879-bb87-f08c-f041" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="6213-d2bc-affa-7ad5" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="8cde-a63f-e14f-412f" name="Walker Fist (Attack Walker)" hidden="false" collective="false" import="true" targetId="e008-b179-c068-469a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ee3-3884-452f-ffa5" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77f6-b58e-6ec9-bcc1" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="a381-8b04-7abb-1897" name="Missile Launcher" hidden="false" collective="false" import="true" targetId="ff1b-714c-6353-221d" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="fb0f-3566-cad7-db5d" name="Twin Autocannon" hidden="false" collective="false" import="true" targetId="3640-bb26-8a54-047c" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="30dc-ca03-918a-208d" name="Replace Assault Rifle Array:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ae9f-b0b3-7941-47d7">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f2d-fc46-1637-c937" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5a1-2502-2a34-4d2a" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="2c2c-714a-e219-fa09" name="Walker Fist &amp; Storm Rifle" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="b5b4-b1e3-8ff2-8891" name="Replace any Storm Rifle:" hidden="false" collective="false" import="true" defaultSelectionEntryId="248b-bff9-c6cc-400d">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="360a-ebad-1af4-3be4" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86f8-d5e9-6100-ff19" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="248b-bff9-c6cc-400d" name="Storm Rifle" hidden="false" collective="false" import="true" targetId="696d-b8cf-37bb-c9bf" type="selectionEntry"/>
+                    <entryLink id="604a-2704-a8f2-a881" name="Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="b4cc-bca2-fafc-9825" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="48d9-1d47-d4e1-7fbe" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="f65d-3753-7d61-0f77" name="Walker Fist (Attack Walker)" hidden="false" collective="false" import="true" targetId="e008-b179-c068-469a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcb7-6867-cd45-3be7" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e375-2211-b7fc-d84e" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="ae9f-b0b3-7941-47d7" name="Assault Rifle Array" hidden="false" collective="false" import="true" targetId="faa1-761d-0d50-2135" type="selectionEntry"/>
+            <entryLink id="3d66-9151-2210-bcbc" name="Plasma Cannon" hidden="false" collective="false" import="true" targetId="05e9-6fae-2a04-8820" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="308a-5c6d-d6f0-8254" name="Heavy Minigun" hidden="false" collective="false" import="true" targetId="9db1-0539-dc9f-f147" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="2777-7cd6-d48f-3686" name="Heavy Fusion Rifle" hidden="false" collective="false" import="true" targetId="a5f5-d44a-03b0-9a99" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="c91b-e84f-4b99-95f0" name="Twin Heavy Machinegun" hidden="false" collective="false" import="true" targetId="dae8-3106-6a96-228c" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="cf6c-a7fc-cbf3-2379" name="Twin Autocannon" hidden="false" collective="false" import="true" targetId="3640-bb26-8a54-047c" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="9b58-b398-a3b6-098b" name="Twin Laser Cannon" hidden="false" collective="false" import="true" targetId="d271-2d81-e640-0040" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="70.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="3877-a6bf-a239-588f" name="Twin Heavy Flamethrower" hidden="false" collective="false" import="true" targetId="76d2-5dc6-d28b-c278" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ff71-eebb-947e-4153" name="Upgrade with:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="57ce-e41d-bb72-19ad" name="Veteran Walker" hidden="false" collective="false" import="true" targetId="d839-b6ad-8a75-cb04" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5062-b9fe-e991-afaa" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="115.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
     <rule id="ff04-8ef9-82f1-a88b" name="Shield Wall" publicationId="dead-6af1-a069-5579" hidden="false">
@@ -15884,6 +15900,11 @@
     <profile id="7068-1217-bca3-7bd7" name="Forward Sentries" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
       <characteristics>
         <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">Scout</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="a83a-15ac-32a0-f793" name="Veteran Walker" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
+      <characteristics>
+        <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">This model gets +1 to its attack rolls for melee and shooting.</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -1917,159 +1917,34 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="130.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4242-0e7b-8e02-867f" name="Death Brother" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="028c-f276-e98e-5728" name="Death Brother" hidden="false" targetId="e5d7-d227-48d1-f869" type="profile"/>
-        <infoLink id="590f-ac60-4de9-5ffa" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="6f9d-21dc-3d34-fe92" name="Furious" hidden="false" targetId="ded5-4f1f-c61d-4659" type="rule"/>
-        <infoLink id="f462-9a9a-80d2-84eb" name="Regeneration" hidden="false" targetId="dea8-a8f9-1865-4424" type="rule"/>
-      </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="88cf-757b-056f-d1b5" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="5bef-d53a-e341-a323">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c3bf-ad5d-e558-c486" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e714-79d4-4007-72db" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="7891-b150-81b0-25f5" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="9922-253f-0853-80fd" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="0cc1-22ed-0a37-2e9e" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="5bef-d53a-e341-a323" name="CCW (A1)" hidden="false" collective="false" import="true" targetId="4761-1567-afe2-c2ed" type="selectionEntry"/>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="3db3-78cd-e783-7dd2" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fea-23a0-8459-2bd7" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87df-4e07-23fc-11dc" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="16e0-3340-b43a-4d7b" name="Death Brother (Pistols)" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="1fb5-89a9-27a1-2733" name="Death Brother" hidden="false" targetId="e5d7-d227-48d1-f869" type="profile"/>
-        <infoLink id="75da-16dc-964b-2adf" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
-        <infoLink id="7583-5831-aef9-8ff6" name="Furious" hidden="false" targetId="ded5-4f1f-c61d-4659" type="rule"/>
-        <infoLink id="44ab-bfb9-4072-cc35" name="Regeneration" hidden="false" targetId="dea8-a8f9-1865-4424" type="rule"/>
-      </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="44cb-cd83-411f-4654" name="Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="4592-0d76-b78c-743a">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f33f-38d2-f65e-9c03" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="819f-579f-eb62-5744" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="52af-1b71-918a-bb74" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="4592-0d76-b78c-743a" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
-            <entryLink id="65f9-f10c-458f-1e85" name="Flame Pistol" hidden="false" collective="false" import="true" targetId="db8f-b317-2b7d-2ed3" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="feb4-d77c-eab4-a07c" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="2071-4cb6-f32c-5d11" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="324c-8542-14a2-229e" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="20be-e2e3-6843-97b6">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9e3-27c9-aad0-58f5" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="802e-7717-131f-a4d5" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="90a5-b7e8-16bf-7c0d" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="7557-5380-82ca-590f" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="f0ba-7c16-6e7e-9342" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="20be-e2e3-6843-97b6" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="d6e3-88c5-611a-b346" name="Death Brothers" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="ef4f-8003-5293-7d17" name="Death Brother" hidden="false" targetId="e5d7-d227-48d1-f869" type="profile"/>
+        <infoLink id="39ad-bdec-1010-9d90" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
+        <infoLink id="d45e-7099-443b-d4e4" name="Furious" hidden="false" targetId="ded5-4f1f-c61d-4659" type="rule"/>
+        <infoLink id="e7f4-d454-8dea-ef82" name="Regeneration" hidden="false" targetId="dea8-a8f9-1865-4424" type="rule"/>
+      </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="8418-b0e1-fb2a-8cda" name="Brothers" hidden="false" collective="false" import="true" defaultSelectionEntryId="1945-049e-62a8-a454">
+        <selectionEntryGroup id="406d-d040-556f-7f70" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="cb73-cf31-5a56-6385">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="953b-c5d5-0ded-4e81" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8f2-0a48-00da-9c86" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0274-e0c6-e1bc-2e6b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96b7-36a9-9fa7-d8aa" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="1945-049e-62a8-a454" name="Assault Rifles &amp; CCWs" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="cb73-cf31-5a56-6385" name="Single Unit [5 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="6738-7362-7355-9428" name="Death Brother" hidden="false" collective="false" import="true" targetId="4242-0e7b-8e02-867f" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3954-4fd2-12e3-0cda" type="max"/>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f4a-24e6-a90a-93b7" type="min"/>
-                  </constraints>
-                </entryLink>
+                <entryLink id="bd10-0bae-4392-e85a" name="Blood Brothers - Upgrade List B (single unit)" hidden="false" collective="false" import="true" targetId="459c-bde6-0f63-d0bf" type="selectionEntryGroup"/>
               </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
             </selectionEntry>
-            <selectionEntry id="e104-599d-c472-cd10" name="Pistols &amp; CCWs" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="6ce9-cd44-c825-3447" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="7515-f117-1734-e5f8" name="Death Brother (Pistols)" hidden="false" collective="false" import="true" targetId="16e0-3340-b43a-4d7b" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d86-0a56-a2f9-46b6" type="max"/>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7516-48c7-2327-9e16" type="min"/>
-                  </constraints>
-                </entryLink>
+                <entryLink id="947d-4dc8-1ee3-bd2c" name="Blood Brothers - Upgrade List B (combined unit)" hidden="false" collective="false" import="true" targetId="65a6-783d-23f7-45d4" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="195.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="5180-65a0-3bd0-4c55" name="Upgrade all models with:" hidden="false" collective="false" import="true">
-          <entryLinks>
-            <entryLink id="d628-b5f9-d482-8a8c" name="Jetpack" hidden="false" collective="false" import="true" targetId="33d6-ea20-9d27-5f4e" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="410f-ad7c-480f-ef92" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
@@ -15086,6 +14961,230 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="60.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="459c-bde6-0f63-d0bf" name="Blood Brothers - Upgrade List B (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="be52-bcc0-17ea-e853" name="Replace all Assault Rifles &amp; CCWs:" hidden="false" collective="false" import="true" defaultSelectionEntryId="bbea-f3be-04d6-b9ce">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a82a-b638-c949-29ce" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f65-0250-49d5-5371" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="bbea-f3be-04d6-b9ce" name="Assault Rifles &amp; CCWs (A1)" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="99e8-e1fc-3420-1e47" name="Replace any CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="4a97-b7a0-31ba-5aba">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff44-32bb-2bda-f75e" type="min"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a380-16eb-7370-434f" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="4a97-b7a0-31ba-5aba" name="CCW (A1)" hidden="false" collective="false" import="true" targetId="4761-1567-afe2-c2ed" type="selectionEntry"/>
+                    <entryLink id="ec74-2dbc-4daa-bde6" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="05f9-8da0-b9ca-e68d" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="b081-a7c1-10a2-2dfb" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="7fd0-2c6a-d17b-9328" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1442-c23d-e553-186e" type="min"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae61-9907-acfe-16da" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="fbbe-57d4-066f-b2a8" name="Pistols &amp; CCWs (A2)" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="ed64-880b-b2c2-501a" name="Replace any CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="e3da-330f-ff00-0053">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36a9-2f2a-3b0a-208d" type="min"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c34-e9b3-3eed-819c" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="e3da-330f-ff00-0053" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+                    <entryLink id="c503-ba72-bc90-8575" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="7c17-f7ea-b361-e2c1" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="e93d-ac66-576c-2ef1" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="8f1c-a24c-0d95-9bb9" name="Replace any Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ba6a-9dd0-d3c3-2058">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b88-5a4e-884a-e7c1" type="min"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebc9-e2f7-a605-a5ac" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="ba6a-9dd0-d3c3-2058" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
+                    <entryLink id="5bc5-f4ac-b974-b70a" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="2071-4cb6-f32c-5d11" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="5ac5-1996-4db5-a0d2" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="d730-8d47-51dc-5129" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ec16-d886-e316-5f1a" name="Upgrade all models with:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="d655-3d0e-0199-3010" name="Jetpack" hidden="false" collective="false" import="true" targetId="33d6-ea20-9d27-5f4e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a8e-1087-3022-8e68" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="65a6-783d-23f7-45d4" name="Blood Brothers - Upgrade List B (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a574-ac91-b501-5350" name="Replace all Assault Rifles &amp; CCWs:" hidden="false" collective="false" import="true" defaultSelectionEntryId="7598-72f4-b674-6408">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2686-3039-267e-d766" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a63-3f04-8f6d-e6ff" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="7598-72f4-b674-6408" name="Assault Rifles &amp; CCWs (A1)" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="1850-6275-7bf8-fb61" name="Replace any CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="5c53-275b-889f-0cc9">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85a7-006f-ce87-3bcb" type="min"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e77b-5c80-c5f3-e145" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="5c53-275b-889f-0cc9" name="CCW (A1)" hidden="false" collective="false" import="true" targetId="4761-1567-afe2-c2ed" type="selectionEntry"/>
+                    <entryLink id="75a5-0b43-f91e-48bc" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="441c-8353-4823-39f2" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="7036-c387-9c95-734e" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="7578-6825-495f-81b1" name="Assault Rifle" hidden="false" collective="false" import="true" targetId="a1da-51ac-5a8f-8f95" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="882a-cad0-faad-56be" type="min"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f05-df26-e2b8-55bd" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="45f4-85d2-fdb9-7e76" name="Pistols &amp; CCWs (A2)" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="b311-1c8f-cce1-48c7" name="Replace any CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="ee4b-f5f5-b054-fcfc">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35b1-48f3-75d8-70d6" type="min"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6700-3c54-9751-21f4" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="ee4b-f5f5-b054-fcfc" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+                    <entryLink id="9f4a-e6f9-0689-7949" name="Energy Sword" hidden="false" collective="false" import="true" targetId="b085-6801-9084-46f0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="6877-36d9-2533-1cd0" name="Energy Fist" hidden="false" collective="false" import="true" targetId="ffff-7bb4-119c-0f59" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="f91c-3857-7a11-3b6b" name="Energy Hammer" hidden="false" collective="false" import="true" targetId="ee08-0414-e5c3-908f" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="14a6-339e-23f3-064d" name="Replace any Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="cae5-16ef-ad6b-9c9c">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80d4-e352-a023-1672" type="min"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2151-1571-d4a4-9e65" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="cae5-16ef-ad6b-9c9c" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
+                    <entryLink id="6d45-8769-96ce-bf01" name="Fusion Pistol" hidden="false" collective="false" import="true" targetId="2071-4cb6-f32c-5d11" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="92df-1a58-0762-dd2c" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="b3c1-a9ea-c3d5-a8ea" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2a98-eeab-d01b-4eb9" name="Upgrade all models with:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="9aa3-9b48-1ed7-8997" name="Jetpack" hidden="false" collective="false" import="true" targetId="33d6-ea20-9d27-5f4e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81c7-86af-0a96-29bc" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="160.0"/>
               </costs>
             </entryLink>
           </entryLinks>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -6464,104 +6464,74 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="125.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1545-1608-f888-3398" name="Prime Brother" hidden="false" collective="false" import="true" type="upgrade">
-      <selectionEntryGroups>
-        <selectionEntryGroup id="d6d6-fba5-c7c7-adba" name="Rifle" hidden="false" collective="false" import="true" defaultSelectionEntryId="e1ed-6672-dae1-ba11">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dbd9-2f2f-7126-fcc6" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b91-480f-a25f-4aa3" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="e1ed-6672-dae1-ba11" name="Auto-Rifle" hidden="false" collective="false" import="true" targetId="c585-5a84-313c-a7cf" type="selectionEntry"/>
-            <entryLink id="c84a-480e-1f8f-7c3e" name="Rifle" hidden="false" collective="false" import="true" targetId="e57e-4a03-ae5a-5411" type="selectionEntry"/>
-            <entryLink id="934c-66ef-c1cb-28f3" name="Precision Rifle" hidden="false" collective="false" import="true" targetId="141f-9981-66b1-32bd" type="selectionEntry"/>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="b955-9ecb-1083-f737" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23c6-94be-3731-09bf" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28ff-eee6-cbc6-8f0e" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="deed-eef5-264b-a884" name="Prime Brothers" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="4070-a057-2962-9f36" name="Prime Brother" hidden="false" targetId="bbe1-413f-34a9-3de8" type="profile"/>
         <infoLink id="d91c-7dd1-7a39-a28e" name="Firstborn" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
       </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="8fd4-9051-acf4-1f50" name="Upgrades" hidden="false" collective="false" import="true">
-          <entryLinks>
-            <entryLink id="39b1-3e89-1877-59e9" name="Medical Training" hidden="false" collective="false" import="true" targetId="8352-cbe6-9410-a422" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="151a-d9fe-8a55-aa10" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="45.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="da63-0674-17ed-77f2" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="e089-6dd6-ec4e-12e6" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db95-62d5-51b6-1e50" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="f6bd-1bbb-4d3a-ce66" name="Prime Brothers" hidden="false" collective="false" import="true" defaultSelectionEntryId="cbac-8225-4c1d-588f">
+        <selectionEntryGroup id="0667-494e-9d38-e9ac" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="a20e-ae28-7383-6e70">
           <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c5e-bd3f-33cb-eaa2" type="min"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="654c-86b5-0bba-3ea0" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8fc-5393-bdf4-9e43" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ec2-554a-1916-64a2" type="max"/>
           </constraints>
-          <entryLinks>
-            <entryLink id="cbac-8225-4c1d-588f" name="Prime Brother" hidden="false" collective="false" import="true" targetId="1545-1608-f888-3398" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ec8-09f8-3f9a-99d5" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="ac5b-50d7-b063-18cd" name="Prime Brother (Leader)" hidden="false" collective="false" import="true" targetId="44eb-c1e6-0855-4e65" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6c1-cb81-51df-2576" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="588c-2308-07b5-1ee0" name="Prime Brother (Specialist)" hidden="false" collective="false" import="true" targetId="f3c9-bdf9-78cc-4c35" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="691a-1488-f3e4-316c" type="max"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
+          <selectionEntries>
+            <selectionEntry id="a20e-ae28-7383-6e70" name="Single Unit [5 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="b71e-7cc2-71ed-a92a" name="Prime Brothers 1 - Upgrade List A (single unit)" hidden="false" collective="false" import="true" targetId="d455-2126-cc2a-5f47" type="selectionEntryGroup"/>
+                <entryLink id="8462-b37e-e8c4-765c" name="Prime Brothers 1 - Upgrade List E (single unit)" hidden="false" collective="false" import="true" targetId="0bb9-e22c-0855-349c" type="selectionEntryGroup"/>
+                <entryLink id="9210-b5ce-12db-e431" name="Prime Brothers 1 - Upgrade List G (single unit)" hidden="false" collective="false" import="true" targetId="a400-7ce9-89fe-a14a" type="selectionEntryGroup"/>
+                <entryLink id="844f-5eb0-e9f4-92d5" name="** Detachment Upgrade (Units of [5], single unit) **" hidden="false" collective="false" import="true" targetId="f024-6c76-c658-300a" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d40-9fa2-76fb-f0c1" type="greaterThan"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="9668-b74b-33d2-1489" name="** Detachment Upgrade (Units of [5] with Tough(3), single unit)" hidden="false" collective="false" import="true" targetId="47b6-1c61-aef4-88db" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d40-9fa2-76fb-f0c1" type="lessThan"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="eb6a-2ff4-33fb-56ff" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="e413-ff88-5b49-97fb" name="Prime Brothers 1 - Upgrade List A (combined unit)" hidden="false" collective="false" import="true" targetId="455d-5965-60e0-731f" type="selectionEntryGroup"/>
+                <entryLink id="cae5-ca7d-d1f4-1ff3" name="Prime Brothers 1 - Upgrade List E (combined unit)" hidden="false" collective="false" import="true" targetId="1ad2-e3d2-1485-cc14" type="selectionEntryGroup"/>
+                <entryLink id="a62b-0b37-fd97-87ff" name="Prime Brothers 1 - Upgrade List G (combined unit)" hidden="false" collective="false" import="true" targetId="2250-3b10-7c7d-aa6f" type="selectionEntryGroup"/>
+                <entryLink id="f047-12f7-31a6-6325" name="** Detachment Upgrade (Units of [5], combined unit) **" hidden="false" collective="false" import="true" targetId="3ed3-d384-8a43-eb07" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d40-9fa2-76fb-f0c1" type="greaterThan"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink id="bd42-a53c-95af-ad24" name="** Detachment Upgrade (Units of [5] with Tough(3), combined unit)" hidden="false" collective="false" import="true" targetId="81c1-61bf-8c23-209f" type="selectionEntryGroup">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3d40-9fa2-76fb-f0c1" type="lessThan"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="225.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="249c-d416-9a98-f5c9" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="7804-ac4a-1800-3ed6" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="4033-d71d-b5cf-a422" name="Wolf Brothers - Counter-Attack" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="a3e4-8ceb-21ff-bfde" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-      </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="225.0"/>
       </costs>
@@ -8160,45 +8130,6 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="44eb-c1e6-0855-4e65" name="Prime Brother (Leader)" hidden="false" collective="false" import="true" type="upgrade">
-      <entryLinks>
-        <entryLink id="b018-6367-3c19-cb35" name="Prime Brothers 1 - Upgrade List A" hidden="false" collective="false" import="true" targetId="d455-2126-cc2a-5f47" type="selectionEntryGroup"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="f3c9-bdf9-78cc-4c35" name="Prime Brother (Specialist)" hidden="false" collective="false" import="true" type="upgrade">
-      <selectionEntryGroups>
-        <selectionEntryGroup id="e7a2-ffcb-5edd-3caf" name="Specialist Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="7b1e-271e-a859-f808">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="116e-958b-f0d3-8b5c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4adf-b76b-0b16-a930" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="7b1e-271e-a859-f808" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry"/>
-            <entryLink id="d182-9f00-db02-38e9" name="Gravity Rifle" hidden="false" collective="false" import="true" targetId="3e4a-da63-fdf2-c5fb" type="selectionEntry"/>
-            <entryLink id="2235-ec21-e5af-c87b" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry"/>
-            <entryLink id="2ba9-7e7c-bc29-5e5b" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="7029-8b4b-9733-1e82" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60b8-4e3f-353b-80c7" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4b4-fc41-e55d-466d" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="c585-5a84-313c-a7cf" name="Auto-Rifle" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="7204-92d1-b6e2-b2af" name="Auto-Rifle" hidden="false" targetId="6566-7dec-c93b-88f3" type="profile"/>
@@ -9721,7 +9652,7 @@
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="d455-2126-cc2a-5f47" name="Prime Brothers 1 - Upgrade List A" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="d455-2126-cc2a-5f47" name="Prime Brothers 1 - Upgrade List A (single unit)" hidden="false" collective="false" import="true">
       <selectionEntryGroups>
         <selectionEntryGroup id="8e8d-6322-86ec-9d5c" name="Replace one Auto-Rifle &amp; CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="167a-ed75-9325-9bba">
           <constraints>
@@ -9730,9 +9661,6 @@
           </constraints>
           <selectionEntries>
             <selectionEntry id="3004-f378-17de-8747" name="Pistol &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e470-4cb1-fd2e-82a1" type="max"/>
-              </constraints>
               <selectionEntryGroups>
                 <selectionEntryGroup id="020f-6088-abd5-6498" name="Replace one Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="50ab-b3d5-a4fb-cf2e">
                   <constraints>
@@ -9803,9 +9731,6 @@
               </costs>
             </selectionEntry>
             <selectionEntry id="167a-ed75-9325-9bba" name="Auto-Rifle &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f913-c147-a133-5a81" type="max"/>
-              </constraints>
               <selectionEntryGroups>
                 <selectionEntryGroup id="34d6-341f-4015-742e" name="Replace one CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="da06-60ef-d80c-f99c">
                   <constraints>
@@ -12793,6 +12718,13 @@
           </costs>
         </entryLink>
         <entryLink id="e811-8ef5-fe4b-670e" name="Dark Brothers - Dark Assault" hidden="false" collective="false" import="true" targetId="cf31-8c37-3347-79a3" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="deed-eef5-264b-a884" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
           </costs>
@@ -12822,6 +12754,13 @@
           </costs>
         </entryLink>
         <entryLink id="fc1a-50e8-33a0-c6c3" name="Dark Brothers - Dark Assault" hidden="false" collective="false" import="true" targetId="cf31-8c37-3347-79a3" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="deed-eef5-264b-a884" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
           </costs>
@@ -14211,6 +14150,328 @@
           <constraints>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b05a-af4b-09c1-f52c" type="min"/>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4215-6c5b-eb89-9c9c" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="455d-5965-60e0-731f" name="Prime Brothers 1 - Upgrade List A (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="12d1-6bbb-8ee8-ab3a" name="Replace two Auto-Rifles &amp; CCWs:" hidden="false" collective="false" import="true" defaultSelectionEntryId="1da5-e3e7-6ebe-a695">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bc3-1f34-30c6-071d" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35e7-611b-3255-0f2a" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="aaf6-bf20-ded4-df76" name="Pistol &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="86b9-d830-aa98-91ba" name="Replace one Pistol:" hidden="false" collective="false" import="true" defaultSelectionEntryId="6fab-4c5e-ac07-bce9">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e49-0647-49b5-ab3b" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb77-6658-afad-6f30" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="6fab-4c5e-ac07-bce9" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry"/>
+                    <entryLink id="57be-8b2c-1018-986a" name="Plasma Pistol" hidden="false" collective="false" import="true" targetId="b4bf-2a04-6bf7-a1e0" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="7c99-bb8d-7ecb-748f" name="Heavy Carbine" hidden="false" collective="false" import="true" targetId="25db-4cd3-f542-cba6" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="1d57-c0aa-bc9b-cba6" name="Rifle (A2)" hidden="false" collective="false" import="true" targetId="893b-7055-5ccb-3592" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="d9a4-4c2d-223e-6e48" name="Precision Rifle" hidden="false" collective="false" import="true" targetId="141f-9981-66b1-32bd" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="3ee3-ed30-8658-250a" name="Flamethrower Pistol" hidden="false" collective="false" import="true" targetId="6c17-17f3-4027-3c9f" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="79a4-be1c-68bf-880c" name="Shred Pistol" hidden="false" collective="false" import="true" targetId="5f1b-580c-f736-839d" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="9b3a-e6ea-8b26-1112" name="Replace one CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="b67f-450d-2608-c89a">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0ee-ed6b-b944-86b6" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bf0-b430-fc76-a2d5" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="b67f-450d-2608-c89a" name="CCW (A4)" hidden="false" collective="false" import="true" targetId="b37c-f7c4-5111-1731" type="selectionEntry"/>
+                    <entryLink id="98c4-3dbd-b6be-58f7" name="Energy Sword (Prime)" hidden="false" collective="false" import="true" targetId="cd64-9c2b-796a-a23d" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="1dff-46e5-0b9d-a433" name="Energy Fist (Prime)" hidden="false" collective="false" import="true" targetId="14b5-9b15-044f-e126" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="e5d8-36a3-1da3-1d57" name="Energy Hammer (Prime)" hidden="false" collective="false" import="true" targetId="a618-db4a-13f7-92a3" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="-10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1da5-e3e7-6ebe-a695" name="Auto-Rifle &amp; CCW" hidden="false" collective="false" import="true" type="upgrade">
+              <selectionEntryGroups>
+                <selectionEntryGroup id="e34b-4a2a-f984-e2a7" name="Replace one CCW:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a8e7-d9d4-06f1-168a">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="162e-58c8-10ce-6633" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1455-e222-2add-e756" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="a8e7-d9d4-06f1-168a" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry"/>
+                    <entryLink id="7424-6f62-0574-c04b" name="Energy Sword (A4,Rending)" hidden="false" collective="false" import="true" targetId="cd64-9c2b-796a-a23d" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="21a3-9ca6-b6ee-7ec3" name="Energy Fist (Prime)" hidden="false" collective="false" import="true" targetId="14b5-9b15-044f-e126" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="153c-ac95-4d5b-99c8" name="Energy Hammer (Prime)" hidden="false" collective="false" import="true" targetId="a618-db4a-13f7-92a3" type="selectionEntry">
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="9a5d-27bd-f437-e214" name="Auto-Rifle" hidden="false" collective="false" import="true" targetId="f2a7-6ad7-5096-a448" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f964-4598-2e1e-3db5" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c685-69bb-58fa-e288" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7d58-c5db-f531-a518" name="Energy Sword, Energy Fist &amp; Fist-Pistol" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="8875-5c27-b803-27f2" name="Energy Sword (A4,Rending)" hidden="false" collective="false" import="true" targetId="cd64-9c2b-796a-a23d" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2cd6-ec7b-66ba-4668" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a42-e160-f67b-8f6f" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="a427-dab0-1540-9e7a" name="Fist-Pistol" hidden="false" collective="false" import="true" targetId="baef-7852-49ca-c43c" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e26-b2f2-99fc-42e0" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f464-bc90-0ec1-af05" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="7eee-d4e1-a5c9-e8e8" name="Energy Fist (Prime)" hidden="false" collective="false" import="true" targetId="14b5-9b15-044f-e126" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9818-df39-241e-d2f7" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a523-49b5-381e-d74b" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="660a-a2db-0a09-5609" name="Upgrade two models with one:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69d5-b24b-b6e5-d2d5" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="183f-5a49-94c1-b25f" name="Camo Cloak" hidden="false" collective="false" import="true" targetId="95b9-f24a-635e-8f6f" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="7c4b-1bbe-414c-7107" name="Combat Shield" hidden="false" collective="false" import="true" targetId="5d42-38b9-de5e-58fd" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="ed8d-f4f7-5a4c-3420" name="Grave Armor" hidden="false" collective="false" import="true" targetId="3d40-9fa2-76fb-f0c1" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="85.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="a400-7ce9-89fe-a14a" name="Prime Brothers 1 - Upgrade List G (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a44b-4395-1916-0843" name="Replace any Auto-Rifle:" hidden="false" collective="false" import="true" defaultSelectionEntryId="2dd2-267c-4a97-ba23">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0498-4c50-3406-3c5a" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8cf4-c2aa-5b04-690f" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="70cb-e9e2-00bb-922f" name="Replace one Auto-Rifle:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e9d-de22-0052-0569" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="a59d-160e-bc01-b104" name="Gravity Rifle" hidden="false" collective="false" import="true" targetId="3e4a-da63-fdf2-c5fb" type="selectionEntry"/>
+                <entryLink id="0a5e-e6a6-3b62-789f" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="511e-7235-bcb6-f77a" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry"/>
+                <entryLink id="193a-29f0-a658-8995" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry"/>
+                <entryLink id="58cd-a049-aee1-efce" name="Heavy Machinegun" hidden="false" collective="false" import="true" targetId="4481-49a4-e4f7-925b" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="2dd2-267c-4a97-ba23" name="Auto-Rifle" hidden="false" collective="false" import="true" targetId="c585-5a84-313c-a7cf" type="selectionEntry"/>
+            <entryLink id="bbc9-19de-ef75-b006" name="Rifle (A2)" hidden="false" collective="false" import="true" targetId="893b-7055-5ccb-3592" type="selectionEntry"/>
+            <entryLink id="1d97-b410-7241-5759" name="Precision Rifle" hidden="false" collective="false" import="true" targetId="141f-9981-66b1-32bd" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5f83-6bf2-f866-e173" name="Upgrade all models with any:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="1ed3-f54b-adf6-0875" name="Veteran Infantry" hidden="false" collective="false" import="true" targetId="c1fc-c830-141f-e36e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8876-159d-c8f5-801c" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="a7c2-55d4-f4c6-f2cd" name="Grave Armor" hidden="false" collective="false" import="true" targetId="3d40-9fa2-76fb-f0c1" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd62-dfa6-cc12-ede5" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="435.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="bc13-2670-206a-bec5" name="One model may take one Auto-Rifle attachment:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4447-f097-2f6b-2ac6" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5e5f-bf21-eb1d-cec5" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="e089-6dd6-ec4e-12e6" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="8e50-4c76-1451-1575" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d51-97c4-f7b3-97f2" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="194d-aab5-a04e-7a49" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="2250-3b10-7c7d-aa6f" name="Prime Brothers 1 - Upgrade List G (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ba25-6499-ef56-dd6e" name="Replace any Auto-Rifle:" hidden="false" collective="false" import="true" defaultSelectionEntryId="5f12-e538-ac8a-3773">
+          <constraints>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="933c-a49b-eb6b-fa62" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a47e-a752-e099-697e" type="max"/>
+          </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="2d07-bf1a-72e8-4fef" name="Replace two Auto-Rifles:" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d414-a127-3769-4d74" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="43e9-530c-12c6-970a" name="Gravity Rifle" hidden="false" collective="false" import="true" targetId="3e4a-da63-fdf2-c5fb" type="selectionEntry"/>
+                <entryLink id="29bf-d242-6f33-e08d" name="Fusion Rifle" hidden="false" collective="false" import="true" targetId="f389-e078-075e-fbff" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="8569-a308-d9c8-1677" name="Plasma Rifle" hidden="false" collective="false" import="true" targetId="4cb4-c780-e943-646a" type="selectionEntry"/>
+                <entryLink id="397d-090e-5d2b-6ef1" name="Flamethrower" hidden="false" collective="false" import="true" targetId="ebb4-9dca-acaa-4dcf" type="selectionEntry"/>
+                <entryLink id="2cb0-9244-2e88-6690" name="Heavy Machinegun" hidden="false" collective="false" import="true" targetId="4481-49a4-e4f7-925b" type="selectionEntry">
+                  <costs>
+                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="5f12-e538-ac8a-3773" name="Auto-Rifle" hidden="false" collective="false" import="true" targetId="c585-5a84-313c-a7cf" type="selectionEntry"/>
+            <entryLink id="b5cf-791b-dcbe-b9b7" name="Rifle (A2)" hidden="false" collective="false" import="true" targetId="893b-7055-5ccb-3592" type="selectionEntry"/>
+            <entryLink id="0f18-37d3-3c8b-2fce" name="Precision Rifle" hidden="false" collective="false" import="true" targetId="141f-9981-66b1-32bd" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="50f4-ba97-fe21-a979" name="Upgrade all models with any:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="8283-3a48-697c-9a2f" name="Veteran Infantry" hidden="false" collective="false" import="true" targetId="c1fc-c830-141f-e36e" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2b6-c555-bc74-44d3" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="100.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="caf2-60e6-5489-53fb" name="Grave Armor" hidden="false" collective="false" import="true" targetId="3d40-9fa2-76fb-f0c1" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="12f4-693e-586e-8d26" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="870.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1667-815f-502e-0aff" name="Two models may take one Auto-Rifle attachment:" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67ef-52ee-d792-e8af" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="6924-2076-b15b-33a0" name="Grenade Launcher" hidden="false" collective="false" import="true" targetId="e089-6dd6-ec4e-12e6" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="af9e-0cc9-3924-52b0" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cd6-fdaa-67c4-afad" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4559-1d07-18d5-3a8c" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -6622,92 +6622,36 @@
     </selectionEntry>
     <selectionEntry id="fac1-7397-5651-780d" name="Blaster Squad" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="f24a-cb22-9e02-b0c0" name="Blaster Brother" hidden="false" targetId="1a44-a57f-e98b-3cde" type="profile"/>
+        <infoLink id="f24a-cb22-9e02-b0c0" name="Prime Blaster Brother" hidden="false" targetId="1a44-a57f-e98b-3cde" type="profile"/>
         <infoLink id="6b64-5ec7-f8b3-e88d" name="Firstborn" hidden="false" targetId="7399-4a35-48ef-4119" type="rule"/>
       </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="bd5f-ebd1-d9c7-3d18" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="3336-1474-9f8e-9795">
+        <selectionEntryGroup id="2ec4-f2e2-483f-959c" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="40b9-6248-a8ee-e9a8">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73bd-66a4-9fa0-87bf" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c413-f420-4207-b2d5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6986-5e41-1771-9832" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b0a-4e23-62f2-a023" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="c7ff-62e0-4540-db7e" name="Plasma Auto-Rifles" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="40b9-6248-a8ee-e9a8" name="Single Unit [5 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="f85a-12f3-6661-7a06" name="Blaster Brother (Assault Plasma Rifles)" hidden="false" collective="false" import="true" targetId="d0f1-634c-3177-22b2" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5bf3-c04a-1391-bf31" type="min"/>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8811-a1d3-626e-9639" type="max"/>
-                  </constraints>
-                </entryLink>
+                <entryLink id="81be-c696-2320-b455" name="Prime Brothers 1 - Upgrade List I (single unit)" hidden="false" collective="false" import="true" targetId="66fb-3d97-7a1b-f179" type="selectionEntryGroup"/>
+                <entryLink id="be0c-24c3-e2f4-ce51" name="Prime Brothers 1 - Upgrade List E (single unit)" hidden="false" collective="false" import="true" targetId="0bb9-e22c-0855-349c" type="selectionEntryGroup"/>
+                <entryLink id="0acf-b1f5-211e-4e9e" name="** Detachment Upgrade (Units of [5], single unit) **" hidden="false" collective="false" import="true" targetId="f024-6c76-c658-300a" type="selectionEntryGroup"/>
               </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
             </selectionEntry>
-            <selectionEntry id="3336-1474-9f8e-9795" name="Heavy Plasma Rifles" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="243d-b6cb-d851-372d" name="Combined Unit [10 models]" hidden="false" collective="false" import="true" type="upgrade">
               <entryLinks>
-                <entryLink id="b5d7-da3f-f23a-1512" name="Blaster Brother (Heavy Plasma Rifles)" hidden="false" collective="false" import="true" targetId="c379-e61c-9d54-f055" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ea3-9ee9-550a-6bf2" type="max"/>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f24c-7f47-c34d-bb56" type="min"/>
-                  </constraints>
-                </entryLink>
+                <entryLink id="1480-1f56-4c4f-86e5" name="Prime Brothers 1 - Upgrade List I (combined unit)" hidden="false" collective="false" import="true" targetId="89b8-b70b-c4c9-36a7" type="selectionEntryGroup"/>
+                <entryLink id="7d54-4429-70fc-9b31" name="Prime Brothers 1 - Upgrade List E (combined unit)" hidden="false" collective="false" import="true" targetId="1ad2-e3d2-1485-cc14" type="selectionEntryGroup"/>
+                <entryLink id="16b2-f87d-544e-2ad4" name="** Detachment Upgrade (Units of [5], combined unit) **" hidden="false" collective="false" import="true" targetId="3ed3-d384-8a43-eb07" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e27d-d650-6303-4f59" name="Light Plasma Cannons" hidden="false" collective="false" import="true" type="upgrade">
-              <entryLinks>
-                <entryLink id="fa96-a872-2385-b7df" name="Blaster Brother (Light Plasma Cannons)" hidden="false" collective="false" import="true" targetId="b7b5-3a7d-227a-709c" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f423-856e-9f1b-7dca" type="max"/>
-                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81de-658f-0af6-41f2" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="215.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
-        <selectionEntryGroup id="4946-0794-e377-2d10" name="Upgrades" hidden="false" collective="false" import="true">
-          <entryLinks>
-            <entryLink id="3c7d-aa68-9544-df48" name="Medical Training" hidden="false" collective="false" import="true" targetId="8352-cbe6-9410-a422" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2545-6e39-619e-0148" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="45.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="0740-eb20-80b7-93b8" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="9015-976e-5c04-013e" name="Wolf Brothers - Counter-Attack" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="af42-f507-1102-8b38" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="9f80-ec1e-79d0-45e9" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-      </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="215.0"/>
       </costs>
@@ -14640,6 +14584,118 @@
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="66fb-3d97-7a1b-f179" name="Prime Brothers 1 - Upgrade List I (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="bf68-b7e0-570b-3359" name="Replace all Heavy Plasma Rifles:" hidden="false" collective="false" import="true" defaultSelectionEntryId="23b2-b21e-3b30-72b3">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2fc-987f-caf7-1a25" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c8cf-8eb3-8ed5-9455" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="23b2-b21e-3b30-72b3" name="Heavy Plasma Rifles" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="9f6c-6cb4-9341-96f8" name="Heavy Plasma Rifle" hidden="false" collective="false" import="true" targetId="2b41-316b-ae64-3271" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab6b-1dcd-ecf2-d955" type="min"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af16-af6c-0ead-2fdf" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="da0f-d0e6-7334-66f7" name="Plasma Auto-Rifles" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="2f71-5d6e-ddae-cadf" name="Plasma Auto-Rifle" hidden="false" collective="false" import="true" targetId="855a-d205-3a2e-a218" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5a2-c84a-398e-9c9b" type="min"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f959-026b-416c-4850" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d1cf-2990-cf5c-9eb4" name="Light Plasma Cannons" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="3260-dec0-e753-ef00" name="Light Plasma Cannon" hidden="false" collective="false" import="true" targetId="3cf8-d2f0-20f0-b78f" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b07-8465-02b4-c0af" type="min"/>
+                    <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1199-f2c4-4991-1d2c" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="69ff-6c24-d0f8-74da" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="168d-fc4b-a9af-d00f" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccf4-7a16-3969-6cea" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d79d-ea82-3725-fafa" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="89b8-b70b-c4c9-36a7" name="Prime Brothers 1 - Upgrade List I (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7525-6d67-1a31-b427" name="Replace all Heavy Plasma Rifles:" hidden="false" collective="false" import="true" defaultSelectionEntryId="a4a4-033d-7eea-ceed">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39f7-ac27-a392-c881" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc29-ace2-20c2-5368" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="a4a4-033d-7eea-ceed" name="Heavy Plasma Rifles" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="5d2e-4f8f-30e2-7942" name="Heavy Plasma Rifle" hidden="false" collective="false" import="true" targetId="2b41-316b-ae64-3271" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ef1-b88b-0180-97f8" type="min"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd10-ca25-a616-887a" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="95b2-0c34-5033-8e38" name="Plasma Auto-Rifles" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="5ef5-97ee-1fcf-8375" name="Plasma Auto-Rifle" hidden="false" collective="false" import="true" targetId="855a-d205-3a2e-a218" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f20a-3bcc-54d0-22c9" type="min"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61fb-60b6-0e7e-06bd" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f537-1cd3-033b-8788" name="Light Plasma Cannons" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="658e-5f8a-0112-ae0c" name="Light Plasma Cannon" hidden="false" collective="false" import="true" targetId="3cf8-d2f0-20f0-b78f" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21a0-49a6-fa7a-bc5f" type="min"/>
+                    <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9a1-ec87-8857-9827" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="3772-5dea-ed3a-4f80" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="168d-fc4b-a9af-d00f" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7430-4b41-f3f6-2f35" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0352-b28b-4faf-75de" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -2106,6 +2106,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="500a-4942-d1e2-d9ed" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="bc43-88e5-f070-4e7f" name="** Detachment Upgrade (Units of [1] with Tough(6) **" hidden="false" collective="false" import="true" targetId="35c2-8df3-f833-4949" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="245.0"/>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -8397,112 +8397,47 @@
           </constraints>
           <selectionEntries>
             <selectionEntry id="a455-00e1-7163-aa5b" name="Single Unit [3 models]" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntries>
-                <selectionEntry id="3b53-7b14-da0b-d16e" name="Prime Guard Brother" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="ab23-8a20-5b92-5894" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa99-b0f3-79d9-f037" type="min"/>
-                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1320-057f-377e-81e8" type="max"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ce77-02a7-ac42-d204" type="min"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8276-c022-656a-814c" type="max"/>
                   </constraints>
-                  <entryLinks>
-                    <entryLink id="3b4e-fe3e-6c12-fef2" name="Pistol" hidden="false" collective="false" import="true" targetId="0f74-a615-8329-0c1a" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5622-d348-dcc0-55ae" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77d0-062b-5d74-6dcc" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="8e27-d23a-1ce1-e30e" name="Energy Sword (Guards)" hidden="false" collective="false" import="true" targetId="262a-3a6e-424e-b887" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9602-ad6f-6498-5abe" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="69bc-95d0-8ade-bc1b" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="0a3d-61c1-462e-6d71" name="Detachment Upgrade" hidden="false" collective="false" import="true">
-                  <entryLinks>
-                    <entryLink id="9a9e-6887-a863-3dc1" name="Wolf Brothers - Counter" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="62e9-749c-7a9c-fda3" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="ac5c-4b0c-d265-e206" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
+                </entryLink>
+                <entryLink id="1092-9307-4f8d-2ab0" name="Energy Sword (Elite)" hidden="false" collective="false" import="true" targetId="262a-3a6e-424e-b887" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c31b-3f9b-ab21-8119" type="min"/>
+                    <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="693f-1dad-ebcc-10bf" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="ec42-afcc-a695-934b" name="** Detachment Upgrade (Units of [3], single unit) **" hidden="false" collective="false" import="true" targetId="a060-d513-9f57-6e27" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="9d7b-250b-2a41-c14c" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="5f32-7bf6-1454-972c" name="Pistol" hidden="false" collective="false" import="true" targetId="bb7e-64f2-5ded-f697" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e7e8-d13a-c445-da08" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1af6-6cae-b89c-704d" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="96b9-7411-7f30-3bcf" name="Energy Sword (Elite)" hidden="false" collective="false" import="true" targetId="262a-3a6e-424e-b887" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65b1-9fa9-6804-26eb" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a27a-3455-cb01-9fda" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="9028-ba1f-5721-db17" name="** Detachment Upgrade (Units of [3], combined unit) **" hidden="false" collective="false" import="true" targetId="453e-ef26-c3dc-e2b5" type="selectionEntryGroup"/>
+              </entryLinks>
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="145.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8e9d-b131-d088-3f1b" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
-              <selectionEntries>
-                <selectionEntry id="4daf-377f-1be5-1c62" name="Prime Guard Brother" hidden="false" collective="false" import="true" type="upgrade">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d517-fa99-a42a-cb0d" type="min"/>
-                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cefb-b080-32b0-fdb0" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="438d-1208-bf3b-c9ef" name="Pistol" hidden="false" collective="false" import="true" targetId="0f74-a615-8329-0c1a" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd2b-227b-e745-dc37" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="798a-423f-3b48-b72a" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="33f7-a335-4c37-ffc5" name="Energy Sword (Guards)" hidden="false" collective="false" import="true" targetId="262a-3a6e-424e-b887" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="071a-d485-5af4-bf25" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f019-facb-059d-1596" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <costs>
-                    <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="a9ad-b872-e825-4349" name="Detachment Upgrade" hidden="false" collective="false" import="true">
-                  <entryLinks>
-                    <entryLink id="5b5f-b847-da56-35d4" name="Wolf Brothers - Counter" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="a022-ae25-4fc2-87ef" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="e1ed-1114-db3b-a54b" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
-                      <costs>
-                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-                      </costs>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="290.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="145.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c20f-9972-05d3-59c4" name="Eradication Squad" hidden="false" collective="false" import="true" type="upgrade">
@@ -12509,7 +12444,7 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
     </selectionEntryGroup>
-    <selectionEntryGroup id="47b6-1c61-aef4-88db" name="** Detachment Upgrade (Units of [5] with Tough(3), single unit)" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="47b6-1c61-aef4-88db" name="** Detachment Upgrade (Units of [5] with Tough(3), single unit) **" hidden="false" collective="false" import="true">
       <entryLinks>
         <entryLink id="0871-faa3-8f5d-1b8f" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
           <costs>
@@ -12545,7 +12480,7 @@
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="81c1-61bf-8c23-209f" name="** Detachment Upgrade (Units of [5] with Tough(3), combined unit)" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="81c1-61bf-8c23-209f" name="** Detachment Upgrade (Units of [5] with Tough(3), combined unit) **" hidden="false" collective="false" import="true">
       <entryLinks>
         <entryLink id="2349-a7e3-d3bc-8b70" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
           <costs>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -2869,56 +2869,6 @@
         <infoLink id="4a52-c417-797b-4e0e" name="Death Star Jet" hidden="false" targetId="7375-638f-2bb5-aba2" type="profile"/>
         <infoLink id="11d6-9af0-c4ae-5da5" name="Aircraft" hidden="false" targetId="187f-6a03-5b99-a4db" type="rule"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="cc9b-31b9-5c93-ec3f" name="Main Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="9bcf-e081-16d4-1b32">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef8f-43aa-b7be-5ee0" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a3a7-1efa-66cd-363a" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="9bcf-e081-16d4-1b32" name="Twin Minigun" hidden="false" collective="false" import="true" targetId="a8f7-27d2-59eb-c865" type="selectionEntry"/>
-            <entryLink id="94fc-4ee4-544a-3ded" name="Twin Laser Cannon" hidden="false" collective="false" import="true" targetId="d271-2d81-e640-0040" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="abac-7d07-63a6-5994" name="Ordnance" hidden="false" collective="false" import="true" defaultSelectionEntryId="e9b6-6396-10cf-eda8">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a487-4b2d-7f1a-ff73" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff07-e310-d3d6-424f" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="8ce5-06c7-edf5-fe44" name="Storm Missiles" hidden="false" collective="false" import="true" targetId="ae99-efd2-91f4-19d6" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="e9b6-6396-10cf-eda8" name="Death Rockets" hidden="false" collective="false" import="true" targetId="f0af-d1d7-aa49-7903" type="selectionEntry"/>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="0dd1-4382-ddd9-4038" name="Upgrades" hidden="false" collective="false" import="true">
-          <entryLinks>
-            <entryLink id="ce72-b1bb-ce47-e258" name="Cargo Space" hidden="false" collective="false" import="true" targetId="d1c0-d223-5e2f-fc42" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a41-5d59-49c5-4f40" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="b428-a855-b4b8-7339" name="Assault Rifle Array" hidden="false" collective="false" import="true" targetId="faa1-761d-0d50-2135" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="134c-97ed-fde7-a074" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="ea74-fe8b-8c11-8de9" name="Cluster Bombs" hidden="false" collective="false" import="true" targetId="fa8d-6425-5252-5eb7" type="selectionEntry">
           <constraints>
@@ -2926,6 +2876,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db45-b28a-5cc6-3dcc" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="f44b-9d42-7f74-5dbc" name="Watch Brothers - Upgrade List E" hidden="false" collective="false" import="true" targetId="b196-ed90-05a4-8ce6" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="250.0"/>
@@ -16108,6 +16059,58 @@
               </constraints>
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="b196-ed90-05a4-8ce6" name="Watch Brothers - Upgrade List E" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6c5f-f1de-7703-bf11" name="Replace Twin Minigun:" hidden="false" collective="false" import="true" defaultSelectionEntryId="b135-59f7-97fe-40a4">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0277-3140-71b8-0ded" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d902-e7ac-4d5b-6848" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="b135-59f7-97fe-40a4" name="Twin Minigun" hidden="false" collective="false" import="true" targetId="a8f7-27d2-59eb-c865" type="selectionEntry"/>
+            <entryLink id="19fc-085c-5070-ea4d" name="Twin Laser Cannon" hidden="false" collective="false" import="true" targetId="d271-2d81-e640-0040" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e1f0-131e-e6cd-4de0" name="Replace Death Rockets:" hidden="false" collective="false" import="true" defaultSelectionEntryId="6161-5fdd-f957-5a2c">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fcc-7e48-7b48-b3f2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cad2-e26a-58ec-43c0" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="fdc7-21ae-6eb2-1fca" name="Storm Missiles" hidden="false" collective="false" import="true" targetId="ae99-efd2-91f4-19d6" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="6161-5fdd-f957-5a2c" name="Death Rockets" hidden="false" collective="false" import="true" targetId="f0af-d1d7-aa49-7903" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a3ed-4a4c-9bd5-1986" name="Upgrade with any:" hidden="false" collective="false" import="true">
+          <entryLinks>
+            <entryLink id="1e17-8f4b-7fa0-74fd" name="Cargo Space" hidden="false" collective="false" import="true" targetId="d1c0-d223-5e2f-fc42" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e25-ad02-792d-bcf9" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="5e37-42aa-949f-fe99" name="Assault Rifle Array" hidden="false" collective="false" import="true" targetId="faa1-761d-0d50-2135" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d04-264e-5acf-ac32" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
               </costs>
             </entryLink>
           </entryLinks>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -2411,18 +2411,6 @@
         <infoLink id="e41a-6907-6fa0-61a9" name="Ambush" hidden="false" targetId="859e-e070-e91c-26e1" type="rule"/>
         <infoLink id="b106-a49a-34b4-2091" name="Dark Resolve" hidden="false" targetId="5dec-9937-47f8-7cf4" type="rule"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="4d6f-1087-5393-b703" name="Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="f6e6-96ee-9b10-ee7e">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aef5-f7f8-9632-2032" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c0c2-0095-4d87-80d0" type="min"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="8725-b42e-93cf-06d9" name="Minigun" hidden="false" collective="false" import="true" targetId="7b99-9f38-072e-e027" type="selectionEntry"/>
-            <entryLink id="f6e6-96ee-9b10-ee7e" name="Heavy Machinegun" hidden="false" collective="false" import="true" targetId="4481-49a4-e4f7-925b" type="selectionEntry"/>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="2025-e3b2-662c-3ff5" name="Plasma Burst-Cannon" hidden="false" collective="false" import="true" targetId="a64b-5183-2864-f148" type="selectionEntry">
           <constraints>
@@ -2430,6 +2418,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f5f-d7d2-1ae7-31d1" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="2a29-3e5b-caa6-0df5" name="Dark Brothers - Upgrade List E" hidden="false" collective="false" import="true" targetId="4ade-bd63-6621-8604" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="250.0"/>

--- a/Battle_Brothers.cat
+++ b/Battle_Brothers.cat
@@ -6778,54 +6778,32 @@
         <infoLink id="7128-d1e9-203a-4e73" name="Stealth" hidden="false" targetId="1b59-5d31-4675-c926" type="rule"/>
       </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="8fd3-22a2-bcef-10b6" name="Ranged Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="cd99-b4c9-7f79-1a1e">
+        <selectionEntryGroup id="a7af-af52-461a-9166" name="Unit Size" hidden="false" collective="false" import="true" defaultSelectionEntryId="9e1e-f731-843f-5540">
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="24a0-1fa9-4679-135f" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c35e-436b-d904-a732" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28bb-1f39-9a1f-e13c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccc6-162f-f670-f3c2" type="max"/>
           </constraints>
-          <entryLinks>
-            <entryLink id="cd99-b4c9-7f79-1a1e" name="Sniper Rifle" hidden="false" collective="false" import="true" targetId="77e0-0bbf-54ae-e813" type="selectionEntry"/>
-            <entryLink id="1ce8-64cd-e670-e303" name="Laser Rifle" hidden="false" collective="false" import="true" targetId="f69f-c3c7-8aef-d01b" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cb9-57ec-0a6b-acc9" type="max"/>
-              </constraints>
+          <selectionEntries>
+            <selectionEntry id="9e1e-f731-843f-5540" name="Single Unit [3 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="6204-f02b-1eea-a882" name="** Detachment Upgrade (Units of [3], single unit) **" hidden="false" collective="false" import="true" targetId="a060-d513-9f57-6e27" type="selectionEntryGroup"/>
+                <entryLink id="698a-6a13-727d-e98b" name="Prime Brothers 1 - Upgrade List J (single unit)" hidden="false" collective="false" import="true" targetId="936a-2e35-796b-f5fb" type="selectionEntryGroup"/>
+              </entryLinks>
+            </selectionEntry>
+            <selectionEntry id="9131-5cf8-f5ac-cff9" name="Combined Unit [6 models]" hidden="false" collective="false" import="true" type="upgrade">
+              <entryLinks>
+                <entryLink id="a57b-8f77-7301-7919" name="** Detachment Upgrade (Units of [3], combined unit) **" hidden="false" collective="false" import="true" targetId="453e-ef26-c3dc-e2b5" type="selectionEntryGroup"/>
+                <entryLink id="9f72-ec93-40c2-66f1" name="Prime Brothers 1 - Upgrade List J (combined unit)" hidden="false" collective="false" import="true" targetId="7655-8825-514a-a499" type="selectionEntryGroup"/>
+              </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="180.0"/>
               </costs>
-            </entryLink>
-          </entryLinks>
+            </selectionEntry>
+          </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="5cd8-0189-ffdc-9b0e" name="Blood Brothers - Furious" hidden="false" collective="false" import="true" targetId="058f-6713-6de0-2dc0" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="0073-96c9-9d55-339f" name="Dark Brothers - Grim" hidden="false" collective="false" import="true" targetId="aa16-9052-a575-e57a" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="f386-fda4-c2f2-409f" name="Wolf Brothers - Counter-Attack" hidden="false" collective="false" import="true" targetId="df0a-bf8a-ece8-04f5" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="04fa-9ba6-634d-63d7" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="168d-fc4b-a9af-d00f" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec8a-f737-06de-b015" type="max"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="468e-e334-f85b-b5ae" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="d680-48aa-75de-6789" name="Knight Brothers - Aegis" hidden="false" collective="false" import="true" targetId="e88d-6563-fb44-e4bf" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-          </costs>
-        </entryLink>
-      </entryLinks>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="205.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="180.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d984-2f6e-718a-0ff7" name="Fist-Carbine" hidden="false" collective="true" import="true" type="upgrade">
@@ -14551,6 +14529,58 @@
           <constraints>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7430-4b41-f3f6-2f35" type="min"/>
             <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0352-b28b-4faf-75de" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="936a-2e35-796b-f5fb" name="Prime Brothers 1 - Upgrade List J (single unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9ecd-9416-917f-7726" name="Replace any Sniper Rifle:" hidden="false" collective="false" import="true" defaultSelectionEntryId="96ea-b911-d39f-d6c9">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9ce-bc84-defb-c89b" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1af1-14ed-a2bb-9ee0" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="96ea-b911-d39f-d6c9" name="Sniper Rifle" hidden="false" collective="false" import="true" targetId="77e0-0bbf-54ae-e813" type="selectionEntry"/>
+            <entryLink id="9c20-1bac-a677-9b4e" name="Laser Rifle" hidden="false" collective="false" import="true" targetId="f69f-c3c7-8aef-d01b" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="47f5-f067-90a2-af40" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="068a-1d1d-b288-2f25" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21b7-6dc0-d691-2ef1" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="7655-8825-514a-a499" name="Prime Brothers 1 - Upgrade List J (combined unit)" hidden="false" collective="false" import="true">
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3547-c2d3-f666-a4cd" name="Replace any Sniper Rifle:" hidden="false" collective="false" import="true" defaultSelectionEntryId="701d-90bc-28dc-8bd8">
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eee5-d72f-0e52-efde" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0e9-2ac2-2fa9-9b16" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="701d-90bc-28dc-8bd8" name="Sniper Rifle" hidden="false" collective="false" import="true" targetId="77e0-0bbf-54ae-e813" type="selectionEntry"/>
+            <entryLink id="4cba-d306-b788-d703" name="Laser Rifle" hidden="false" collective="false" import="true" targetId="f69f-c3c7-8aef-d01b" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="fa54-2489-bdff-959f" name="CCW (A2)" hidden="false" collective="false" import="true" targetId="2cf5-bae0-bd1b-c205" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f721-645c-7b28-a0e0" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="922b-15f0-1f16-0070" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>

--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,7 @@ table!
 |---|---|---|
 |Game System|v2.10|Done|
 |Alien Hives|v2.9|Done|
-|Battle Brothers|Main v2.12 - Prime v2.12 - Detachments v2.14|Done|
+|Battle Brothers|Main v2.12 - Prime v2.14 - Detachments v2.14|Done|
 |Battle Sisters|v2.9|Done|
 |Custodian Brothers|v2.1|Done|
 |Dark Elf Raiders|v2.7|Done|


### PR DESCRIPTION
Major overhaul of the Battle Brothers, Prime Brothers and Detachments lists including:
- Fix issue #111 
- Allow for combined squads
- Total reorganization of upgrades to more directly mirror the OPR Army Books
- Army Selection option to differentiate between Battle Bros and Prime Bros, since they are now technically separate Army Books