### PR TITLE
Updated Alien Hives to v2.11

### DIFF
--- a/Alien_Hives.cat
+++ b/Alien_Hives.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="df4c-bebc-a82e-f430" name="Alien Hives" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="d755-5d69-2721-c11b" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="df4c-bebc-a82e-f430" name="Alien Hives" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="d755-5d69-2721-c11b" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="3518-c2b3-bfde-3ff1" name="Alien Hives v2.9"/>
   </publications>
@@ -170,73 +170,73 @@
         <infoLink id="fa6b-1d6c-e310-2a18" name="Hive Lord" hidden="false" targetId="2005-c874-8d25-283d" type="profile"/>
       </infoLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="3d87-fd08-4175-8f50" name="Weapons - Arms [pick 2]" hidden="false" collective="false" import="true" defaultSelectionEntryId="26ed-65af-1f50-6273">
+        <selectionEntryGroup id="3d87-fd08-4175-8f50" name="Weapons - Arms [pick 3]" hidden="false" collective="false" import="true" defaultSelectionEntryId="26ed-65af-1f50-6273">
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8951-6b95-6507-762e" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c47e-99aa-8090-fb95" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8951-6b95-6507-762e" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c47e-99aa-8090-fb95" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="26ed-65af-1f50-6273" name="Razor Claws" hidden="false" collective="false" import="true" targetId="c76e-deb8-200c-e75a" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e095-fb44-07a4-0d35" type="max"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e095-fb44-07a4-0d35" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="ecdf-d337-16a9-704e" name="Piercing Claws (A3,AP2)" hidden="false" collective="false" import="true" targetId="3ad1-63ca-437f-86f3" type="selectionEntry">
+            <entryLink id="ecdf-d337-16a9-704e" name="Piercing Claws" hidden="false" collective="false" import="true" targetId="3ad1-63ca-437f-86f3" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9ee-3e21-ed36-d6ce" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="2ca2-1b1b-3519-7eb9" name="Smashing Claw (A3,AP4)" hidden="false" collective="false" import="true" targetId="86f9-3f6a-6b08-f085" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4de6-1caf-8d96-dd3f" type="max"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f9ee-3e21-ed36-d6ce" type="max"/>
               </constraints>
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
               </costs>
             </entryLink>
-            <entryLink id="d955-ae13-37d9-9f93" name="Serrated Claws (A6,AP2)" hidden="false" collective="false" import="true" targetId="4339-677c-1361-9190" type="selectionEntry">
+            <entryLink id="2ca2-1b1b-3519-7eb9" name="Smashing Claw" hidden="false" collective="false" import="true" targetId="86f9-3f6a-6b08-f085" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6eb-0d80-6501-1adb" type="max"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4de6-1caf-8d96-dd3f" type="max"/>
               </constraints>
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
               </costs>
             </entryLink>
-            <entryLink id="1179-3886-cfea-dd28" name="Sword Claws (A3,AP2)" hidden="false" collective="false" import="true" targetId="5dc8-5fec-55fe-de7a" type="selectionEntry">
+            <entryLink id="d955-ae13-37d9-9f93" name="Serrated Claws" hidden="false" collective="false" import="true" targetId="4339-677c-1361-9190" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebd6-a7ab-46fd-2915" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="beb1-a19d-c112-5ad0" name="Whip Limb &amp; Sword Claw (A2,AP1)" hidden="false" collective="false" import="true" targetId="4b6a-becd-466c-f590" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00f0-8deb-38d4-dc5a" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="fc33-bc8d-2a92-a531" name="Twin Bio-Pistols" hidden="false" collective="false" import="true" targetId="76ac-3068-350d-19e1" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8999-71ba-ea16-c195" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="f366-310a-538a-646a" name="Heavy Bio-Carbine" hidden="false" collective="false" import="true" targetId="0c5b-9d5b-8488-a3ab" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab60-657f-aea1-bc2d" type="max"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f6eb-0d80-6501-1adb" type="max"/>
               </constraints>
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
               </costs>
             </entryLink>
-            <entryLink id="05b6-7360-6a12-1ec3" name="Barb-Cannon" hidden="false" collective="false" import="true" targetId="0796-3b38-5f88-4f96" type="selectionEntry">
+            <entryLink id="1179-3886-cfea-dd28" name="Sword Claws" hidden="false" collective="false" import="true" targetId="5dc8-5fec-55fe-de7a" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="887e-abd5-2b8e-0125" type="max"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebd6-a7ab-46fd-2915" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="beb1-a19d-c112-5ad0" name="Whip Limb &amp; Sword Claw" hidden="false" collective="false" import="true" targetId="4b6a-becd-466c-f590" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00f0-8deb-38d4-dc5a" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="fc33-bc8d-2a92-a531" name="Twin Bio-Pistols" hidden="false" collective="false" import="true" targetId="76ac-3068-350d-19e1" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8999-71ba-ea16-c195" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="f366-310a-538a-646a" name="Heavy Bio-Carbine" hidden="false" collective="false" import="true" targetId="0c5b-9d5b-8488-a3ab" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab60-657f-aea1-bc2d" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="05b6-7360-6a12-1ec3" name="Barb Cannon" hidden="false" collective="false" import="true" targetId="0796-3b38-5f88-4f96" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="887e-abd5-2b8e-0125" type="max"/>
               </constraints>
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
@@ -244,7 +244,7 @@
             </entryLink>
             <entryLink id="e2f7-8d1d-42d5-63d9" name="Acid Cannon" hidden="false" collective="false" import="true" targetId="6df6-dafc-66b8-08c8" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e807-1cc8-7e2d-089e" type="max"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e807-1cc8-7e2d-089e" type="max"/>
               </constraints>
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
@@ -252,7 +252,7 @@
             </entryLink>
             <entryLink id="559d-9108-351b-d2be" name="Heavy Bio-Spitter" hidden="false" collective="false" import="true" targetId="abc4-b335-2409-eca3" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="175a-c4d5-87cd-54cd" type="max"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="175a-c4d5-87cd-54cd" type="max"/>
               </constraints>
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
@@ -260,7 +260,7 @@
             </entryLink>
             <entryLink id="5024-6e16-88c8-b3f8" name="Heavy Barb Cannon" hidden="false" collective="false" import="true" targetId="17ea-ec1a-1358-8440" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5838-7f8c-b261-18bb" type="max"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5838-7f8c-b261-18bb" type="max"/>
               </constraints>
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
@@ -268,7 +268,7 @@
             </entryLink>
             <entryLink id="65a1-de37-7717-56ac" name="Heavy Acid Cannon" hidden="false" collective="false" import="true" targetId="e2d8-c57c-c20b-bd7a" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a78-053c-3a90-f3ef" type="max"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a78-053c-3a90-f3ef" type="max"/>
               </constraints>
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="50.0"/>
@@ -276,12 +276,12 @@
             </entryLink>
             <entryLink id="4b78-3fb2-0f71-6db7" name="Bio-Carbine" hidden="false" collective="false" import="true" targetId="aaaa-2ae3-b951-327b" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3372-0860-388b-4e2b" type="max"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3372-0860-388b-4e2b" type="max"/>
               </constraints>
             </entryLink>
             <entryLink id="76ae-4857-2ff5-9f3d" name="Bio-Spitter" hidden="false" collective="false" import="true" targetId="8021-94c2-4f34-b199" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="528c-c9a9-87ce-2f6f" type="max"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="528c-c9a9-87ce-2f6f" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
@@ -357,10 +357,10 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="daac-1f8d-9953-9fc2" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="5ee4-ea30-7829-0374" name="Beast Tail Upgrades" hidden="false" collective="false" import="true" targetId="7e59-feb8-9bd9-307e" type="selectionEntryGroup"/>
+        <entryLink id="5ee4-ea30-7829-0374" name="Weapons - Tail [max 1]" hidden="false" collective="false" import="true" targetId="7e59-feb8-9bd9-307e" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="335.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="345.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c76e-deb8-200c-e75a" name="Razor Claws" hidden="false" collective="false" import="true" type="upgrade">
@@ -550,7 +550,7 @@
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be99-5a07-6bc9-5b08" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="6621-dd6c-8245-2384" name="Piercing Claws (A3,AP2)" hidden="false" collective="false" import="true" targetId="3ad1-63ca-437f-86f3" type="selectionEntry">
+            <entryLink id="6621-dd6c-8245-2384" name="Piercing Claws" hidden="false" collective="false" import="true" targetId="3ad1-63ca-437f-86f3" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="76ea-b8ec-e5dd-07fc" type="max"/>
               </constraints>
@@ -558,36 +558,36 @@
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
               </costs>
             </entryLink>
-            <entryLink id="098c-2b45-9d32-ceac" name="Smashing Claw (A3,AP4)" hidden="false" collective="false" import="true" targetId="86f9-3f6a-6b08-f085" type="selectionEntry">
+            <entryLink id="098c-2b45-9d32-ceac" name="Smashing Claw" hidden="false" collective="false" import="true" targetId="86f9-3f6a-6b08-f085" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="da7f-0044-2d1a-c24a" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
               </costs>
             </entryLink>
-            <entryLink id="689f-c4a9-e0a3-56de" name="Serrated Claws (A6,AP2)" hidden="false" collective="false" import="true" targetId="4339-677c-1361-9190" type="selectionEntry">
+            <entryLink id="689f-c4a9-e0a3-56de" name="Serrated Claws" hidden="false" collective="false" import="true" targetId="4339-677c-1361-9190" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3394-62b0-46f9-7617" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
               </costs>
             </entryLink>
-            <entryLink id="cf77-fe20-53b9-79da" name="Sword Claws (A3,AP2)" hidden="false" collective="false" import="true" targetId="5dc8-5fec-55fe-de7a" type="selectionEntry">
+            <entryLink id="cf77-fe20-53b9-79da" name="Sword Claws" hidden="false" collective="false" import="true" targetId="5dc8-5fec-55fe-de7a" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab93-c58f-6be2-cb88" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
               </costs>
             </entryLink>
-            <entryLink id="ecc9-065f-e7d4-59fb" name="Whip Limb &amp; Sword Claw (A2,AP1)" hidden="false" collective="false" import="true" targetId="4b6a-becd-466c-f590" type="selectionEntry">
+            <entryLink id="ecc9-065f-e7d4-59fb" name="Whip Limb &amp; Sword Claw" hidden="false" collective="false" import="true" targetId="4b6a-becd-466c-f590" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="973e-e3a3-fa31-622e" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
               </costs>
             </entryLink>
             <entryLink id="188e-327c-8817-16a8" name="Twin Bio-Pistols" hidden="false" collective="false" import="true" targetId="76ac-3068-350d-19e1" type="selectionEntry">
@@ -687,7 +687,7 @@
         <entryLink id="c98b-5b46-7057-5c53" name="Weapons - Tail [max 1]" hidden="false" collective="false" import="true" targetId="7e59-feb8-9bd9-307e" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="185.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="170.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8d0e-666b-b80f-6195" name="Snatcher Lord" hidden="false" collective="false" import="true" type="upgrade">
@@ -755,10 +755,10 @@
         <entryLink id="2bcf-db90-1cbe-13cc" name="Spells" hidden="false" collective="false" import="true" targetId="db9a-8ce7-bcc1-14f5" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="130.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="190.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8238-a866-fe92-0d9f" name="Piercing Claws" hidden="false" collective="true" import="true" type="upgrade">
+    <selectionEntry id="8238-a866-fe92-0d9f" name="Piercing Claws" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="8dbb-2b08-5b3b-6643" name="Razor Pincers" hidden="false" targetId="05be-f7be-083d-ea2a" type="profile"/>
         <infoLink id="8c06-2b61-dc20-0992" name="Rending" hidden="false" targetId="9726-accd-9015-f6f6" type="rule"/>
@@ -889,7 +889,7 @@
                     <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1c6-132f-9314-c832" type="min"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="237d-4681-8369-0e53" name="Grunt" hidden="false" collective="false" import="true" targetId="8899-58b7-35c7-0cc4" type="selectionEntry">
+                    <entryLink id="237d-4681-8369-0e53" name="Grunt (Twin Bio-Pistols)" hidden="false" collective="false" import="true" targetId="8899-58b7-35c7-0cc4" type="selectionEntry">
                       <constraints>
                         <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1a0-aabf-9ca5-421b" type="max"/>
                       </constraints>
@@ -996,14 +996,14 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="120.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="130.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="120.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="130.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="c46a-0bd1-1964-fc30" name="Twin Bio-Pistols" hidden="false" collective="true" import="true" type="upgrade">
@@ -1081,10 +1081,37 @@
                         <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cce7-3e9f-069c-2a41" type="max"/>
                       </constraints>
                     </entryLink>
-                    <entryLink id="db40-b4b7-1152-939a" name="Assault Grunt (Special Weapon)" hidden="false" collective="false" import="true" targetId="6e92-65f9-0726-16ea" type="selectionEntry">
+                    <entryLink id="61ee-ab33-6605-6230" name="Assault Grunt (Piercing Claws)" hidden="false" collective="false" import="true" targetId="565b-7301-3726-a2ea" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6840-6446-e5b6-ccb9" type="max"/>
+                        <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c11-a2cd-4cac-fdf4" type="max"/>
                       </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="8e56-d60b-4a37-66da" name="Assault Grunt (Serrated Claws)" hidden="false" collective="false" import="true" targetId="d018-a3c8-9960-19fc" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2adc-4e23-0e47-8587" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="26c4-4974-0815-9413" name="Assault Grunt (Smashing Claws)" hidden="false" collective="false" import="true" targetId="9073-f951-c114-9a8f" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfbf-d7ff-5793-4866" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="cfc2-aa72-2483-0345" name="Assault Grunt (Sword Claws)" hidden="false" collective="false" import="true" targetId="4593-5dea-50eb-4814" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b18d-f437-3f66-ff2b" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
@@ -1126,23 +1153,50 @@
                         <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a840-f5f9-29bf-f39a" type="max"/>
                       </constraints>
                     </entryLink>
-                    <entryLink id="42fd-d1da-1d20-fef6" name="Assault Grunt (Special Weapon)" hidden="false" collective="false" import="true" targetId="6e92-65f9-0726-16ea" type="selectionEntry">
+                    <entryLink id="cbf8-23a4-2f2d-1c98" name="Assault Grunt (Piercing Claws)" hidden="false" collective="false" import="true" targetId="565b-7301-3726-a2ea" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c28a-9df7-05ed-08e2" type="max"/>
+                        <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="360a-214e-41bf-f1c1" type="max"/>
                       </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="c484-2b93-39e0-82cc" name="Assault Grunt (Serrated Claws)" hidden="false" collective="false" import="true" targetId="d018-a3c8-9960-19fc" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e6c-2759-16ae-bfaa" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="3965-b5a5-5945-e90f" name="Assault Grunt (Smashing Claws)" hidden="false" collective="false" import="true" targetId="9073-f951-c114-9a8f" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a20c-9af3-0dfa-a7af" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink id="bb63-bf12-199a-3722" name="Assault Grunt (Sword Claws)" hidden="false" collective="false" import="true" targetId="4593-5dea-50eb-4814" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="20.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="392a-4e9e-d72c-6577" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                      </costs>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="160.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="170.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="160.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="170.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="14bc-89c0-754d-4ad6" name="Winged Grunt (Bio-Gun)" hidden="false" collective="false" import="true" type="upgrade">
@@ -1286,19 +1340,19 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="180.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="190.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="180.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="190.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="bdfd-e970-72a7-39e6" name="Soul-Snatcher" hidden="false" collective="false" import="true" type="upgrade">
       <entryLinks>
-        <entryLink id="18cb-0915-2281-789b" name="Razor Pincers" hidden="false" collective="false" import="true" targetId="8238-a866-fe92-0d9f" type="selectionEntry">
+        <entryLink id="18cb-0915-2281-789b" name="Piercing Claws" hidden="false" collective="false" import="true" targetId="8238-a866-fe92-0d9f" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fc0-55b2-6aa5-796e" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b68-038e-271a-6b9a" type="min"/>
@@ -1350,7 +1404,7 @@
                   </constraints>
                   <entryLinks>
                     <entryLink id="a840-9549-824a-8dbe" name="Soul-Snatcher" hidden="false" collective="false" import="true" targetId="bdfd-e970-72a7-39e6" type="selectionEntry"/>
-                    <entryLink id="2be2-4cb4-c28d-f913" name="Soul-Snatcher (Piercing+Razor Claws)" hidden="false" collective="false" import="true" targetId="3fe1-3200-30ec-cbda" type="selectionEntry">
+                    <entryLink id="2be2-4cb4-c28d-f913" name="Soul-Snatcher (+Razor Claws)" hidden="false" collective="false" import="true" targetId="3fe1-3200-30ec-cbda" type="selectionEntry">
                       <costs>
                         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
                       </costs>
@@ -1398,14 +1452,14 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="200.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="215.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="200.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="215.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1824-3273-9a1f-1957" name="Hive Swarm" hidden="false" collective="false" import="true" type="upgrade">
@@ -1429,6 +1483,7 @@
     <selectionEntry id="be92-78a6-55b4-d6d7" name="Swarm Attack" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="46c6-9ee4-7da8-4b1b" name="Swarm Attack" hidden="false" targetId="83db-db16-b2bb-a315" type="profile"/>
+        <infoLink id="3914-7e02-2c0e-c86c" name="Poison" hidden="false" targetId="2c45-0e1e-fec5-8dbb" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
@@ -1577,25 +1632,30 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="951e-c931-3752-a3e8" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="bf8c-6213-2ad2-3888" name="Whip Limb &amp; Sword Claw (A2)" hidden="false" collective="false" import="true" targetId="21ef-4484-3b57-ef5e" type="selectionEntry">
+            <entryLink id="bf8c-6213-2ad2-3888" name="Whip Limb &amp; Sword Claw" hidden="false" collective="false" import="true" targetId="21ef-4484-3b57-ef5e" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
               </costs>
             </entryLink>
-            <entryLink id="8956-7e4d-bcac-c921" name="Razor Claws (A3,AP1)" hidden="false" collective="false" import="true" targetId="5c30-2ce2-c8dc-316a" type="selectionEntry"/>
-            <entryLink id="3514-79ad-3e16-3707" name="Piercing Claws (A3,AP1)" hidden="false" collective="false" import="true" targetId="50ad-68c4-7540-0320" type="selectionEntry">
+            <entryLink id="8956-7e4d-bcac-c921" name="Razor Claws" hidden="false" collective="false" import="true" targetId="5c30-2ce2-c8dc-316a" type="selectionEntry"/>
+            <entryLink id="3514-79ad-3e16-3707" name="Piercing Claws" hidden="false" collective="false" import="true" targetId="50ad-68c4-7540-0320" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
               </costs>
             </entryLink>
-            <entryLink id="7009-c44f-b5f7-30d4" name="Sword Claws (A3,AP1)" hidden="false" collective="false" import="true" targetId="6fda-60d4-a266-4432" type="selectionEntry">
+            <entryLink id="7009-c44f-b5f7-30d4" name="Sword Claws" hidden="false" collective="false" import="true" targetId="6fda-60d4-a266-4432" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
               </costs>
             </entryLink>
-            <entryLink id="c8e1-853f-f948-eab3" name="Smashing Claw (A3,AP3)" hidden="false" collective="false" import="true" targetId="2917-6565-e6e7-a157" type="selectionEntry">
+            <entryLink id="c8e1-853f-f948-eab3" name="Smashing Claw" hidden="false" collective="false" import="true" targetId="2917-6565-e6e7-a157" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="c782-60eb-6e6d-9b1e" name="Serrated Claws" hidden="false" collective="false" import="true" targetId="7be3-6c53-90a5-9537" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -1612,7 +1672,11 @@
               </costs>
             </entryLink>
             <entryLink id="3da8-38b3-f393-e1fb" name="Bio-Carbine" hidden="false" collective="false" import="true" targetId="aaaa-2ae3-b951-327b" type="selectionEntry"/>
-            <entryLink id="4486-10f2-bd52-eb5b" name="Razor Claws (A3,AP1)" hidden="false" collective="false" import="true" targetId="5c30-2ce2-c8dc-316a" type="selectionEntry"/>
+            <entryLink id="4486-10f2-bd52-eb5b" name="Razor Claws" hidden="false" collective="false" import="true" targetId="5c30-2ce2-c8dc-316a" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
             <entryLink id="7f12-519b-ca75-fdb3" name="Twin Bio-Pistols" hidden="false" collective="false" import="true" targetId="76ac-3068-350d-19e1" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
@@ -1661,25 +1725,30 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b150-bdae-9bbb-212b" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="500b-3ed7-5a15-b229" name="Whip Limb &amp; Sword Claw (A2)" hidden="false" collective="false" import="true" targetId="21ef-4484-3b57-ef5e" type="selectionEntry">
+            <entryLink id="500b-3ed7-5a15-b229" name="Whip Limb &amp; Sword Claw" hidden="false" collective="false" import="true" targetId="21ef-4484-3b57-ef5e" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
               </costs>
             </entryLink>
             <entryLink id="1cd8-36ce-f153-5353" name="Razor Claws (A3,AP1)" hidden="false" collective="false" import="true" targetId="5c30-2ce2-c8dc-316a" type="selectionEntry"/>
-            <entryLink id="2080-36ba-5de2-9033" name="Piercing Claws (A3,AP1)" hidden="false" collective="false" import="true" targetId="50ad-68c4-7540-0320" type="selectionEntry">
+            <entryLink id="2080-36ba-5de2-9033" name="Piercing Claws" hidden="false" collective="false" import="true" targetId="50ad-68c4-7540-0320" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
               </costs>
             </entryLink>
-            <entryLink id="5a1e-0925-fdae-d0f3" name="Sword Claws (A3,AP1)" hidden="false" collective="false" import="true" targetId="6fda-60d4-a266-4432" type="selectionEntry">
+            <entryLink id="5a1e-0925-fdae-d0f3" name="Sword Claws" hidden="false" collective="false" import="true" targetId="6fda-60d4-a266-4432" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
               </costs>
             </entryLink>
-            <entryLink id="8ab9-42c2-5e5e-9782" name="Smashing Claw (A3,AP3)" hidden="false" collective="false" import="true" targetId="2917-6565-e6e7-a157" type="selectionEntry">
+            <entryLink id="8ab9-42c2-5e5e-9782" name="Smashing Claw" hidden="false" collective="false" import="true" targetId="2917-6565-e6e7-a157" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="50cb-cdec-5919-593b" name="Serrated Claws" hidden="false" collective="false" import="true" targetId="7be3-6c53-90a5-9537" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -1808,14 +1877,14 @@
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="185.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="190.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="185.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="190.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="aaaa-2ae3-b951-327b" name="Bio-Carbine" hidden="false" collective="false" import="true" type="upgrade">
@@ -1831,6 +1900,7 @@
         <infoLink id="93d4-1c23-a76f-079f" name="Hive Guardian" hidden="false" targetId="57b3-e32c-52a3-9d91" type="profile"/>
         <infoLink id="8bc8-63a2-4212-cd7d" name="Tough(X)" hidden="false" targetId="b9d3-4d17-007c-22cb" type="rule"/>
         <infoLink id="b3a1-a767-3491-8ce5" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
+        <infoLink id="604c-fc30-5076-1376" name="Relentless" hidden="false" targetId="973a-bce3-c43c-b039" type="rule"/>
       </infoLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="9e83-c06a-1748-9238" name="Weapons [pick 2 - max 1 ranged]" hidden="false" collective="false" import="true" defaultSelectionEntryId="2656-9417-6f06-abda">
@@ -1858,30 +1928,30 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="dd5d-10cd-23df-f65d" name="Razor Pincers" hidden="false" collective="false" import="true" targetId="3ad1-63ca-437f-86f3" type="selectionEntry">
+            <entryLink id="dd5d-10cd-23df-f65d" name="Piercing Claws" hidden="false" collective="false" import="true" targetId="3ad1-63ca-437f-86f3" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
               </costs>
             </entryLink>
-            <entryLink id="2656-9417-6f06-abda" name="Razor Claws (A3,AP2)" hidden="false" collective="false" import="true" targetId="c76e-deb8-200c-e75a" type="selectionEntry"/>
-            <entryLink id="908a-e50f-ad9c-c90b" name="Smashing Claw (A3,AP4)" hidden="false" collective="false" import="true" targetId="86f9-3f6a-6b08-f085" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="360c-e9d0-66ab-733a" name="Serrated Claws (A6,AP2)" hidden="false" collective="false" import="true" targetId="4339-677c-1361-9190" type="selectionEntry">
+            <entryLink id="2656-9417-6f06-abda" name="Razor Claws" hidden="false" collective="false" import="true" targetId="c76e-deb8-200c-e75a" type="selectionEntry"/>
+            <entryLink id="908a-e50f-ad9c-c90b" name="Smashing Claw" hidden="false" collective="false" import="true" targetId="86f9-3f6a-6b08-f085" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
               </costs>
             </entryLink>
-            <entryLink id="ce33-ec5e-3728-50e7" name="Sword Claws (A3,AP2)" hidden="false" collective="false" import="true" targetId="5dc8-5fec-55fe-de7a" type="selectionEntry">
+            <entryLink id="360c-e9d0-66ab-733a" name="Serrated Claws" hidden="false" collective="false" import="true" targetId="4339-677c-1361-9190" type="selectionEntry">
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
               </costs>
             </entryLink>
-            <entryLink id="86a6-0805-1e7b-e47c" name="Whip Limb &amp; Sword Claw (A2,AP1)" hidden="false" collective="false" import="true" targetId="4b6a-becd-466c-f590" type="selectionEntry">
+            <entryLink id="ce33-ec5e-3728-50e7" name="Sword Claws" hidden="false" collective="false" import="true" targetId="5dc8-5fec-55fe-de7a" type="selectionEntry">
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="86a6-0805-1e7b-e47c" name="Whip Limb &amp; Sword Claw" hidden="false" collective="false" import="true" targetId="4b6a-becd-466c-f590" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -1891,7 +1961,7 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4764-2fc1-e9be-f1b5" name="Smashing Claw" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="4764-2fc1-e9be-f1b5" name="Smashing Claw" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="5f1a-7c4c-108a-0239" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
         <infoLink id="4151-5754-0072-be43" name="Smashing Claws" hidden="false" targetId="523a-c781-941f-1bb4" type="profile"/>
@@ -1969,14 +2039,14 @@
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="325.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="275.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="325.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="275.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="1a30-5826-3817-83ea" name="Shadow Hunter" hidden="false" collective="false" import="true" type="upgrade">
@@ -2024,25 +2094,30 @@
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f00c-3604-fa8f-b2d6" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="0222-ffe4-fc08-8c49" name="Whip Limb &amp; Sword Claw" hidden="false" collective="false" import="true" targetId="21ef-4484-3b57-ef5e" type="selectionEntry">
+            <entryLink id="0222-ffe4-fc08-8c49" name="Whip Limb &amp; Sword Claw" hidden="false" collective="false" import="true" targetId="4b6a-becd-466c-f590" type="selectionEntry">
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
               </costs>
             </entryLink>
-            <entryLink id="dd4a-e3ef-142a-7d2e" name="Razor Claws (A3,AP1)" hidden="false" collective="false" import="true" targetId="5c30-2ce2-c8dc-316a" type="selectionEntry"/>
-            <entryLink id="3526-aa4d-7503-f0ea" name="Piercing Claws (A3,AP1)" hidden="false" collective="false" import="true" targetId="50ad-68c4-7540-0320" type="selectionEntry">
+            <entryLink id="dd4a-e3ef-142a-7d2e" name="Razor Claws" hidden="false" collective="false" import="true" targetId="c76e-deb8-200c-e75a" type="selectionEntry"/>
+            <entryLink id="3526-aa4d-7503-f0ea" name="Piercing Claws" hidden="false" collective="false" import="true" targetId="3ad1-63ca-437f-86f3" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
               </costs>
             </entryLink>
-            <entryLink id="ea94-1252-29e3-1a46" name="Sword Claws (A3,AP1)" hidden="false" collective="false" import="true" targetId="6fda-60d4-a266-4432" type="selectionEntry">
+            <entryLink id="ea94-1252-29e3-1a46" name="Sword Claws" hidden="false" collective="false" import="true" targetId="5dc8-5fec-55fe-de7a" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="4842-c2cf-e63b-711c" name="Smashing Claw" hidden="false" collective="false" import="true" targetId="2917-6565-e6e7-a157" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
               </costs>
             </entryLink>
-            <entryLink id="4842-c2cf-e63b-711c" name="Smashing Claw (A3,AP3)" hidden="false" collective="false" import="true" targetId="2917-6565-e6e7-a157" type="selectionEntry">
+            <entryLink id="4a2d-7bf8-d567-3085" name="Serrated Claws" hidden="false" collective="false" import="true" targetId="4339-677c-1361-9190" type="selectionEntry">
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
               </costs>
             </entryLink>
           </entryLinks>
@@ -2066,28 +2141,28 @@
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3566-c486-e6b2-318a" type="min"/>
           </constraints>
           <entryLinks>
-            <entryLink id="7e8e-6da9-9b8d-47a4" name="Razor Claws (A3,AP1)" hidden="false" collective="false" import="true" targetId="5c30-2ce2-c8dc-316a" type="selectionEntry"/>
-            <entryLink id="a310-130f-61e3-8157" name="Piercing Claws (A3,AP1)" hidden="false" collective="false" import="true" targetId="50ad-68c4-7540-0320" type="selectionEntry">
+            <entryLink id="7e8e-6da9-9b8d-47a4" name="Razor Claws" hidden="false" collective="false" import="true" targetId="5c30-2ce2-c8dc-316a" type="selectionEntry"/>
+            <entryLink id="a310-130f-61e3-8157" name="Piercing Claws" hidden="false" collective="false" import="true" targetId="50ad-68c4-7540-0320" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
               </costs>
             </entryLink>
-            <entryLink id="ad76-788c-853c-0eb0" name="Smashing Claw (A3,AP3)" hidden="false" collective="false" import="true" targetId="2917-6565-e6e7-a157" type="selectionEntry">
+            <entryLink id="ad76-788c-853c-0eb0" name="Smashing Claw" hidden="false" collective="false" import="true" targetId="2917-6565-e6e7-a157" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
               </costs>
             </entryLink>
-            <entryLink id="a5d4-a71f-c2b8-1ab2" name="Serrated Claws (A6,AP1)" hidden="false" collective="false" import="true" targetId="7be3-6c53-90a5-9537" type="selectionEntry">
+            <entryLink id="a5d4-a71f-c2b8-1ab2" name="Serrated Claws" hidden="false" collective="false" import="true" targetId="7be3-6c53-90a5-9537" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
               </costs>
             </entryLink>
-            <entryLink id="ee5f-1f92-3f14-a54f" name="Sword Claws (A3,AP1)" hidden="false" collective="false" import="true" targetId="6fda-60d4-a266-4432" type="selectionEntry">
+            <entryLink id="ee5f-1f92-3f14-a54f" name="Sword Claws" hidden="false" collective="false" import="true" targetId="6fda-60d4-a266-4432" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
               </costs>
             </entryLink>
-            <entryLink id="b913-f5cc-ac8a-e594" name="Whip Limb &amp; Sword Claw (A2)" hidden="false" collective="false" import="true" targetId="21ef-4484-3b57-ef5e" type="selectionEntry">
+            <entryLink id="b913-f5cc-ac8a-e594" name="Whip Limb &amp; Sword Claw" hidden="false" collective="false" import="true" targetId="21ef-4484-3b57-ef5e" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
               </costs>
@@ -2099,9 +2174,9 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0805-b28f-ca7e-9159" name="Piercing Claws" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="0805-b28f-ca7e-9159" name="Piercing Claws" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="6214-9b16-d645-a689" name="Razor Pincers" hidden="false" targetId="05be-f7be-083d-ea2a" type="profile"/>
+        <infoLink id="6214-9b16-d645-a689" name="Piercing Claws" hidden="false" targetId="05be-f7be-083d-ea2a" type="profile"/>
         <infoLink id="9d97-2064-c630-c40e" name="Rending" hidden="false" targetId="9726-accd-9015-f6f6" type="rule"/>
       </infoLinks>
       <costs>
@@ -2177,14 +2252,14 @@
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="195.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="205.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="195.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="205.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="62ed-2c0d-dee6-102b" name="Venom Floater" hidden="false" collective="false" import="true" type="upgrade">
@@ -2195,7 +2270,7 @@
         <infoLink id="86ff-7856-0cb2-0379" name="Shrouding Mist" hidden="false" targetId="e84b-2811-0895-94c9" type="rule"/>
       </infoLinks>
       <entryLinks>
-        <entryLink id="9af3-11ef-d568-7508" name="Posion Cloud" hidden="false" collective="false" import="true" targetId="05c3-a1e6-75fd-6911" type="selectionEntry">
+        <entryLink id="9af3-11ef-d568-7508" name="Poison Cloud" hidden="false" collective="false" import="true" targetId="05c3-a1e6-75fd-6911" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61bd-9d76-cbee-8b07" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78a6-50b1-ad21-83c6" type="min"/>
@@ -2246,14 +2321,14 @@
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="225.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="235.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="225.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="235.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8ead-2ed9-e43b-0ed6" name="Synapse Floater" hidden="false" collective="false" import="true" type="upgrade">
@@ -2264,12 +2339,19 @@
         <infoLink id="dd4b-5e4e-2237-242d" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
         <infoLink id="1380-e708-2df5-4051" name="Psychic Synapse" hidden="false" targetId="8272-5465-c7a2-8ada" type="rule"/>
         <infoLink id="b393-4597-6a21-16d9" name="Psychic(X)" hidden="false" targetId="ba47-b43b-18f8-97c1" type="rule"/>
+        <infoLink id="c0cd-a347-a873-d025" name="Stealth" hidden="false" targetId="1b59-5d31-4675-c926" type="rule"/>
       </infoLinks>
       <entryLinks>
         <entryLink id="9e56-2493-f405-1474" name="Psychic Shock" hidden="false" collective="false" import="true" targetId="a26f-27da-0dce-7bd6" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f74-8f64-fee3-0cfb" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f55-1c8a-567f-0fcb" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="90bd-31a4-0fdd-ed89" name="Psychic Blast" hidden="false" collective="false" import="true" targetId="66e2-312a-4503-bd5a" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3230-1375-2696-62fa" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98cf-8e48-32d2-3d24" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
@@ -2360,7 +2442,7 @@
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="280.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="285.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -2395,7 +2477,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="175.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="205.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="cfee-fac3-75fa-6b75" name="Spit Flames" hidden="false" collective="false" import="true" type="upgrade">
@@ -2433,7 +2515,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7306-ef8e-f868-83b1" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="2b2f-cdfc-c982-1cba" name="Spore Cannon" hidden="false" collective="false" import="true" targetId="283c-76e4-afa9-dd0c" type="selectionEntry">
+        <entryLink id="2b2f-cdfc-c982-1cba" name="Spore Gun" hidden="false" collective="false" import="true" targetId="283c-76e4-afa9-dd0c" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f32a-69c3-c1e9-2d1d" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c78a-ab16-455a-1065" type="min"/>
@@ -2441,7 +2523,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="260.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="265.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="67da-2ea6-d09c-74d0" name="Spore" hidden="false" collective="false" import="true" type="upgrade">
@@ -2637,7 +2719,7 @@
     </selectionEntry>
     <selectionEntry id="50ad-68c4-7540-0320" name="Piercing Claws" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="1f5e-bb66-c02c-8471" name="Razor Pincers" hidden="false" targetId="84c9-d94d-94d1-4bb9" type="profile"/>
+        <infoLink id="1f5e-bb66-c02c-8471" name="Piercing Claws" hidden="false" targetId="84c9-d94d-94d1-4bb9" type="profile"/>
         <infoLink id="9a09-ec6b-6d50-de90" name="Rending" hidden="false" targetId="9726-accd-9015-f6f6" type="rule"/>
         <infoLink id="0ea7-f139-d957-6f20" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
       </infoLinks>
@@ -2707,9 +2789,15 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1da2-6e0c-78c7-ec0c" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="313f-1280-a9a2-b41a" name="Viscious Jaw" hidden="false" collective="false" import="true" targetId="57f1-4cdb-7bd4-680a" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75d0-56ce-496e-b66c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ac8-98f7-4f81-8e8f" type="min"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="275.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="305.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5ae4-81da-1e36-a3f8" name="Toxico-Rex" hidden="false" collective="false" import="true" type="upgrade">
@@ -2718,6 +2806,8 @@
         <infoLink id="261e-1f07-8e52-ccff" name="Fear" hidden="false" targetId="d21e-0b0f-ebec-46da" type="rule"/>
         <infoLink id="3348-d043-8228-468e" name="Fearless" hidden="false" targetId="fe6b-f29d-2128-a0b0" type="rule"/>
         <infoLink id="adac-5c6f-d81d-3943" name="Toxico-Rex" hidden="false" targetId="69ed-a75a-67d8-4eed" type="profile"/>
+        <infoLink id="3624-5519-d1a4-fdd0" name="Shrouding Mist" hidden="false" targetId="e84b-2811-0895-94c9" type="rule"/>
+        <infoLink id="452e-880a-4f38-5c17" name="Stealth" hidden="false" targetId="1b59-5d31-4675-c926" type="rule"/>
       </infoLinks>
       <entryLinks>
         <entryLink id="8088-f3da-ba48-bb43" name="Acid Spurt" hidden="false" collective="false" import="true" targetId="1538-854b-6d77-3e6f" type="selectionEntry">
@@ -2742,7 +2832,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="285.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="375.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6941-7625-7701-3401" name="Psycho-Rex" hidden="false" collective="false" import="true" type="upgrade">
@@ -2752,6 +2842,8 @@
         <infoLink id="6fa0-2e7d-9299-4755" name="Psycho-Rex" hidden="false" targetId="2d3e-9193-cbdd-f378" type="profile"/>
         <infoLink id="2bef-351d-d752-7453" name="Psychic(X)" hidden="false" targetId="ba47-b43b-18f8-97c1" type="rule"/>
         <infoLink id="0f5a-8364-43cc-0b30" name="Fear" hidden="false" targetId="d21e-0b0f-ebec-46da" type="rule"/>
+        <infoLink id="6fe9-2eeb-4973-d52d" name="Regeneration" hidden="false" targetId="dea8-a8f9-1865-4424" type="rule"/>
+        <infoLink id="4e34-2c22-9d27-c5b8" name="Stealth" hidden="false" targetId="1b59-5d31-4675-c926" type="rule"/>
       </infoLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="b87f-1324-39e5-2ec0" name="Upgrade with any:" hidden="false" collective="false" import="true">
@@ -2791,9 +2883,15 @@
           </constraints>
         </entryLink>
         <entryLink id="7ae9-7320-d818-63d0" name="Weapons - Tail [max 1]" hidden="false" collective="false" import="true" targetId="7e59-feb8-9bd9-307e" type="selectionEntryGroup"/>
+        <entryLink id="f80a-bb04-d273-6cc5" name="Psychic Blast" hidden="false" collective="false" import="true" targetId="032a-7e60-1dd5-7736" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f8e-7aec-9fd6-f42d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="495b-ac2d-94d1-64af" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="285.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="405.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="207d-c013-691e-6946" name="Devourer Beast" hidden="false" collective="false" import="true" type="upgrade">
@@ -2825,7 +2923,7 @@
         <entryLink id="5a70-5fd4-7603-06ad" name="Beast Upgrades - Upgrade with any:" hidden="false" collective="false" import="true" targetId="5885-a779-cf0b-1c64" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="420.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="490.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="fa8d-78d5-5b25-fe12" name="Artillery Beast" hidden="false" collective="false" import="true" type="upgrade">
@@ -2869,7 +2967,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="425.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="560.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="9b5f-04b5-5552-d58e" name="Tyrant Beast" hidden="false" collective="false" import="true" type="upgrade">
@@ -2929,7 +3027,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="415.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="505.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4070-e0f1-243c-9a20" name="Bio-Minigun" hidden="false" collective="false" import="true" type="upgrade">
@@ -2970,7 +3068,7 @@
         <entryLink id="6409-0a4d-851c-c18f" name="Beast Upgrades - Upgrade with any:" hidden="false" collective="false" import="true" targetId="5885-a779-cf0b-1c64" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="560.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="630.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d091-96fd-b993-c5dd" name="Burrower" hidden="false" collective="false" import="true" type="upgrade">
@@ -2998,7 +3096,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="445.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="480.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="8ae2-3805-bb4c-a938" name="Invasion Spore" hidden="false" collective="false" import="true" type="upgrade">
@@ -3023,10 +3121,10 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c064-6c67-e86b-4fbb" name="Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="8cb8-b8e2-b250-94c9">
+        <selectionEntryGroup id="c064-6c67-e86b-4fbb" name="Weapons" hidden="false" collective="false" import="true">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbde-3e99-9e12-377b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0b1-c6a1-9983-723a" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0b1-c6a1-9983-723a" type="min"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="47f7-298a-52ef-7381" name="5x Barb-Cannons" hidden="false" collective="false" import="true" type="upgrade">
@@ -3039,7 +3137,7 @@
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="65.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="70.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="bb0d-582a-1120-7e82" name="5x Acid Cannons" hidden="false" collective="false" import="true" type="upgrade">
@@ -3052,7 +3150,7 @@
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="70.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="75.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c155-f53c-df0e-4df2" name="5x Shredder Cannons" hidden="false" collective="false" import="true" type="upgrade">
@@ -3065,7 +3163,7 @@
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="55.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="60.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="911d-b76d-a231-88f6" name="5x Bio-Carbines" hidden="false" collective="false" import="true" type="upgrade">
@@ -3078,7 +3176,7 @@
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="8cb8-b8e2-b250-94c9" name="5x Bio-Guns" hidden="false" collective="false" import="true" type="upgrade">
@@ -3091,7 +3189,7 @@
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="c1d5-7d89-aa07-7553" name="5x Bio-Spitters" hidden="false" collective="false" import="true" type="upgrade">
@@ -3104,7 +3202,7 @@
                 </entryLink>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="25.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="30.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
@@ -3119,7 +3217,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="165.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="160.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6cf3-d758-0964-8c29" name="Rapacious Beast" hidden="false" collective="false" import="true" type="upgrade">
@@ -3215,7 +3313,7 @@
     </selectionEntry>
     <selectionEntry id="4339-677c-1361-9190" name="Serrated Claws" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="bce4-4b41-85c0-ebd8" name="Serrated Claws (A6,AP2)" hidden="false" targetId="2889-5d8d-b260-c347" type="profile"/>
+        <infoLink id="bce4-4b41-85c0-ebd8" name="Serrated Claws" hidden="false" targetId="2889-5d8d-b260-c347" type="profile"/>
         <infoLink id="8908-cfbd-ac7e-4d47" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
       </infoLinks>
       <costs>
@@ -3277,7 +3375,7 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="11b2-f466-6769-0c50" name="Piercing Claws" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="11b2-f466-6769-0c50" name="Piercing Claws" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="3cc5-b9df-0388-a495" name="Piercing Claws (A2,AP2)" hidden="false" targetId="38bb-6b5a-6cfe-99d0" type="profile"/>
         <infoLink id="0764-5e91-6d67-57e5" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
@@ -3356,23 +3454,32 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4eff-8e83-1dd8-a94e" type="max"/>
           </constraints>
           <entryLinks>
-            <entryLink id="bfce-69b4-6e11-8fcf" name="Razor Claws (A3,AP1)" hidden="false" collective="false" import="true" targetId="5c30-2ce2-c8dc-316a" type="selectionEntry"/>
-            <entryLink id="2b3f-01b0-85df-6c8d" name="Piercing Claws (A3,AP1)" hidden="false" collective="false" import="true" targetId="50ad-68c4-7540-0320" type="selectionEntry">
+            <entryLink id="bfce-69b4-6e11-8fcf" name="Razor Claws" hidden="false" collective="false" import="true" targetId="5c30-2ce2-c8dc-316a" type="selectionEntry"/>
+            <entryLink id="2b3f-01b0-85df-6c8d" name="Piercing Claws" hidden="false" collective="false" import="true" targetId="50ad-68c4-7540-0320" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
               </costs>
             </entryLink>
-            <entryLink id="6134-ce88-084a-ccf1" name="Serrated Claws (A6,AP1)" hidden="false" collective="false" import="true" targetId="7be3-6c53-90a5-9537" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="4f7a-2117-d1eb-a63b" name="Sword Claws (A3,AP1)" hidden="false" collective="false" import="true" targetId="6fda-60d4-a266-4432" type="selectionEntry">
+            <entryLink id="6134-ce88-084a-ccf1" name="Serrated Claws" hidden="false" collective="false" import="true" targetId="7be3-6c53-90a5-9537" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
               </costs>
             </entryLink>
-            <entryLink id="e615-e5ad-447e-224f" name="Whip Limb &amp; Sword Claw (A2)" hidden="false" collective="false" import="true" targetId="21ef-4484-3b57-ef5e" type="selectionEntry"/>
+            <entryLink id="4f7a-2117-d1eb-a63b" name="Sword Claws" hidden="false" collective="false" import="true" targetId="6fda-60d4-a266-4432" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="e615-e5ad-447e-224f" name="Whip Limb &amp; Sword Claw" hidden="false" collective="false" import="true" targetId="21ef-4484-3b57-ef5e" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="7dca-db32-0662-081f" name="Smashing Claw" hidden="false" collective="false" import="true" targetId="86f9-3f6a-6b08-f085" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+              </costs>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="0e4c-209f-d4fc-8d7a" name="Weapons - Lower Arms [pick 1]" hidden="false" collective="false" import="true" defaultSelectionEntryId="9d4a-794e-0022-a273">
@@ -3407,33 +3514,37 @@
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
               </costs>
             </entryLink>
-            <entryLink id="5f06-f147-7581-a4f3" name="Smashing Claw (A3,AP3)" hidden="false" collective="false" import="true" targetId="2917-6565-e6e7-a157" type="selectionEntry">
+            <entryLink id="5f06-f147-7581-a4f3" name="Smashing Claw" hidden="false" collective="false" import="true" targetId="2917-6565-e6e7-a157" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
               </costs>
             </entryLink>
-            <entryLink id="ae6a-2cb0-dff9-a425" name="Sword Claws (A3,AP1)" hidden="false" collective="false" import="true" targetId="6fda-60d4-a266-4432" type="selectionEntry">
+            <entryLink id="ae6a-2cb0-dff9-a425" name="Sword Claws" hidden="false" collective="false" import="true" targetId="6fda-60d4-a266-4432" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
               </costs>
             </entryLink>
-            <entryLink id="b4c6-fc5a-cc27-15b3" name="Whip Limb &amp; Sword Claw (A2)" hidden="false" collective="false" import="true" targetId="21ef-4484-3b57-ef5e" type="selectionEntry"/>
-            <entryLink id="9c2f-912d-ad9e-f7c3" name="Piercing Claws (A3,AP1)" hidden="false" collective="false" import="true" targetId="50ad-68c4-7540-0320" type="selectionEntry">
+            <entryLink id="b4c6-fc5a-cc27-15b3" name="Whip Limb &amp; Sword Claw" hidden="false" collective="false" import="true" targetId="21ef-4484-3b57-ef5e" type="selectionEntry">
+              <costs>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="9c2f-912d-ad9e-f7c3" name="Piercing Claws" hidden="false" collective="false" import="true" targetId="50ad-68c4-7540-0320" type="selectionEntry">
               <costs>
                 <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
               </costs>
             </entryLink>
-            <entryLink id="5b27-5c95-5900-c594" name="Razor Claws (A3,AP1)" hidden="false" collective="false" import="true" targetId="5c30-2ce2-c8dc-316a" type="selectionEntry"/>
-            <entryLink id="916c-5ae8-b047-8ba4" name="Serrated Claws (A6,AP1)" hidden="false" collective="false" import="true" targetId="7be3-6c53-90a5-9537" type="selectionEntry">
+            <entryLink id="5b27-5c95-5900-c594" name="Razor Claws" hidden="false" collective="false" import="true" targetId="5c30-2ce2-c8dc-316a" type="selectionEntry"/>
+            <entryLink id="916c-5ae8-b047-8ba4" name="Serrated Claws" hidden="false" collective="false" import="true" targetId="7be3-6c53-90a5-9537" type="selectionEntry">
               <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
               </costs>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="110.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="100.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="524d-744a-262a-3a87" name="Shredder Cannon" hidden="false" collective="false" import="true" type="upgrade">
@@ -3448,7 +3559,7 @@
     <selectionEntry id="2917-6565-e6e7-a157" name="Smashing Claw" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="149f-cddb-fada-68f1" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
-        <infoLink id="3760-8e74-84dc-5a69" name="Smashing Claws (A3,AP3)" hidden="false" targetId="08c1-7f5a-f189-a72d" type="profile"/>
+        <infoLink id="3760-8e74-84dc-5a69" name="Smashing Claws" hidden="false" targetId="08c1-7f5a-f189-a72d" type="profile"/>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
@@ -3456,7 +3567,7 @@
     </selectionEntry>
     <selectionEntry id="7be3-6c53-90a5-9537" name="Serrated Claws" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="a84c-b77a-0f3b-0101" name="Serrated Claws (A6,AP1)" hidden="false" targetId="6162-8957-3483-1052" type="profile"/>
+        <infoLink id="a84c-b77a-0f3b-0101" name="Serrated Claws" hidden="false" targetId="6162-8957-3483-1052" type="profile"/>
         <infoLink id="edcb-33e6-aef0-8c7c" name="AP(X)" hidden="false" targetId="f84f-fda5-e478-455d" type="rule"/>
       </infoLinks>
       <costs>
@@ -3531,7 +3642,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="75.0"/>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="80.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="71b0-062a-79a2-5f7c" name="2x Piercing Claws (A2)" hidden="false" collective="false" import="true" type="upgrade">
@@ -3672,55 +3783,15 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6e92-65f9-0726-16ea" name="Assault Grunt (Special Weapon)" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="0c37-4212-8856-3480" name="Serrated Claws" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="4e70-99af-805b-afcf" name="Assault Grunt" hidden="false" targetId="99eb-6d4f-c7ff-9808" type="profile"/>
-        <infoLink id="8b2c-2c86-c1fb-cd76" name="Strider" hidden="false" targetId="9dea-b566-200a-0605" type="rule"/>
-        <infoLink id="c87f-5f57-51cf-3dc1" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
-      </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="015c-9cbd-3abc-01fd" name="Melee Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="d3c9-9562-cd29-b5ef">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f984-8c61-40a3-ac4e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b385-a783-34d9-787c" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="24ec-1626-7f46-b51c" name="Sword Claws (A2)" hidden="false" collective="false" import="true" targetId="2832-64ca-06a5-6725" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="d3c9-9562-cd29-b5ef" name="Serrated Claws (A4)" hidden="false" collective="false" import="true" targetId="0c37-4212-8856-3480" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="c333-7855-96a9-8f53" name="Smashing Claw (A2,AP2)" hidden="false" collective="false" import="true" targetId="4764-2fc1-e9be-f1b5" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="ff54-8de5-5458-3950" name="Piercing Claws (A2)" hidden="false" collective="false" import="true" targetId="0805-b28f-ca7e-9159" type="selectionEntry">
-              <costs>
-                <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <costs>
-        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="0c37-4212-8856-3480" name="Serrated Claws" hidden="false" collective="false" import="true" type="upgrade">
-      <infoLinks>
-        <infoLink id="1980-8a0c-55e0-420a" name="Serrated Claws (A4)" hidden="false" targetId="bde7-35ee-a3d4-7def" type="profile"/>
+        <infoLink id="1980-8a0c-55e0-420a" name="Serrated Claws" hidden="false" targetId="bde7-35ee-a3d4-7def" type="profile"/>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2832-64ca-06a5-6725" name="Sword Claws" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="2832-64ca-06a5-6725" name="Sword Claws" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
         <infoLink id="8f85-fb03-61c5-ca97" name="Sword Claws (A2)" hidden="false" targetId="88d7-8943-3888-5f68" type="profile"/>
         <infoLink id="7c98-095d-580d-136f" name="Deadly(X)" hidden="false" targetId="377b-3864-960e-57ac" type="rule"/>
@@ -4030,6 +4101,90 @@
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="40.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="66e2-312a-4503-bd5a" name="Psychic Blast" hidden="false" collective="true" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="3562-0b23-5afa-b51f" name="Psychic Blast" hidden="false" targetId="dab5-dcbe-4652-efc3" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="57f1-4cdb-7bd4-680a" name="Viscious Jaw" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="17fe-4fe7-87a1-021b" name="Viscious Jaw" hidden="false" targetId="65c1-3f31-5829-0ea6" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="032a-7e60-1dd5-7736" name="Psychic Blast" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="ed91-87c8-4e06-b4a8" name="Psychic Blast" hidden="false" targetId="bf95-d841-b82f-faee" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="565b-7301-3726-a2ea" name="Assault Grunt (Piercing Claws)" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="25cc-fb01-0da2-e6d8" name="Assault Grunt" hidden="false" targetId="99eb-6d4f-c7ff-9808" type="profile"/>
+        <infoLink id="f837-36b5-e92c-70d2" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
+        <infoLink id="43f5-5f09-6c46-bb71" name="Strider" hidden="false" targetId="9dea-b566-200a-0605" type="rule"/>
+      </infoLinks>
+      <entryLinks>
+        <entryLink id="a25f-3cd6-cb52-6de2" name="Piercing Claws" hidden="false" collective="false" import="true" targetId="0805-b28f-ca7e-9159" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="256e-ba61-839e-0384" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c57e-82be-5066-fa21" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="9073-f951-c114-9a8f" name="Assault Grunt (Smashing Claws)" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="a9bd-cb4c-90a9-b156" name="Assault Grunt" hidden="false" targetId="99eb-6d4f-c7ff-9808" type="profile"/>
+        <infoLink id="e037-35c1-d9b2-20ff" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
+        <infoLink id="1ea4-0185-ec2f-5608" name="Strider" hidden="false" targetId="9dea-b566-200a-0605" type="rule"/>
+      </infoLinks>
+      <entryLinks>
+        <entryLink id="ffc2-630c-d6f6-5cf7" name="Smashing Claw" hidden="false" collective="false" import="true" targetId="4764-2fc1-e9be-f1b5" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0925-de14-26f3-08db" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79dd-f80e-d03a-1a11" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="d018-a3c8-9960-19fc" name="Assault Grunt (Serrated Claws)" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="3c8f-effa-6219-598f" name="Assault Grunt" hidden="false" targetId="99eb-6d4f-c7ff-9808" type="profile"/>
+        <infoLink id="45c1-0ace-55b5-5ddf" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
+        <infoLink id="1e2b-4b8b-4f9a-562a" name="Strider" hidden="false" targetId="9dea-b566-200a-0605" type="rule"/>
+      </infoLinks>
+      <entryLinks>
+        <entryLink id="be8f-f259-0d2f-efa3" name="Serrated Claws" hidden="false" collective="false" import="true" targetId="0c37-4212-8856-3480" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2010-92cf-770a-2719" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfa0-6ca8-0ef6-3499" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntry>
+    <selectionEntry id="4593-5dea-50eb-4814" name="Assault Grunt (Sword Claws)" hidden="false" collective="false" import="true" type="upgrade">
+      <infoLinks>
+        <infoLink id="b9bc-d73c-fc81-e201" name="Assault Grunt" hidden="false" targetId="99eb-6d4f-c7ff-9808" type="profile"/>
+        <infoLink id="737d-db94-83b6-cb70" name="Fast" hidden="false" targetId="f6ca-56fe-a21c-08fa" type="rule"/>
+        <infoLink id="7cf4-53ff-d192-1516" name="Strider" hidden="false" targetId="9dea-b566-200a-0605" type="rule"/>
+      </infoLinks>
+      <entryLinks>
+        <entryLink id="38ce-9692-4db0-258a" name="Sword Claws" hidden="false" collective="false" import="true" targetId="2832-64ca-06a5-6725" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b9d-30b3-dc22-16ed" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fd1-dace-686e-9ebf" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="db9a-8ce7-bcc1-14f5" name="Spells" hidden="false" collective="false" import="true">
@@ -4059,22 +4214,22 @@
       <entryLinks>
         <entryLink id="c650-25ee-8366-7fcb" name="Tail Mace" hidden="false" collective="false" import="true" targetId="3226-9559-4259-5bb3" type="selectionEntry">
           <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
           </costs>
         </entryLink>
         <entryLink id="5d7a-1a16-89fd-b545" name="Tail Pincer" hidden="false" collective="false" import="true" targetId="38f3-89bc-9e12-0cae" type="selectionEntry">
           <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
           </costs>
         </entryLink>
         <entryLink id="664c-9fc5-d385-545f" name="Tail Scythe" hidden="false" collective="false" import="true" targetId="76af-6ed6-c8c0-9cc9" type="selectionEntry">
           <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
           </costs>
         </entryLink>
         <entryLink id="df78-9608-b247-ff8c" name="Tail Whip" hidden="false" collective="false" import="true" targetId="df63-ba7f-f649-3504" type="selectionEntry">
           <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
           </costs>
         </entryLink>
       </entryLinks>
@@ -4101,60 +4256,60 @@
     </selectionEntryGroup>
     <selectionEntryGroup id="f2ae-f39e-e790-da86" name="Weapons - Beast - Melee" hidden="false" collective="false" import="true" defaultSelectionEntryId="c0d9-1129-6c99-acc9">
       <entryLinks>
-        <entryLink id="c0d9-1129-6c99-acc9" name="Razor Claws (A3,AP2)" hidden="false" collective="false" import="true" targetId="c76e-deb8-200c-e75a" type="selectionEntry"/>
-        <entryLink id="7634-8b1b-5025-24d1" name="Piercing Claws (A3,AP2)" hidden="false" collective="false" import="true" targetId="3ad1-63ca-437f-86f3" type="selectionEntry">
+        <entryLink id="c0d9-1129-6c99-acc9" name="Razor Claws" hidden="false" collective="false" import="true" targetId="c76e-deb8-200c-e75a" type="selectionEntry"/>
+        <entryLink id="7634-8b1b-5025-24d1" name="Piercing Claws" hidden="false" collective="false" import="true" targetId="3ad1-63ca-437f-86f3" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
           </costs>
         </entryLink>
-        <entryLink id="2276-810e-6fb0-a17a" name="Smashing Claw (A3,AP4)" hidden="false" collective="false" import="true" targetId="86f9-3f6a-6b08-f085" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="43a3-e211-e8f5-123c" name="Serrated Claws (A6,AP2)" hidden="false" collective="false" import="true" targetId="4339-677c-1361-9190" type="selectionEntry">
+        <entryLink id="2276-810e-6fb0-a17a" name="Smashing Claw" hidden="false" collective="false" import="true" targetId="86f9-3f6a-6b08-f085" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
           </costs>
         </entryLink>
-        <entryLink id="a573-bf99-a574-f74b" name="Sword Claws (A3,AP2)" hidden="false" collective="false" import="true" targetId="5dc8-5fec-55fe-de7a" type="selectionEntry">
+        <entryLink id="43a3-e211-e8f5-123c" name="Serrated Claws" hidden="false" collective="false" import="true" targetId="4339-677c-1361-9190" type="selectionEntry">
           <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
           </costs>
         </entryLink>
-        <entryLink id="17a6-cd29-3029-9a03" name="Whip Limb &amp; Sword Claw (A2,AP1)" hidden="false" collective="false" import="true" targetId="4b6a-becd-466c-f590" type="selectionEntry">
+        <entryLink id="a573-bf99-a574-f74b" name="Sword Claws" hidden="false" collective="false" import="true" targetId="5dc8-5fec-55fe-de7a" type="selectionEntry">
           <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="17a6-cd29-3029-9a03" name="Whip Limb &amp; Sword Claw" hidden="false" collective="false" import="true" targetId="4b6a-becd-466c-f590" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
           </costs>
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="7328-3d8a-c3a9-b190" name="Weapons - Beast - Melee &amp; Ranged" hidden="false" collective="false" import="true" defaultSelectionEntryId="4087-7224-906e-efed">
       <entryLinks>
-        <entryLink id="4087-7224-906e-efed" name="Razor Claws (A3,AP2)" hidden="false" collective="false" import="true" targetId="c76e-deb8-200c-e75a" type="selectionEntry"/>
-        <entryLink id="b495-7fcd-0a06-1ba1" name="Piercing Claws (A3,AP2)" hidden="false" collective="false" import="true" targetId="3ad1-63ca-437f-86f3" type="selectionEntry">
+        <entryLink id="4087-7224-906e-efed" name="Razor Claws" hidden="false" collective="false" import="true" targetId="c76e-deb8-200c-e75a" type="selectionEntry"/>
+        <entryLink id="b495-7fcd-0a06-1ba1" name="Piercing Claws" hidden="false" collective="false" import="true" targetId="3ad1-63ca-437f-86f3" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
           </costs>
         </entryLink>
-        <entryLink id="1608-65bf-c40c-94d8" name="Smashing Claw (A3,AP4)" hidden="false" collective="false" import="true" targetId="86f9-3f6a-6b08-f085" type="selectionEntry">
-          <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="5.0"/>
-          </costs>
-        </entryLink>
-        <entryLink id="70f2-aa74-dfb9-750b" name="Serrated Claws (A6,AP2)" hidden="false" collective="false" import="true" targetId="4339-677c-1361-9190" type="selectionEntry">
+        <entryLink id="1608-65bf-c40c-94d8" name="Smashing Claw" hidden="false" collective="false" import="true" targetId="86f9-3f6a-6b08-f085" type="selectionEntry">
           <costs>
             <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
           </costs>
         </entryLink>
-        <entryLink id="7f3f-8dfb-f6ab-f98c" name="Sword Claws (A3,AP2)" hidden="false" collective="false" import="true" targetId="5dc8-5fec-55fe-de7a" type="selectionEntry">
+        <entryLink id="70f2-aa74-dfb9-750b" name="Serrated Claws" hidden="false" collective="false" import="true" targetId="4339-677c-1361-9190" type="selectionEntry">
           <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
           </costs>
         </entryLink>
-        <entryLink id="2030-fdb5-a957-076b" name="Whip Limb &amp; Sword Claw (A2,AP1)" hidden="false" collective="false" import="true" targetId="4b6a-becd-466c-f590" type="selectionEntry">
+        <entryLink id="7f3f-8dfb-f6ab-f98c" name="Sword Claws" hidden="false" collective="false" import="true" targetId="5dc8-5fec-55fe-de7a" type="selectionEntry">
           <costs>
-            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="10.0"/>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="15.0"/>
+          </costs>
+        </entryLink>
+        <entryLink id="2030-fdb5-a957-076b" name="Whip Limb &amp; Sword Claw" hidden="false" collective="false" import="true" targetId="4b6a-becd-466c-f590" type="selectionEntry">
+          <costs>
+            <cost name="pts" typeId="567f-6468-66c6-2ea2" value="20.0"/>
           </costs>
         </entryLink>
         <entryLink id="a061-40d8-bdf9-53f3" name="Heavy Bio-Carbine" hidden="false" collective="false" import="true" targetId="0c5b-9d5b-8488-a3ab" type="selectionEntry">
@@ -4205,7 +4360,7 @@
       <description>If this model is ever engaged in melee it is immediately killed and the enemy takes 3 hits for Spores and 9 hits for a Massive Spore. Additionally this model automatically passes all morale tests.</description>
     </rule>
     <rule id="b7c0-78ce-1622-6361" name="Pheromones" publicationId="3518-c2b3-bfde-3ff1" hidden="false">
-      <description>When this unit is activated pick 2 friendly units within 12&quot;, which get +1 to their rolls next time they take a morale test.</description>
+      <description>When this unit is activated, pick 2 friendly units within 12&quot;, which take one wound next time they fail a morale test, and the test counts as passed instead.</description>
     </rule>
     <rule id="e84b-2811-0895-94c9" name="Shrouding Mist" publicationId="3518-c2b3-bfde-3ff1" hidden="false">
       <description>When this unit is activated pick 2 friendly units within 6”, which get Stealth next time they are shot at.</description>
@@ -4216,8 +4371,8 @@
     <rule id="8272-5465-c7a2-8ada" name="Psychic Synapse" publicationId="3518-c2b3-bfde-3ff1" hidden="false">
       <description>This unit counts as having Psychic(X), where X is the number of models in it. Only one model may cast or block spells each round.</description>
     </rule>
-    <rule id="9f61-9c21-1e77-176f" name="Spawn Grunts" publicationId="3518-c2b3-bfde-3ff1" hidden="false">
-      <description>When this unit is activated you may place a unit of 5 Grunts fully within 6&quot;.</description>
+    <rule id="9f61-9c21-1e77-176f" name="Spawn Brood" publicationId="3518-c2b3-bfde-3ff1" hidden="false">
+      <description>When this unit is activated you may place a unit of 5 Grunts or 3 Hive Swarms fully within 6&quot; of it.</description>
     </rule>
     <rule id="0bf2-d8cc-a5ce-d06f" name="Surprise Attack" publicationId="3518-c2b3-bfde-3ff1" hidden="false">
       <description>This unit counts as having the Ambush rule and may be deployed up to 3&quot; away from enemy units. Once the unit is deployed roll 4 dice, for each 4+ it deals 3 hits with AP(2) to one enemy unit within 3&quot; (this may target multiple units).</description>
@@ -4248,7 +4403,7 @@
       <characteristics>
         <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">3+</characteristic>
         <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">3+</characteristic>
-        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fast, Fearless, Hero, Psychic(1), Scout, Strider, Tough(3)</characteristic>
+        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fast, Fearless, Hero, Psychic(1), Scout, Strider, Tough(6)</characteristic>
       </characteristics>
     </profile>
     <profile id="b15a-c3ce-15e1-8e24" name="Grunt" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
@@ -4297,12 +4452,12 @@
       <characteristics>
         <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">3+</characteristic>
         <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">2+</characteristic>
-        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fearless, Tough(3)</characteristic>
+        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fearless, Relentless, Tough(3)</characteristic>
       </characteristics>
     </profile>
     <profile id="21cb-65c8-1133-9c08" name="Shadow Hunter" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
       <characteristics>
-        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">4+</characteristic>
+        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">3+</characteristic>
         <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">3+</characteristic>
         <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Ambush, Fast, Fear, Fearless, Stealth, Strider, Tough(6)</characteristic>
       </characteristics>
@@ -4325,7 +4480,7 @@
       <characteristics>
         <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">4+</characteristic>
         <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">3+</characteristic>
-        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fearless, Regeneration, Psychic Synapse, Tough(3)</characteristic>
+        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fearless, Regeneration, Psychic Synapse, Stealth, Tough(3)</characteristic>
       </characteristics>
     </profile>
     <profile id="bd41-6d79-0658-f9ca" name="Flamer Beast" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
@@ -4351,7 +4506,7 @@
     </profile>
     <profile id="baa0-ad77-cf5b-c2a3" name="Razor Claws" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A4</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(2)</characteristic>
       </characteristics>
     </profile>
@@ -4364,7 +4519,7 @@
     </profile>
     <profile id="05be-f7be-083d-ea2a" name="Piercing Claws" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A2</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">Rending</characteristic>
       </characteristics>
     </profile>
@@ -4377,19 +4532,19 @@
     </profile>
     <profile id="cdf0-5c69-607a-6321" name="Razor Claws" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A1</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A2</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022"/>
       </characteristics>
     </profile>
     <profile id="83db-db16-b2bb-a315" name="Swarm Attack" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
         <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A4</characteristic>
-        <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022"/>
+        <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">Poison</characteristic>
       </characteristics>
     </profile>
     <profile id="d389-5c28-8aa8-abbb" name="Razor Claws" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A2</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022"/>
       </characteristics>
     </profile>
@@ -4408,7 +4563,7 @@
     <profile id="5914-444a-90f0-1ce0" name="Spit Flames" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
       <characteristics>
         <characteristic name="Range" typeId="79f4-5578-c041-f866">18&quot;</characteristic>
-        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A6</characteristic>
+        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A12</characteristic>
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(1), Indirect</characteristic>
       </characteristics>
     </profile>
@@ -4476,13 +4631,13 @@
     </profile>
     <profile id="013d-25a5-22b3-3a53" name="Piercing Claws" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A4</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(2), Rending</characteristic>
       </characteristics>
     </profile>
     <profile id="a855-0977-d1de-4b67" name="Sword Claws" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A4</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(2), Deadly(3)</characteristic>
       </characteristics>
     </profile>
@@ -4498,19 +4653,19 @@
     </profile>
     <profile id="523a-c781-941f-1bb4" name="Smashing Claws" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A2</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(2)</characteristic>
       </characteristics>
     </profile>
     <profile id="645f-42ea-5df9-2a55" name="Whip Limb &amp; Sword Claw" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A2</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(1), Deadly(6)</characteristic>
       </characteristics>
     </profile>
     <profile id="5667-c5d3-208c-fe4c" name="Heavy Shock-Gun" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
       <characteristics>
-        <characteristic name="Range" typeId="79f4-5578-c041-f866">18&quot;24&quot;</characteristic>
+        <characteristic name="Range" typeId="79f4-5578-c041-f866">24&quot;</characteristic>
         <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A1</characteristic>
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(2), Blast(3)</characteristic>
       </characteristics>
@@ -4550,7 +4705,7 @@
     </profile>
     <profile id="6cfb-beba-ff50-1bba" name="Tail Pincer" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A1</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A2</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(2), Rending</characteristic>
       </characteristics>
     </profile>
@@ -4613,19 +4768,19 @@
       <characteristics>
         <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">4+</characteristic>
         <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">2+</characteristic>
-        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fear, Fearless, Tough(12)</characteristic>
+        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fear, Fearless, Shrouding Mist, Stealth, Tough(12)</characteristic>
       </characteristics>
     </profile>
     <profile id="2d3e-9193-cbdd-f378" name="Psycho-Rex" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
       <characteristics>
         <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">4+</characteristic>
         <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">2+</characteristic>
-        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fear, Fearless, Psychic(2), Tough(12)</characteristic>
+        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fear, Fearless, Psychic(2), Regeneration, Stealth, Tough(12)</characteristic>
       </characteristics>
     </profile>
     <profile id="1a84-f563-fed4-3e13" name="Devourer Beast" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
       <characteristics>
-        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">4+</characteristic>
+        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">3+</characteristic>
         <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">2+</characteristic>
         <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fear, Fearless, Tough(18)</characteristic>
       </characteristics>
@@ -4639,21 +4794,21 @@
     </profile>
     <profile id="7527-fe3c-9db4-df7f" name="Tyrant Beast" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
       <characteristics>
-        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">4+</characteristic>
+        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">3+</characteristic>
         <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">2+</characteristic>
         <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fear, Fearless, Tough(18)</characteristic>
       </characteristics>
     </profile>
     <profile id="44bb-7085-520b-1566" name="Spawning Beast" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
       <characteristics>
-        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">4+</characteristic>
+        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">3+</characteristic>
         <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">2+</characteristic>
-        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fear, Fearless, Spawn Grunts, Tough(18)</characteristic>
+        <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fear, Fearless, Spawn Brood, Tough(18)</characteristic>
       </characteristics>
     </profile>
     <profile id="767f-cb91-b35c-132f" name="Burrower" hidden="false" typeId="a8fa-e9ce-c38a-c73e" typeName="Unit">
       <characteristics>
-        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">4+</characteristic>
+        <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">3+</characteristic>
         <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">2+</characteristic>
         <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Fear, Fearless, Surprise Attack, Tough(18)</characteristic>
       </characteristics>
@@ -4687,14 +4842,14 @@
     </profile>
     <profile id="b3b9-9216-66a8-c72f" name="Smashing Claws" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A4</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(4)</characteristic>
       </characteristics>
     </profile>
     <profile id="0067-e5e3-a668-1de8" name="Tongue" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
       <characteristics>
         <characteristic name="Range" typeId="79f4-5578-c041-f866">12&quot;</characteristic>
-        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A1</characteristic>
+        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A3</characteristic>
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(4), Deadly(3), Sniper</characteristic>
       </characteristics>
     </profile>
@@ -4708,13 +4863,13 @@
     <profile id="bc88-33b7-1054-a4c1" name="Toxic Spray" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
       <characteristics>
         <characteristic name="Range" typeId="79f4-5578-c041-f866">18&quot;</characteristic>
-        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A6</characteristic>
+        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A18</characteristic>
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(1)</characteristic>
       </characteristics>
     </profile>
     <profile id="f054-22e9-23ec-2e9a" name="Razor Claws" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A4</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(1)</characteristic>
       </characteristics>
     </profile>
@@ -4738,13 +4893,13 @@
     </profile>
     <profile id="174a-babf-72ad-5dca" name="Tail Scythe" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A1</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A2</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(2), Deadly</characteristic>
       </characteristics>
     </profile>
     <profile id="1523-9188-ba73-7529" name="Tail Mace" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A1</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A2</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(4)</characteristic>
       </characteristics>
     </profile>
@@ -4765,20 +4920,20 @@
     <profile id="ecac-9045-955a-01af" name="Fracture Cannon" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
       <characteristics>
         <characteristic name="Range" typeId="79f4-5578-c041-f866">48&quot;</characteristic>
-        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A1</characteristic>
+        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A3</characteristic>
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(4), Deadly(3)</characteristic>
       </characteristics>
     </profile>
     <profile id="6d42-7c29-e77a-4a54" name="Bio-Minigun" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
       <characteristics>
         <characteristic name="Range" typeId="79f4-5578-c041-f866">18&quot;</characteristic>
-        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A20</characteristic>
+        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A30</characteristic>
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d"/>
       </characteristics>
     </profile>
     <profile id="84c9-d94d-94d1-4bb9" name="Piercing Claws" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A4</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(1), Rending</characteristic>
       </characteristics>
     </profile>
@@ -4824,7 +4979,7 @@
     </profile>
     <profile id="2889-5d8d-b260-c347" name="Serrated Claws" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A6</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A8</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(2)</characteristic>
       </characteristics>
     </profile>
@@ -4844,7 +4999,7 @@
     </profile>
     <profile id="6b17-8978-2e0f-4e1e" name="Tail Whip" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A2</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A4</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(2)</characteristic>
       </characteristics>
     </profile>
@@ -4867,7 +5022,7 @@
     </profile>
     <profile id="38bb-6b5a-6cfe-99d0" name="Piercing Claws" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A2</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(2), Rending</characteristic>
       </characteristics>
     </profile>
@@ -4887,25 +5042,25 @@
     </profile>
     <profile id="08c1-7f5a-f189-a72d" name="Smashing Claws" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A4</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(3)</characteristic>
       </characteristics>
     </profile>
     <profile id="6162-8957-3483-1052" name="Serrated Claws" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A6</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A8</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(1)</characteristic>
       </characteristics>
     </profile>
     <profile id="6179-f337-4b2a-5309" name="Whip Limb &amp; Sword Claw" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A2</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">Deadly(6)</characteristic>
       </characteristics>
     </profile>
     <profile id="b21c-7d92-b1aa-1d7f" name="Sword Claws" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A4</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(1), Deadly(3)</characteristic>
       </characteristics>
     </profile>
@@ -4918,7 +5073,7 @@
     </profile>
     <profile id="e575-1469-c036-70eb" name="2x Piercing Claws (A2)" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A2</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">Rending</characteristic>
       </characteristics>
     </profile>
@@ -4952,13 +5107,13 @@
     </profile>
     <profile id="bde7-35ee-a3d4-7def" name="Serrated Claws" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A4</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A6</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022"/>
       </characteristics>
     </profile>
     <profile id="88d7-8943-3888-5f68" name="Sword Claws" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
       <characteristics>
-        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A2</characteristic>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A3</characteristic>
         <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">Deadly(3)</characteristic>
       </characteristics>
     </profile>
@@ -4975,14 +5130,14 @@
     <profile id="1972-49da-bb6e-d8eb" name="Heavy Fracture Cannon" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
       <characteristics>
         <characteristic name="Range" typeId="79f4-5578-c041-f866">48&quot;</characteristic>
-        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A3</characteristic>
+        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A6</characteristic>
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(4), Deadly(3)</characteristic>
       </characteristics>
     </profile>
     <profile id="0831-9725-5d25-9193" name="Bio-Artillery" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
       <characteristics>
         <characteristic name="Range" typeId="79f4-5578-c041-f866">36&quot;</characteristic>
-        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A1</characteristic>
+        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A3</characteristic>
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">Blast(6), Indirect</characteristic>
       </characteristics>
     </profile>
@@ -5026,6 +5181,26 @@
         <characteristic name="Quality" typeId="c619-fc26-5d0b-187d">6+</characteristic>
         <characteristic name="Defense" typeId="5564-b1cb-27d0-1af7">6+</characteristic>
         <characteristic name="Special Rules" typeId="6039-8041-2416-3f32">Explosive Head, Tough(3)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="dab5-dcbe-4652-efc3" name="Psychic Blast" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="79f4-5578-c041-f866">18&quot;</characteristic>
+        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A1</characteristic>
+        <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(1), Blast(3)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="65c1-3f31-5829-0ea6" name="Viscious Jaw" hidden="false" typeId="a876-7ff4-b28f-0999" typeName="Melee Weapon">
+      <characteristics>
+        <characteristic name="Attacks" typeId="af84-b2a4-6a80-9e7b">A4</characteristic>
+        <characteristic name="Special Rules" typeId="7a54-240f-72ef-5022">AP(3)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="bf95-d841-b82f-faee" name="Psychic Blast" hidden="false" typeId="3c71-da94-e5b3-d7c8" typeName="Ranged Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="79f4-5578-c041-f866">18&quot;</characteristic>
+        <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A2</characteristic>
+        <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">AP(1), Blast(3)</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>


### PR DESCRIPTION
  * All units have more melee attacks across the board
  * Snatcher Lords now have Tough(6)
  * Shadow hunters are now Quality 3+
  * Hive Swarms now have Poison
  * Synapse floaters now have Stealth and a ranged attack
  * Hive guardians now have Relentless
  * Grunts can now replace ANY Razor Claws
  * All monsters with Tough(18) now have Quality 3+
  * All monster ranged weapons now have more attacks
  * Carnivo-Rex now have a Vicious Jaws attack
  * Toxico-Rex now have Shrouding Mist and Stealt
  * Psycho-Rex now have Regeneration, Stealth and a ranged attack
  * Spawning Beasts can now choose to spawn Hive Swarms
  * Pheromones now allow units to auto-pass morale tests by taking wounds