### PR TITLE
Removed reference to old pheromones description

### DIFF
--- a/Alien_Hives.cat
+++ b/Alien_Hives.cat
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <catalogue id="df4c-bebc-a82e-f430" name="Alien Hives" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="d755-5d69-2721-c11b" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
-    <publication id="3518-c2b3-bfde-3ff1" name="Alien Hives v2.9"/>
+    <publication id="3518-c2b3-bfde-3ff1" name="Alien Hives v2.11"/>
   </publications>
   <entryLinks>
     <entryLink id="a502-27a4-fc46-4917" name="Hive Lord" hidden="false" collective="false" import="true" targetId="b4ec-35df-a8ec-3001" type="selectionEntry">
@@ -3359,7 +3359,7 @@
     </selectionEntry>
     <selectionEntry id="40fd-ce58-371d-5c1b" name="Pheromones" hidden="false" collective="false" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="6265-53d5-4560-cc19" name="Pheromones" hidden="false" targetId="6152-39e9-47e6-d95e" type="profile"/>
+        <infoLink id="6265-53d5-4560-cc19" name="Pheromones" hidden="false" targetId="b7c0-78ce-1622-6361" type="rule"/>
       </infoLinks>
       <costs>
         <cost name="pts" typeId="567f-6468-66c6-2ea2" value="0.0"/>
@@ -5008,11 +5008,6 @@
         <characteristic name="Range" typeId="79f4-5578-c041-f866">6&quot;</characteristic>
         <characteristic name="Attacks" typeId="4633-0aa3-94f7-3be7">A3</characteristic>
         <characteristic name="Special Rules" typeId="9fb1-424b-834c-5e7d">Deadly(3)</characteristic>
-      </characteristics>
-    </profile>
-    <profile id="6152-39e9-47e6-d95e" name="Pheromones" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">
-      <characteristics>
-        <characteristic name="Special Rules" typeId="189e-687a-bec2-51ad">When this unit is activated pick 2 friendly units within 12&quot;, which get +1 to their rolls next time they take a morale test.</characteristic>
       </characteristics>
     </profile>
     <profile id="961e-5970-1890-3f9d" name="Psychic Barrier" hidden="false" typeId="a964-43c6-d8f5-e47f" typeName="Equipment">

--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,7 @@ table!
 | Army | Version | Progress |
 |---|---|---|
 |Game System|v2.10|Done|
-|Alien Hives|v2.9|Done|
+|Alien Hives|v2.11|Done|
 |Battle Brothers|Main v2.12 - Prime v2.15 - Detachments v2.14|Done|
 |Battle Sisters|v2.9|Done|
 |Custodian Brothers|v2.1|Done|


### PR DESCRIPTION
When trying to add a synapse floater to my army list, I was seeing a reference to the old pheromones description. I fixed it by getting rid of the profile entry and referencing the list instead.